### PR TITLE
Allow fully qualified path to subscription

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -103,6 +103,8 @@ google-cloud-pubsub = <version>
      config.enable_message_ordering = true;
 
      // Create subscription
+     // If subscription name does not contain a "/", then the project is taken from client above. Otherwise, the
+     // name will be treated as a fully qualified resource name
      let subscription = client.subscription("test-subscription");
      if !subscription.exists(None, None).await? {
          subscription.create(topic.fully_qualified_name(), config, None, None).await?;

--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -203,11 +203,19 @@ impl Client {
     }
 
     pub fn fully_qualified_topic_name(&self, id: &str) -> String {
-        format!("projects/{}/topics/{}", self.project_id, id)
+        if id.contains("/") {
+            id.to_string()
+        } else {
+            format!("projects/{}/topics/{}", self.project_id, id)
+        }
     }
 
     pub fn fully_qualified_subscription_name(&self, id: &str) -> String {
-        format!("projects/{}/subscriptions/{}", self.project_id, id)
+        if id.contains("/") {
+            id.to_string()
+        } else {
+            format!("projects/{}/subscriptions/{}", self.project_id, id)
+        }
     }
 
     fn fully_qualified_project_name(&self) -> String {


### PR DESCRIPTION
If subscription name contains a slash, then treat it as a fully qualified name to the subscription. This allows for specifying a subscription in another project than the project used for authentication.