### PR TITLE
reader.next(call_options) -> reader.next()

### DIFF
--- a/spanner/Cargo.toml
+++ b/spanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-spanner"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/spanner"

--- a/spanner/README.md
+++ b/spanner/README.md
@@ -44,7 +44,7 @@ Create `Client` and call transaction API same as [Google Cloud Go](https://githu
      stmt.add_param("OwnerUserID",&"ownerId");
      let mut tx = client.single().await?;
      let mut iter = tx.query(stmt).await?;
-     while let Some(row) = iter.next(None).await? {
+     while let Some(row) = iter.next().await? {
          let guild_id = row.column_by_name::<String>("GuildId");
      }
      Ok(())

--- a/spanner/src/lib.rs
+++ b/spanner/src/lib.rs
@@ -34,7 +34,7 @@
 //!     stmt.add_param("OwnerUserID",&"ownerId");
 //!     let mut tx = client.single().await?;
 //!     let mut iter = tx.query(stmt).await?;
-//!     while let Some(row) = iter.next(None).await? {
+//!     while let Some(row) = iter.next().await? {
 //!         let guild_id = row.column_by_name::<String>("GuildId");
 //!     }
 //!     Ok(())
@@ -240,7 +240,7 @@
 //!         Key::key(&"pk2")
 //!     ]).await?;
 //!
-//!     while let Some(row) = iter.next(None).await? {
+//!     while let Some(row) = iter.next().await? {
 //!         // use row
 //!     };
 //!     Ok(())
@@ -493,7 +493,7 @@
 //!             let key = Key::key(&"user1");
 //!             let mut reader = tx.read("UserItem", &["UserId", "ItemId", "Quantity"], key).await?;
 //!             let mut ms = vec![];
-//!             while let Some(row) = reader.next(None).await? {
+//!             while let Some(row) = reader.next().await? {
 //!                 let user_id = row.column_by_name::<i64>("UserId")?;
 //!                 let item_id = row.column_by_name::<i64>("ItemId")?;
 //!                 let quantity = row.column_by_name::<i64>("Quantity")? + 1;

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -120,7 +120,7 @@ impl<'a> RowIterator<'a> {
     }
 
     pub fn set_call_options(&mut self, option: CallOptions) {
-       self.reader_option = Some(option);
+        self.reader_option = Some(option);
     }
 
     /// Merge tries to combine two protobuf Values if possible.
@@ -254,7 +254,7 @@ impl<'a> AsyncIterator for RowIterator<'a> {
         }
 
         // no data found or record chunked.
-        if !self.try_recv(option.clone()).await? {
+        if !self.try_recv(self.reader_option.clone()).await? {
             return Ok(None);
         }
         return self.next().await;

--- a/spanner/src/transaction.rs
+++ b/spanner/src/transaction.rs
@@ -185,7 +185,8 @@ impl Transaction {
         let mut reader = self
             .read_with_option(table, columns, KeySet::from(key), options)
             .await?;
-        return reader.next(Some(call_options)).await;
+        reader.set_call_options(call_options);
+        return reader.next().await;
     }
 
     pub(crate) fn get_session_name(&self) -> String {

--- a/spanner/tests/common.rs
+++ b/spanner/tests/common.rs
@@ -218,7 +218,7 @@ pub async fn read_only_transaction(session: ManagedSession) -> ReadOnlyTransacti
 pub async fn all_rows(mut itr: RowIterator<'_>) -> Vec<Row> {
     let mut rows = vec![];
     loop {
-        match itr.next(None).await {
+        match itr.next().await {
             Ok(row) => {
                 if row.is_some() {
                     rows.push(row.unwrap());

--- a/spanner/tests/transaction_rw.rs
+++ b/spanner/tests/transaction_rw.rs
@@ -17,7 +17,7 @@ use google_cloud_spanner::transaction_rw::ReadWriteTransaction;
 pub async fn all_rows(mut itr: RowIterator<'_>) -> Result<Vec<Row>, Status> {
     let mut rows = vec![];
     loop {
-        match itr.next(None).await {
+        match itr.next().await {
             Ok(row) => {
                 if row.is_some() {
                     rows.push(row.unwrap());


### PR DESCRIPTION
reader.next(call_options) -> reader.next()
use `reader.set_call_options` instead of `reader.next(call_options)` to set call options