### PR TITLE
feat: Enable auth without credential files

### DIFF
--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -22,10 +22,10 @@ home = "0.5"
 urlencoding = "2.1"
 tokio = { version = "1.20", features = ["fs"]}
 google-cloud-metadata = { version = "0.3.1", path = "../metadata", default-features = false }
+base64 = "0.13"
 
 [dev-dependencies]
 tokio = { version = "1.20", features = ["test-util", "rt-multi-thread", "macros"]}
-base64 = "0.13"
 tracing-subscriber = {version="0.3", features=["env-filter","std"]}
 ctor = "0.1"
 serial_test = "0.5.1"


### PR DESCRIPTION
## What
With this PR, the `auth` crate will read credentials from the `GOOGLE_APPLICATION_CREDENTIALS_JSON` environment variable if its set.

Closes #51 

## Why
This PR makes it possible to authorize google-cloud in environments without filesystems, or where it doesn't make sense to tie down auth to files.

## Note
For maximum backwards compatibility, signatures are left untouched and keeping true to the original spirit the API surface is not increased beyond the new environment variable.
