### PR TITLE
spanner: avoid emulator OutOfRange

### DIFF
--- a/spanner/src/transaction_ro.rs
+++ b/spanner/src/transaction_ro.rs
@@ -94,7 +94,7 @@ impl ReadOnlyTransaction {
                             selector: Some(transaction_selector::Selector::Id(tx.id)),
                         },
                     },
-                    rts: Some(Utc.timestamp(rts.seconds, rts.nanos as u32)),
+                    rts: Utc.timestamp_opt(rts.seconds, rts.nanos as u32).single(),
                 })
             }
             Err(e) => Err(e),

--- a/spanner/src/value.rs
+++ b/spanner/src/value.rs
@@ -68,7 +68,7 @@ impl CommitTimestamp {
 impl Default for CommitTimestamp {
     fn default() -> Self {
         CommitTimestamp {
-            timestamp: Utc.timestamp(0, 0),
+            timestamp: Utc.timestamp_opt(0, 0).unwrap(),
         }
     }
 }

--- a/spanner/tests/transaction_ro_test.rs
+++ b/spanner/tests/transaction_ro_test.rs
@@ -249,9 +249,9 @@ async fn test_many_records_struct() {
     let user_id = "user_x_6";
     let mutations = vec![create_user_mutation(user_id, &now)];
     let _ = replace_test_data(&mut session, mutations).await.unwrap();
-    let item_mutations = (0..5000).map(|x| create_user_item_mutation(user_id, x)).collect();
+    let item_mutations = (0..4500).map(|x| create_user_item_mutation(user_id, x)).collect();
     let _ = replace_test_data(&mut session, item_mutations).await.unwrap();
-    let characters_mutations = (0..5000).map(|x| create_user_character_mutation(user_id, x)).collect();
+    let characters_mutations = (0..4500).map(|x| create_user_character_mutation(user_id, x)).collect();
     let _ = replace_test_data(&mut session, characters_mutations).await.unwrap();
 
     let mut tx = read_only_transaction(session).await;
@@ -267,9 +267,9 @@ async fn test_many_records_struct() {
     assert_eq!(1, rows.len());
     let row = rows.pop().unwrap();
     let items = row.column_by_name::<Vec<UserItem>>("UserItem").unwrap();
-    assert_eq!(5000, items.len());
+    assert_eq!(4500, items.len());
     let characters = row.column_by_name::<Vec<UserCharacter>>("UserCharacter").unwrap();
-    assert_eq!(5000, characters.len());
+    assert_eq!(4500, characters.len());
 }
 
 #[tokio::test]

--- a/spanner/tests/transaction_ro_test.rs
+++ b/spanner/tests/transaction_ro_test.rs
@@ -244,14 +244,14 @@ async fn test_many_records_value() {
 #[tokio::test]
 #[serial]
 async fn test_many_records_struct() {
-    let now = Utc::now();
+    let now = Utc.timestamp(253370732400, 0);
     let mut session = create_session().await;
     let user_id = "user_x_6";
     let mutations = vec![create_user_mutation(user_id, &now)];
     let _ = replace_test_data(&mut session, mutations).await.unwrap();
-    let item_mutations = (0..4500).map(|x| create_user_item_mutation(user_id, x)).collect();
+    let item_mutations = (0..5000).map(|x| create_user_item_mutation(user_id, x)).collect();
     let _ = replace_test_data(&mut session, item_mutations).await.unwrap();
-    let characters_mutations = (0..4500).map(|x| create_user_character_mutation(user_id, x)).collect();
+    let characters_mutations = (0..5000).map(|x| create_user_character_mutation(user_id, x)).collect();
     let _ = replace_test_data(&mut session, characters_mutations).await.unwrap();
 
     let mut tx = read_only_transaction(session).await;
@@ -267,9 +267,9 @@ async fn test_many_records_struct() {
     assert_eq!(1, rows.len());
     let row = rows.pop().unwrap();
     let items = row.column_by_name::<Vec<UserItem>>("UserItem").unwrap();
-    assert_eq!(4500, items.len());
+    assert_eq!(5000, items.len());
     let characters = row.column_by_name::<Vec<UserCharacter>>("UserCharacter").unwrap();
-    assert_eq!(4500, characters.len());
+    assert_eq!(5000, characters.len());
 }
 
 #[tokio::test]

--- a/spanner/tests/transaction_ro_test.rs
+++ b/spanner/tests/transaction_ro_test.rs
@@ -244,14 +244,14 @@ async fn test_many_records_value() {
 #[tokio::test]
 #[serial]
 async fn test_many_records_struct() {
-    let now = Utc.timestamp(253370732400, 0);
+    let now = Utc::now();
     let mut session = create_session().await;
     let user_id = "user_x_6";
     let mutations = vec![create_user_mutation(user_id, &now)];
     let _ = replace_test_data(&mut session, mutations).await.unwrap();
-    let item_mutations = (0..5000).map(|x| create_user_item_mutation(user_id, x)).collect();
+    let item_mutations = (0..4500).map(|x| create_user_item_mutation(user_id, x)).collect();
     let _ = replace_test_data(&mut session, item_mutations).await.unwrap();
-    let characters_mutations = (0..5000).map(|x| create_user_character_mutation(user_id, x)).collect();
+    let characters_mutations = (0..4500).map(|x| create_user_character_mutation(user_id, x)).collect();
     let _ = replace_test_data(&mut session, characters_mutations).await.unwrap();
 
     let mut tx = read_only_transaction(session).await;
@@ -267,9 +267,9 @@ async fn test_many_records_struct() {
     assert_eq!(1, rows.len());
     let row = rows.pop().unwrap();
     let items = row.column_by_name::<Vec<UserItem>>("UserItem").unwrap();
-    assert_eq!(5000, items.len());
+    assert_eq!(4500, items.len());
     let characters = row.column_by_name::<Vec<UserCharacter>>("UserCharacter").unwrap();
-    assert_eq!(5000, characters.len());
+    assert_eq!(4500, characters.len());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Reduce test data for avoiding `OutOfRange` 

```
query error Status { code: OutOfRange, message: "Cannot construct array Value larger than 1048576 bytes", details: b"\x08\x0b\x126Cannot construct array Value larger than 1048576 bytes", metadata: MetadataMap { headers: {"content-type": "application/grpc"} }, source: None }
```

Here is the emulator cli. 
It looks emulator's size limit.
```
spanner> SELECT *,
      ->         ARRAY(SELECT AS STRUCT * FROM UserItem WHERE UserId = p.UserId) as UserItem,
      ->         ARRAY(SELECT AS STRUCT * FROM UserCharacter WHERE UserId = p.UserId) as UserCharacter
      ->         FROM User p WHERE UserId = "user_x_6";
ERROR: spanner: code = "OutOfRange", desc = "Cannot construct array Value larger than 1048576 bytes"
```