### PR TITLE
Exists returns result enum not bool

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -18,121 +18,134 @@ google-cloud-pubsub = <version>
 
 ```rust
  use google_cloud_pubsub::client::Client;
- use google_cloud_gax::cancel::CancellationToken;
- use google_cloud_googleapis::pubsub::v1::PubsubMessage;
- use google_cloud_pubsub::topic::TopicConfig;
- use google_cloud_pubsub::subscription::SubscriptionConfig;
- use google_cloud_gax::grpc::Status;
- use tokio::task::JoinHandle;
+use google_cloud_gax::cancel::CancellationToken;
+use google_cloud_googleapis::pubsub::v1::PubsubMessage;
+use google_cloud_pubsub::topic::TopicConfig;
+use google_cloud_pubsub::subscription::SubscriptionConfig;
+use google_cloud_gax::grpc::Status;
+use tokio::task::JoinHandle;
 
- #[tokio::main]
- async fn main() -> Result<(), Status> {
+#[tokio::main]
+async fn main() -> Result<(), Status> {
 
-     // Create pubsub client.
-     // The default project is determined by credentials.
-     // - If the GOOGLE_APPLICATION_CREDENTIALS is specified the project_id is from credentials.
-     // - If the server is running on GCP the project_id is from metadata server
-     // - If the PUBSUB_EMULATOR_HOST is specified the project_id is 'local-project'
-     let mut client = Client::default().await.unwrap();
+    // Create pubsub client.
+    // The default project is determined by credentials.
+    // - If the GOOGLE_APPLICATION_CREDENTIALS is specified the project_id is from credentials.
+    // - If the server is running on GCP the project_id is from metadata server
+    // - If the PUBSUB_EMULATOR_HOST is specified the project_id is 'local-project'
+    let mut client = Client::default().await.unwrap();
 
-     // Create topic.
-     let topic = client.topic("test-topic");
-     if !topic.exists(None, None).await? {
-         topic.create(None, None, None).await?;
-     }
+    // Create topic.
+    let topic = client.topic("test-topic");
+    match topic.exists(None, None).await {
+        Ok(true) => {
+            println!("Topic already exists!");
+        }
+        Err(e) => {
+            topic.create(None, None, None).await?;
+        }
+    }
 
-     // Start publisher.
-     let publisher = topic.new_publisher(None);
+    // Start publisher.
+    let publisher = topic.new_publisher(None);
 
-     // Publish message.
-     let tasks : Vec<JoinHandle<Result<String,Status>>> = (0..10).into_iter().map(|_i| {
-         let publisher = publisher.clone();
-         tokio::spawn(async move {
-             let mut msg = PubsubMessage::default();
-             msg.data = "abc".into();
-             // Set ordering_key if needed (https://cloud.google.com/pubsub/docs/ordering)
-             // msg.ordering_key = "order".into();
+    // Publish message.
+    let tasks: Vec<JoinHandle<Result<String, Status>>> = (0..10).into_iter().map(|_i| {
+        let publisher = publisher.clone();
+        tokio::spawn(async move {
+            let mut msg = PubsubMessage::default();
+            msg.data = "abc".into();
+            // Set ordering_key if needed (https://cloud.google.com/pubsub/docs/ordering)
+            // msg.ordering_key = "order".into();
 
-             // Send a message. There are also `publish_bulk` and `publish_immediately` methods.
-             let mut awaiter = publisher.publish(msg).await;
-             
-             // The get method blocks until a server-generated ID or an error is returned for the published message.
-             awaiter.get(None).await
-         })
-     }).collect();
+            // Send a message. There are also `publish_bulk` and `publish_immediately` methods.
+            let mut awaiter = publisher.publish(msg).await;
 
-     // Wait for all publish task finish
-     for task in tasks {
-         let message_id = task.await.unwrap()?;
-     }
+            // The get method blocks until a server-generated ID or an error is returned for the published message.
+            awaiter.get(None).await
+        })
+    }).collect();
 
-     // Wait for publishers in topic finish.
-     let mut publisher = publisher;
-     publisher.shutdown();
+    // Wait for all publish task finish
+    for task in tasks {
+        let message_id = task.await.unwrap()?;
+    }
 
-     Ok(())
- }
+    // Wait for publishers in topic finish.
+    let mut publisher = publisher;
+    publisher.shutdown();
+
+    Ok(())
+}
 ```
 
 ### Subscribe Message
 
 ```rust
  use google_cloud_pubsub::client::Client;
- use google_cloud_gax::cancel::CancellationToken;
- use google_cloud_googleapis::pubsub::v1::PubsubMessage;
- use google_cloud_pubsub::subscription::SubscriptionConfig;
- use google_cloud_gax::grpc::Status;
- use std::time::Duration;
+use google_cloud_gax::cancel::CancellationToken;
+use google_cloud_googleapis::pubsub::v1::PubsubMessage;
+use google_cloud_pubsub::subscription::SubscriptionConfig;
+use google_cloud_gax::grpc::Status;
+use std::time::Duration;
 
- #[tokio::main]
- async fn main() -> Result<(), Status> {
+#[tokio::main]
+async fn main() -> Result<(), Status> {
 
-     // Create pubsub client.
-     // The default project is determined by credentials.
-     // - If the GOOGLE_APPLICATION_CREDENTIALS is specified the project_id is from credentials.
-     // - If the server is running on GCP the project_id is from metadata server
-     // - If the PUBSUB_EMULATOR_HOST is specified the project_id is 'local-project'
-     let mut client = Client::default().await.unwrap();
+    // Create pubsub client.
+    // The default project is determined by credentials.
+    // - If the GOOGLE_APPLICATION_CREDENTIALS is specified the project_id is from credentials.
+    // - If the server is running on GCP the project_id is from metadata server
+    // - If the PUBSUB_EMULATOR_HOST is specified the project_id is 'local-project'
+    let mut client = Client::default().await.unwrap();
 
-     // Get the topic to subscribe to.
-     let topic = client.topic("test-topic");
+    // Get the topic to subscribe to.
+    let topic = client.topic("test-topic");
 
-     // Configure subscription.
-     let mut config = SubscriptionConfig::default();
-     // Enable message ordering if needed (https://cloud.google.com/pubsub/docs/ordering)
-     config.enable_message_ordering = true;
+    // Configure subscription.
+    let mut config = SubscriptionConfig::default();
+    // Enable message ordering if needed (https://cloud.google.com/pubsub/docs/ordering)
+    config.enable_message_ordering = true;
 
-     // Create subscription
-     let subscription = client.subscription("test-subscription");
-     if !subscription.exists(None, None).await? {
-         subscription.create(topic.fully_qualified_name(), config, None, None).await?;
-     }
-     // Token for cancel.
-     let cancel = CancellationToken::new();
-     let cancel2 = cancel.clone();
-     tokio::spawn(async move {
-         // Cancel after 10 seconds.
-         tokio::time::sleep(Duration::from_secs(10)).await;
-         cancel2.cancel();
-     });
+    // Create subscription
+    let subscription = client.subscription("test-subscription");
+    
+    match subscription.exists(None, None).await{ 
+        Ok(true) => {
+            println("Subscription already exists!");
+        },
+        Err(err) => {
+            subscription.create(topic.fully_qualified_name(), config, None, None).await?;
+        }
+    }
+    // Token for cancel.
+    let cancel = CancellationToken::new();
+    let cancel2 = cancel.clone();
+    tokio::spawn(async move {
+        // Cancel after 10 seconds.
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel2.cancel();
+    });
 
-     // Receive blocks until the ctx is cancelled or an error occurs.
-     subscription.receive(|mut message, cancel| async move {
-         // Handle data.
-         let data = message.message.data.as_slice();
-         println!("{:?}", data);
+    // Receive blocks until the ctx is cancelled or an error occurs.
+    subscription.receive(|mut message, cancel| async move {
+        // Handle data.
+        let data = message.message.data.as_slice();
+        println!("{:?}", data);
 
-         // Ack or Nack message.
-         message.ack().await;
-     }, cancel.clone(), None).await;
+        // Ack or Nack message.
+        message.ack().await;
+    }, cancel.clone(), None).await;
 
-     // Delete subscription if needed.
-     subscription.delete(None, None).await;
+    // Delete subscription if needed.
+    subscription.delete(None, None).await;
 
-     Ok(())
- }
+    Ok(())
+}
 ```
 
 ## Example
+
 Here is the example with using Warp.
+
 * https://github.com/yoshidan/google-cloud-rust-example/tree/main/pubsub/rust

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -38,11 +38,18 @@ async fn main() -> Result<(), Status> {
     // Create topic.
     let topic = client.topic("test-topic");
     match topic.exists(None, None).await {
-        Ok(true) => {
-            println!("Topic already exists!");
+        Ok(_b) => {
+            println!("Topic already exists.");
         }
-        Err(e) => {
-            topic.create(None, None, None).await?;
+        Err(err) => {
+            match topic.create(None, None, None).await{
+                Ok(_b) => {
+                    println!("Topic created successfully.");
+                }
+                Err(_e) => {
+                    println!("Error creating topic: {:?}", _e);
+                }
+            }
         }
     }
 
@@ -111,11 +118,18 @@ async fn main() -> Result<(), Status> {
     let subscription = client.subscription("test-subscription");
     
     match subscription.exists(None, None).await{ 
-        Ok(true) => {
+        Ok(_b) => {
             println("Subscription already exists!");
         },
         Err(err) => {
-            subscription.create(topic.fully_qualified_name(), config, None, None).await?;
+            match subscription.create(topic.fully_qualified_name(), config, None, None).await {
+                Ok(_b) => {
+                    println!("Subscription created successfully.");
+                }
+                Err(_e) => {
+                    println!("Error creating Subscription: {:?}", _e);
+                }
+            }
         }
     }
     // Token for cancel.


### PR DESCRIPTION
From the function signature `pub async fn exists(&self, cancel: Option<CancellationToken>, retry: Option<RetrySetting>) -> Result<bool, Status>` the exists function returns a Result enum not a bool. Changed the read me to utilise a `match` statement to handle the result correctly