### PR TITLE
Derive debug for pubsub to use with OnceCell

### DIFF
--- a/foundation/auth/src/token_source/mod.rs
+++ b/foundation/auth/src/token_source/mod.rs
@@ -8,10 +8,18 @@ use crate::token::Token;
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::time::Duration;
+use std::fmt::{Debug, Formatter};
 
 #[async_trait]
 pub trait TokenSource: Send + Sync {
     async fn token(&self) -> Result<Token, Error>;
+}
+
+impl Debug for dyn TokenSource {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let token_source_string = format!("{:?}", self);
+        write!(f, "{}", token_source_string.as_str())
+    }
 }
 
 fn default_http_client() -> reqwest::Client {

--- a/foundation/gax/src/conn.rs
+++ b/foundation/gax/src/conn.rs
@@ -18,7 +18,7 @@ const TLS_CERTS: &[u8] = include_bytes!("roots.pem");
 
 pub type Channel = Either<AsyncFilter<TonicChannel, AsyncAuthInterceptor>, TonicChannel>;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AsyncAuthInterceptor {
     token_source: Arc<dyn TokenSource>,
 }
@@ -66,6 +66,7 @@ pub enum Environment {
     GoogleCloud(Project),
 }
 
+#[derive(Debug)]
 pub struct ConnectionManager {
     index: AtomicI64,
     conns: Vec<Channel>,

--- a/foundation/gax/src/retry.rs
+++ b/foundation/gax/src/retry.rs
@@ -55,7 +55,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RetrySetting {
     pub from_millis: u64,
     pub max_delay: Option<Duration>,

--- a/pubsub/src/apiv1/conn_pool.rs
+++ b/pubsub/src/apiv1/conn_pool.rs
@@ -8,6 +8,7 @@ const SCOPES: [&str; 2] = [
     "https://www.googleapis.com/auth/pubsub.data",
 ];
 
+#[derive(Debug)]
 pub struct ConnectionManager {
     inner: GRPCConnectionManager,
 }

--- a/pubsub/src/apiv1/publisher_client.rs
+++ b/pubsub/src/apiv1/publisher_client.rs
@@ -14,7 +14,7 @@ use google_cloud_googleapis::pubsub::v1::{
     Topic, UpdateTopicRequest,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct PublisherClient {
     cm: Arc<ConnectionManager>,
 }

--- a/pubsub/src/apiv1/schema_client.rs
+++ b/pubsub/src/apiv1/schema_client.rs
@@ -12,7 +12,7 @@ use google_cloud_googleapis::pubsub::v1::{
 };
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct SchemaClient {
     cm: Arc<ConnectionManager>,
 }

--- a/pubsub/src/apiv1/subscriber_client.rs
+++ b/pubsub/src/apiv1/subscriber_client.rs
@@ -29,7 +29,7 @@ pub(crate) fn create_empty_streaming_pull_request() -> StreamingPullRequest {
     };
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct SubscriberClient {
     cm: Arc<ConnectionManager>,
 }

--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -42,7 +42,7 @@ pub enum Error {
 ///
 /// Clients should be reused rather than being created as needed.
 /// A Client may be shared by multiple tasks.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     project_id: String,
     pubc: PublisherClient,

--- a/pubsub/src/publisher.rs
+++ b/pubsub/src/publisher.rs
@@ -75,7 +75,7 @@ impl Awaiter {
 /// Each item is added with a given key.
 /// Items added to the empty string key are handled in random order.
 /// Items added to any other key are handled sequentially.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Publisher {
     ordering_senders: Arc<Vec<async_channel::Sender<ReservedMessage>>>,
     sender: async_channel::Sender<ReservedMessage>,
@@ -144,6 +144,7 @@ impl Publisher {
     }
 }
 
+#[derive(Debug)]
 struct Tasks {
     inner: Option<Vec<JoinHandle<()>>>,
 }

--- a/pubsub/src/subscriber.rs
+++ b/pubsub/src/subscriber.rs
@@ -76,6 +76,7 @@ impl Default for SubscriberConfig {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct Subscriber {
     pinger: Option<JoinHandle<()>>,
     inner: Option<JoinHandle<()>>,

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -98,6 +98,7 @@ impl Default for ReceiveConfig {
 }
 
 /// Subscription is a reference to a PubSub subscription.
+#[derive(Debug)]
 pub struct Subscription {
     fqsn: String,
     subc: SubscriberClient,

--- a/pubsub/src/topic.rs
+++ b/pubsub/src/topic.rs
@@ -40,7 +40,7 @@ impl Default for TopicConfig {
 /// Topic is a reference to a PubSub topic.
 ///
 /// The methods of Topic are safe for use by multiple tasks.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Topic {
     fqtn: String,
     pubc: PublisherClient,


### PR DESCRIPTION
Add `#[derive(Debug)]` to pubsub structs and dependencies in order to use with OnceCell.