### PR TITLE
docs: fix link to list objects documentation

### DIFF
--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1676,7 +1676,7 @@ impl StorageClient {
     }
 
     /// Lists the objects.
-    /// https://cloud.google.com/storage/docs/json_api/v1/projects/hmacKeys/delete
+    /// https://cloud.google.com/storage/docs/json_api/v1/objects/list
     ///
     /// ```
     /// use google_cloud_storage::client::Client;


### PR DESCRIPTION
Fixes the link to documentation for the list objects request. 