### PR TITLE
refactor(auth): forward reqwest::Error

### DIFF
--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-auth"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/auth"

--- a/foundation/auth/src/error.rs
+++ b/foundation/auth/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     #[error("jwt error: {0}")]
     JwtError(#[from] jwt::errors::Error),
 
-    #[error("http error")]
+    #[error("http error: {0}")]
     HttpError(#[from] reqwest::Error),
 
     #[error("GOOGLE_APPLICATION_CREDENTIALS or default credentials is required: {0}")]

--- a/foundation/gax/Cargo.toml
+++ b/foundation/gax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-gax"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/gax"
@@ -16,7 +16,7 @@ tonic = { version = "0.8", features = ["prost", "tls-webpki-roots"] }
 thiserror = "1.0"
 tower = { version = "0.4", features = ["filter"] }
 http = "0.2"
-google-cloud-auth= { version = "0.6.0", path = "../auth", default-features = false }
+google-cloud-auth= { version = "0.6.1", path = "../auth", default-features = false }
 tokio-util = "0.7"
 tokio-retry = "0.3"
 

--- a/foundation/longrunning/Cargo.toml
+++ b/foundation/longrunning/Cargo.toml
@@ -11,7 +11,7 @@ description = "Google Cloud Platform longrunning library."
 
 [dependencies]
 google-cloud-googleapis = { version = "0.6.0", path = "../../googleapis" }
-google-cloud-gax = { version = "0.10.0", path = "../gax", default-features = false }
+google-cloud-gax = { version = "0.10.1", path = "../gax", default-features = false }
 tonic = { version = "0.8", features = ["tls", "prost"] }
 prost = "0.11"
 

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-pubsub"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub"
@@ -19,7 +19,7 @@ async-channel = "1.6"
 async-stream = "0.3"
 thiserror = "1.0"
 
-google-cloud-auth = { version = "0.6.0", path = "../foundation/auth", default-features = false }
+google-cloud-auth = { version = "0.6.1", path = "../foundation/auth", default-features = false }
 google-cloud-gax = { version = "0.10.0", path = "../foundation/gax", default-features = false }
 google-cloud-googleapis = { version = "0.6.0", path = "../googleapis", features = ["pubsub"]}
 

--- a/spanner/Cargo.toml
+++ b/spanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-spanner"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/spanner"
@@ -22,7 +22,7 @@ base64 = "0.13"
 anyhow = "1.0"
 serde = { version = "1.0", optional = true }
 
-google-cloud-auth= { version = "0.6.0", path = "../foundation/auth", default-features = false}
+google-cloud-auth= { version = "0.6.1", path = "../foundation/auth", default-features = false}
 google-cloud-longrunning= { version = "0.9.0", path = "../foundation/longrunning", default-features = false}
 google-cloud-gax = { version = "0.10.0", path = "../foundation/gax", default-features = false}
 google-cloud-googleapis = { version = "0.6.0", path = "../googleapis", features = ["spanner"]}

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-storage"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/storage"
@@ -11,7 +11,7 @@ description = "Google Cloud Platform storage client library."
 documentation = "https://docs.rs/google-cloud-storage/latest/google_cloud_storage/"
 
 [dependencies]
-google-cloud-auth = { version = "0.6.0", path = "../foundation/auth", default-features = false }
+google-cloud-auth = { version = "0.6.1", path = "../foundation/auth", default-features = false }
 google-cloud-metadata = { version = "0.3.1", path = "../foundation/metadata", default-features = false }
 rsa = "0.6"
 thiserror = "1.0"


### PR DESCRIPTION
Forward reqwest::Error onto auth::Error::HttpError.

In my application, I have encountered an error with initializing the google_cloud_storage::client::Client. The error is reported simply as "http error". It would help me figure out the root cause if I could see the underlying error returned by reqwest. This PR implements that.