### PR TITLE
Make tonic-build optional

### DIFF
--- a/googleapis/Cargo.toml
+++ b/googleapis/Cargo.toml
@@ -17,9 +17,10 @@ prost = "0.11"
 prost-types = "0.11"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = { version = "0.8", optional = true }
 
 [features]
 spanner = []
 pubsub = []
 storage = []
+generate = ["dep:tonic-build"]

--- a/googleapis/README.md
+++ b/googleapis/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/google-cloud-googleapis.svg)](https://crates.io/crates/google-cloud-googleapis)
 
-```
+```bash
 git clone https://github.com/googleapis/googleapis
-GEN=true cargo build
+cargo build --features generate
 ```

--- a/googleapis/build.rs
+++ b/googleapis/build.rs
@@ -1,18 +1,20 @@
+#[cfg(feature = "generate")]
 fn main() {
-    if std::env::var("GEN").is_ok() {
-        tonic_build::configure()
-            .build_server(false)
-            .out_dir("src") // you can change the generated code's location
-            .compile(
-                &[
-                    "googleapis/google/storage/v2/storage.proto",
-                    "googleapis/google/pubsub/v1/pubsub.proto",
-                    "googleapis/google/spanner/v1/spanner.proto",
-                    "googleapis/google/spanner/admin/database/v1/spanner_database_admin.proto",
-                    "googleapis/google/spanner/admin/instance/v1/spanner_instance_admin.proto",
-                ],
-                &["googleapis"], // specify the root location to search proto dependencies
-            )
-            .unwrap();
-    }
+    tonic_build::configure()
+        .build_server(false)
+        .out_dir("src") // you can change the generated code's location
+        .compile(
+            &[
+                "googleapis/google/storage/v2/storage.proto",
+                "googleapis/google/pubsub/v1/pubsub.proto",
+                "googleapis/google/spanner/v1/spanner.proto",
+                "googleapis/google/spanner/admin/database/v1/spanner_database_admin.proto",
+                "googleapis/google/spanner/admin/instance/v1/spanner_instance_admin.proto",
+            ],
+            &["googleapis"], // specify the root location to search proto dependencies
+        )
+        .unwrap();
 }
+
+#[cfg(not(feature = "generate"))]
+fn main() {}

--- a/googleapis/src/google.api.rs
+++ b/googleapis/src/google.api.rs
@@ -1,3 +1,373 @@
+/// The launch stage as defined by [Google Cloud Platform
+/// Launch Stages](<https://cloud.google.com/terms/launch-stages>).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LaunchStage {
+    /// Do not use this default value.
+    Unspecified = 0,
+    /// The feature is not yet implemented. Users can not use it.
+    Unimplemented = 6,
+    /// Prelaunch features are hidden from users and are only visible internally.
+    Prelaunch = 7,
+    /// Early Access features are limited to a closed group of testers. To use
+    /// these features, you must sign up in advance and sign a Trusted Tester
+    /// agreement (which includes confidentiality provisions). These features may
+    /// be unstable, changed in backward-incompatible ways, and are not
+    /// guaranteed to be released.
+    EarlyAccess = 1,
+    /// Alpha is a limited availability test for releases before they are cleared
+    /// for widespread use. By Alpha, all significant design issues are resolved
+    /// and we are in the process of verifying functionality. Alpha customers
+    /// need to apply for access, agree to applicable terms, and have their
+    /// projects allowlisted. Alpha releases don't have to be feature complete,
+    /// no SLAs are provided, and there are no technical support obligations, but
+    /// they will be far enough along that customers can actually use them in
+    /// test environments or for limited-use tests -- just like they would in
+    /// normal production cases.
+    Alpha = 2,
+    /// Beta is the point at which we are ready to open a release for any
+    /// customer to use. There are no SLA or technical support obligations in a
+    /// Beta release. Products will be complete from a feature perspective, but
+    /// may have some open outstanding issues. Beta releases are suitable for
+    /// limited production use cases.
+    Beta = 3,
+    /// GA features are open to all developers and are considered stable and
+    /// fully qualified for production use.
+    Ga = 4,
+    /// Deprecated features are scheduled to be shut down and removed. For more
+    /// information, see the "Deprecation Policy" section of our [Terms of
+    /// Service](<https://cloud.google.com/terms/>)
+    /// and the [Google Cloud Platform Subject to the Deprecation
+    /// Policy](<https://cloud.google.com/terms/deprecation>) documentation.
+    Deprecated = 5,
+}
+impl LaunchStage {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            LaunchStage::Unspecified => "LAUNCH_STAGE_UNSPECIFIED",
+            LaunchStage::Unimplemented => "UNIMPLEMENTED",
+            LaunchStage::Prelaunch => "PRELAUNCH",
+            LaunchStage::EarlyAccess => "EARLY_ACCESS",
+            LaunchStage::Alpha => "ALPHA",
+            LaunchStage::Beta => "BETA",
+            LaunchStage::Ga => "GA",
+            LaunchStage::Deprecated => "DEPRECATED",
+        }
+    }
+}
+/// Required information for every language.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommonLanguageSettings {
+    /// Link to automatically generated reference documentation.  Example:
+    /// <https://cloud.google.com/nodejs/docs/reference/asset/latest>
+    #[deprecated]
+    #[prost(string, tag = "1")]
+    pub reference_docs_uri: ::prost::alloc::string::String,
+    /// The destination where API teams want this client library to be published.
+    #[prost(enumeration = "ClientLibraryDestination", repeated, tag = "2")]
+    pub destinations: ::prost::alloc::vec::Vec<i32>,
+}
+/// Details about how and where to publish client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClientLibrarySettings {
+    /// Version of the API to apply these settings to.
+    #[prost(string, tag = "1")]
+    pub version: ::prost::alloc::string::String,
+    /// Launch stage of this version of the API.
+    #[prost(enumeration = "LaunchStage", tag = "2")]
+    pub launch_stage: i32,
+    /// When using transport=rest, the client request will encode enums as
+    /// numbers rather than strings.
+    #[prost(bool, tag = "3")]
+    pub rest_numeric_enums: bool,
+    /// Settings for legacy Java features, supported in the Service YAML.
+    #[prost(message, optional, tag = "21")]
+    pub java_settings: ::core::option::Option<JavaSettings>,
+    /// Settings for C++ client libraries.
+    #[prost(message, optional, tag = "22")]
+    pub cpp_settings: ::core::option::Option<CppSettings>,
+    /// Settings for PHP client libraries.
+    #[prost(message, optional, tag = "23")]
+    pub php_settings: ::core::option::Option<PhpSettings>,
+    /// Settings for Python client libraries.
+    #[prost(message, optional, tag = "24")]
+    pub python_settings: ::core::option::Option<PythonSettings>,
+    /// Settings for Node client libraries.
+    #[prost(message, optional, tag = "25")]
+    pub node_settings: ::core::option::Option<NodeSettings>,
+    /// Settings for .NET client libraries.
+    #[prost(message, optional, tag = "26")]
+    pub dotnet_settings: ::core::option::Option<DotnetSettings>,
+    /// Settings for Ruby client libraries.
+    #[prost(message, optional, tag = "27")]
+    pub ruby_settings: ::core::option::Option<RubySettings>,
+    /// Settings for Go client libraries.
+    #[prost(message, optional, tag = "28")]
+    pub go_settings: ::core::option::Option<GoSettings>,
+}
+/// This message configures the settings for publishing [Google Cloud Client
+/// libraries](<https://cloud.google.com/apis/docs/cloud-client-libraries>)
+/// generated from the service config.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Publishing {
+    /// A list of API method settings, e.g. the behavior for methods that use the
+    /// long-running operation pattern.
+    #[prost(message, repeated, tag = "2")]
+    pub method_settings: ::prost::alloc::vec::Vec<MethodSettings>,
+    /// Link to a place that API users can report issues.  Example:
+    /// <https://issuetracker.google.com/issues/new?component=190865&template=1161103>
+    #[prost(string, tag = "101")]
+    pub new_issue_uri: ::prost::alloc::string::String,
+    /// Link to product home page.  Example:
+    /// <https://cloud.google.com/asset-inventory/docs/overview>
+    #[prost(string, tag = "102")]
+    pub documentation_uri: ::prost::alloc::string::String,
+    /// Used as a tracking tag when collecting data about the APIs developer
+    /// relations artifacts like docs, packages delivered to package managers,
+    /// etc.  Example: "speech".
+    #[prost(string, tag = "103")]
+    pub api_short_name: ::prost::alloc::string::String,
+    /// GitHub label to apply to issues and pull requests opened for this API.
+    #[prost(string, tag = "104")]
+    pub github_label: ::prost::alloc::string::String,
+    /// GitHub teams to be added to CODEOWNERS in the directory in GitHub
+    /// containing source code for the client libraries for this API.
+    #[prost(string, repeated, tag = "105")]
+    pub codeowner_github_teams: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// A prefix used in sample code when demarking regions to be included in
+    /// documentation.
+    #[prost(string, tag = "106")]
+    pub doc_tag_prefix: ::prost::alloc::string::String,
+    /// For whom the client library is being published.
+    #[prost(enumeration = "ClientLibraryOrganization", tag = "107")]
+    pub organization: i32,
+    /// Client library settings.  If the same version string appears multiple
+    /// times in this list, then the last one wins.  Settings from earlier
+    /// settings with the same version string are discarded.
+    #[prost(message, repeated, tag = "109")]
+    pub library_settings: ::prost::alloc::vec::Vec<ClientLibrarySettings>,
+}
+/// Settings for Java client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct JavaSettings {
+    /// The package name to use in Java. Clobbers the java_package option
+    /// set in the protobuf. This should be used **only** by APIs
+    /// who have already set the language_settings.java.package_name" field
+    /// in gapic.yaml. API teams should use the protobuf java_package option
+    /// where possible.
+    ///
+    /// Example of a YAML configuration::
+    ///
+    ///   publishing:
+    ///     java_settings:
+    ///       library_package: com.google.cloud.pubsub.v1
+    #[prost(string, tag = "1")]
+    pub library_package: ::prost::alloc::string::String,
+    /// Configure the Java class name to use instead of the service's for its
+    /// corresponding generated GAPIC client. Keys are fully-qualified
+    /// service names as they appear in the protobuf (including the full
+    /// the language_settings.java.interface_names" field in gapic.yaml. API
+    /// teams should otherwise use the service name as it appears in the
+    /// protobuf.
+    ///
+    /// Example of a YAML configuration::
+    ///
+    ///   publishing:
+    ///     java_settings:
+    ///       service_class_names:
+    ///         - google.pubsub.v1.Publisher: TopicAdmin
+    ///         - google.pubsub.v1.Subscriber: SubscriptionAdmin
+    #[prost(map = "string, string", tag = "2")]
+    pub service_class_names: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
+    /// Some settings.
+    #[prost(message, optional, tag = "3")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for C++ client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CppSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Php client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PhpSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Python client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PythonSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Node client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NodeSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Dotnet client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DotnetSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Ruby client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RubySettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Settings for Go client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GoSettings {
+    /// Some settings.
+    #[prost(message, optional, tag = "1")]
+    pub common: ::core::option::Option<CommonLanguageSettings>,
+}
+/// Describes the generator configuration for a method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MethodSettings {
+    /// The fully qualified name of the method, for which the options below apply.
+    /// This is used to find the method to apply the options.
+    #[prost(string, tag = "1")]
+    pub selector: ::prost::alloc::string::String,
+    /// Describes settings to use for long-running operations when generating
+    /// API methods for RPCs. Complements RPCs that use the annotations in
+    /// google/longrunning/operations.proto.
+    ///
+    /// Example of a YAML configuration::
+    ///
+    ///   publishing:
+    ///     method_behavior:
+    ///       - selector: CreateAdDomain
+    ///         long_running:
+    ///           initial_poll_delay:
+    ///             seconds: 60 # 1 minute
+    ///           poll_delay_multiplier: 1.5
+    ///           max_poll_delay:
+    ///             seconds: 360 # 6 minutes
+    ///           total_poll_timeout:
+    ///              seconds: 54000 # 90 minutes
+    #[prost(message, optional, tag = "2")]
+    pub long_running: ::core::option::Option<method_settings::LongRunning>,
+}
+/// Nested message and enum types in `MethodSettings`.
+pub mod method_settings {
+    /// Describes settings to use when generating API methods that use the
+    /// long-running operation pattern.
+    /// All default values below are from those used in the client library
+    /// generators (e.g.
+    /// \[Java\](<https://github.com/googleapis/gapic-generator-java/blob/04c2faa191a9b5a10b92392fe8482279c4404803/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java>)).
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct LongRunning {
+        /// Initial delay after which the first poll request will be made.
+        /// Default value: 5 seconds.
+        #[prost(message, optional, tag = "1")]
+        pub initial_poll_delay: ::core::option::Option<::prost_types::Duration>,
+        /// Multiplier to gradually increase delay between subsequent polls until it
+        /// reaches max_poll_delay.
+        /// Default value: 1.5.
+        #[prost(float, tag = "2")]
+        pub poll_delay_multiplier: f32,
+        /// Maximum time between two subsequent poll requests.
+        /// Default value: 45 seconds.
+        #[prost(message, optional, tag = "3")]
+        pub max_poll_delay: ::core::option::Option<::prost_types::Duration>,
+        /// Total polling timeout.
+        /// Default value: 5 minutes.
+        #[prost(message, optional, tag = "4")]
+        pub total_poll_timeout: ::core::option::Option<::prost_types::Duration>,
+    }
+}
+/// The organization for which the client libraries are being published.
+/// Affects the url where generated docs are published, etc.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ClientLibraryOrganization {
+    /// Not useful.
+    Unspecified = 0,
+    /// Google Cloud Platform Org.
+    Cloud = 1,
+    /// Ads (Advertising) Org.
+    Ads = 2,
+    /// Photos Org.
+    Photos = 3,
+    /// Street View Org.
+    StreetView = 4,
+}
+impl ClientLibraryOrganization {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ClientLibraryOrganization::Unspecified => {
+                "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED"
+            }
+            ClientLibraryOrganization::Cloud => "CLOUD",
+            ClientLibraryOrganization::Ads => "ADS",
+            ClientLibraryOrganization::Photos => "PHOTOS",
+            ClientLibraryOrganization::StreetView => "STREET_VIEW",
+        }
+    }
+}
+/// To where should client libraries be published?
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ClientLibraryDestination {
+    /// Client libraries will neither be generated nor published to package
+    /// managers.
+    Unspecified = 0,
+    /// Generate the client library in a repo under github.com/googleapis,
+    /// but don't publish it to package managers.
+    Github = 10,
+    /// Publish the library to package managers like nuget.org and npmjs.com.
+    PackageManager = 20,
+}
+impl ClientLibraryDestination {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ClientLibraryDestination::Unspecified => {
+                "CLIENT_LIBRARY_DESTINATION_UNSPECIFIED"
+            }
+            ClientLibraryDestination::Github => "GITHUB",
+            ClientLibraryDestination::PackageManager => "PACKAGE_MANAGER",
+        }
+    }
+}
 /// An indicator of the behavior of a given field (for example, that a field
 /// is required in requests, or given as output but ignored as input).
 /// This **does not** change the behavior in protocol buffers itself; it only
@@ -41,6 +411,24 @@ pub enum FieldBehavior {
     /// non-empty value to expect.
     NonEmptyDefault = 7,
 }
+impl FieldBehavior {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            FieldBehavior::Unspecified => "FIELD_BEHAVIOR_UNSPECIFIED",
+            FieldBehavior::Optional => "OPTIONAL",
+            FieldBehavior::Required => "REQUIRED",
+            FieldBehavior::OutputOnly => "OUTPUT_ONLY",
+            FieldBehavior::InputOnly => "INPUT_ONLY",
+            FieldBehavior::Immutable => "IMMUTABLE",
+            FieldBehavior::UnorderedList => "UNORDERED_LIST",
+            FieldBehavior::NonEmptyDefault => "NON_EMPTY_DEFAULT",
+        }
+    }
+}
 /// A simple descriptor of a resource type.
 ///
 /// ResourceDescriptor annotates a resource message (either by means of a
@@ -49,45 +437,46 @@ pub enum FieldBehavior {
 ///
 /// Example:
 ///
-///     message Topic {
-///       // Indicates this message defines a resource schema.
-///       // Declares the resource type in the format of {service}/{kind}.
-///       // For Kubernetes resources, the format is {api group}/{kind}.
-///       option (google.api.resource) = {
-///         type: "pubsub.googleapis.com/Topic"
-///         pattern: "projects/{project}/topics/{topic}"
-///       };
-///     }
+///      message Topic {
+///        // Indicates this message defines a resource schema.
+///        // Declares the resource type in the format of {service}/{kind}.
+///        // For Kubernetes resources, the format is {api group}/{kind}.
+///        option (google.api.resource) = {
+///          type: "pubsub.googleapis.com/Topic"
+///          pattern: "projects/{project}/topics/{topic}"
+///        };
+///      }
 ///
 /// The ResourceDescriptor Yaml config will look like:
 ///
-///     resources:
-///     - type: "pubsub.googleapis.com/Topic"
-///       pattern: "projects/{project}/topics/{topic}"
+///      resources:
+///      - type: "pubsub.googleapis.com/Topic"
+///        pattern: "projects/{project}/topics/{topic}"
 ///
 /// Sometimes, resources have multiple patterns, typically because they can
 /// live under multiple parents.
 ///
 /// Example:
 ///
-///     message LogEntry {
-///       option (google.api.resource) = {
-///         type: "logging.googleapis.com/LogEntry"
-///         pattern: "projects/{project}/logs/{log}"
-///         pattern: "folders/{folder}/logs/{log}"
-///         pattern: "organizations/{organization}/logs/{log}"
-///         pattern: "billingAccounts/{billing_account}/logs/{log}"
-///       };
-///     }
+///      message LogEntry {
+///        option (google.api.resource) = {
+///          type: "logging.googleapis.com/LogEntry"
+///          pattern: "projects/{project}/logs/{log}"
+///          pattern: "folders/{folder}/logs/{log}"
+///          pattern: "organizations/{organization}/logs/{log}"
+///          pattern: "billingAccounts/{billing_account}/logs/{log}"
+///        };
+///      }
 ///
 /// The ResourceDescriptor Yaml config will look like:
 ///
-///     resources:
-///     - type: 'logging.googleapis.com/LogEntry'
-///       pattern: "projects/{project}/logs/{log}"
-///       pattern: "folders/{folder}/logs/{log}"
-///       pattern: "organizations/{organization}/logs/{log}"
-///       pattern: "billingAccounts/{billing_account}/logs/{log}"
+///      resources:
+///      - type: 'logging.googleapis.com/LogEntry'
+///        pattern: "projects/{project}/logs/{log}"
+///        pattern: "folders/{folder}/logs/{log}"
+///        pattern: "organizations/{organization}/logs/{log}"
+///        pattern: "billingAccounts/{billing_account}/logs/{log}"
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceDescriptor {
     /// The resource type. It must be in the format of
@@ -100,7 +489,7 @@ pub struct ResourceDescriptor {
     /// /\[A-Za-z][a-zA-Z0-9\]+/. It should start with an upper case character and
     /// should use PascalCase (UpperCamelCase). The maximum number of
     /// characters allowed for the `resource_type_kind` is 100.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub r#type: ::prost::alloc::string::String,
     /// Optional. The relative resource name pattern associated with this resource
     /// type. The DNS prefix of the full resource name shouldn't be specified here.
@@ -108,41 +497,41 @@ pub struct ResourceDescriptor {
     /// The path pattern must follow the syntax, which aligns with HTTP binding
     /// syntax:
     ///
-    ///     Template = Segment { "/" Segment } ;
-    ///     Segment = LITERAL | Variable ;
-    ///     Variable = "{" LITERAL "}" ;
+    ///      Template = Segment { "/" Segment } ;
+    ///      Segment = LITERAL | Variable ;
+    ///      Variable = "{" LITERAL "}" ;
     ///
     /// Examples:
     ///
-    ///     - "projects/{project}/topics/{topic}"
-    ///     - "projects/{project}/knowledgeBases/{knowledge_base}"
+    ///      - "projects/{project}/topics/{topic}"
+    ///      - "projects/{project}/knowledgeBases/{knowledge_base}"
     ///
     /// The components in braces correspond to the IDs for each resource in the
     /// hierarchy. It is expected that, if multiple patterns are provided,
     /// the same component name (e.g. "project") refers to IDs of the same
     /// type of resource.
-    #[prost(string, repeated, tag="2")]
+    #[prost(string, repeated, tag = "2")]
     pub pattern: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Optional. The field on the resource that designates the resource name
     /// field. If omitted, this is assumed to be "name".
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub name_field: ::prost::alloc::string::String,
     /// Optional. The historical or future-looking state of the resource pattern.
     ///
     /// Example:
     ///
-    ///     // The InspectTemplate message originally only supported resource
-    ///     // names with organization, and project was added later.
-    ///     message InspectTemplate {
-    ///       option (google.api.resource) = {
-    ///         type: "dlp.googleapis.com/InspectTemplate"
-    ///         pattern:
-    ///         "organizations/{organization}/inspectTemplates/{inspect_template}"
-    ///         pattern: "projects/{project}/inspectTemplates/{inspect_template}"
-    ///         history: ORIGINALLY_SINGLE_PATTERN
-    ///       };
-    ///     }
-    #[prost(enumeration="resource_descriptor::History", tag="4")]
+    ///      // The InspectTemplate message originally only supported resource
+    ///      // names with organization, and project was added later.
+    ///      message InspectTemplate {
+    ///        option (google.api.resource) = {
+    ///          type: "dlp.googleapis.com/InspectTemplate"
+    ///          pattern:
+    ///          "organizations/{organization}/inspectTemplates/{inspect_template}"
+    ///          pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+    ///          history: ORIGINALLY_SINGLE_PATTERN
+    ///        };
+    ///      }
+    #[prost(enumeration = "resource_descriptor::History", tag = "4")]
     pub history: i32,
     /// The plural name used in the resource name and permission names, such as
     /// 'projects' for the resource name of 'projects/{project}' and the permission
@@ -152,24 +541,34 @@ pub struct ResourceDescriptor {
     ///
     /// Note: The plural form is required even for singleton resources. See
     /// <https://aip.dev/156>
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub plural: ::prost::alloc::string::String,
     /// The same concept of the `singular` field in k8s CRD spec
     /// <https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/>
     /// Such as "project" for the `resourcemanager.googleapis.com/Project` type.
-    #[prost(string, tag="6")]
+    #[prost(string, tag = "6")]
     pub singular: ::prost::alloc::string::String,
     /// Style flag(s) for this resource.
     /// These indicate that a resource is expected to conform to a given
     /// style. See the specific style flags for additional information.
-    #[prost(enumeration="resource_descriptor::Style", repeated, tag="10")]
+    #[prost(enumeration = "resource_descriptor::Style", repeated, tag = "10")]
     pub style: ::prost::alloc::vec::Vec<i32>,
 }
 /// Nested message and enum types in `ResourceDescriptor`.
 pub mod resource_descriptor {
     /// A description of the historical or future-looking state of the
     /// resource pattern.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum History {
         /// The "unset" value.
@@ -182,8 +581,31 @@ pub mod resource_descriptor {
         /// that from being necessary once there are multiple patterns.)
         FutureMultiPattern = 2,
     }
+    impl History {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                History::Unspecified => "HISTORY_UNSPECIFIED",
+                History::OriginallySinglePattern => "ORIGINALLY_SINGLE_PATTERN",
+                History::FutureMultiPattern => "FUTURE_MULTI_PATTERN",
+            }
+        }
+    }
     /// A flag representing a specific style that a resource claims to conform to.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Style {
         /// The unspecified value. Do not use.
@@ -198,32 +620,45 @@ pub mod resource_descriptor {
         /// additional checks.
         DeclarativeFriendly = 1,
     }
+    impl Style {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Style::Unspecified => "STYLE_UNSPECIFIED",
+                Style::DeclarativeFriendly => "DECLARATIVE_FRIENDLY",
+            }
+        }
+    }
 }
 /// Defines a proto annotation that describes a string field that refers to
 /// an API resource.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceReference {
     /// The resource type that the annotated field references.
     ///
     /// Example:
     ///
-    ///     message Subscription {
-    ///       string topic = 2 [(google.api.resource_reference) = {
-    ///         type: "pubsub.googleapis.com/Topic"
-    ///       }];
-    ///     }
+    ///      message Subscription {
+    ///        string topic = 2 [(google.api.resource_reference) = {
+    ///          type: "pubsub.googleapis.com/Topic"
+    ///        }];
+    ///      }
     ///
     /// Occasionally, a field may reference an arbitrary resource. In this case,
     /// APIs use the special value * in their resource reference.
     ///
     /// Example:
     ///
-    ///     message GetIamPolicyRequest {
-    ///       string resource = 2 [(google.api.resource_reference) = {
-    ///         type: "*"
-    ///       }];
-    ///     }
-    #[prost(string, tag="1")]
+    ///      message GetIamPolicyRequest {
+    ///        string resource = 2 [(google.api.resource_reference) = {
+    ///          type: "*"
+    ///        }];
+    ///      }
+    #[prost(string, tag = "1")]
     pub r#type: ::prost::alloc::string::String,
     /// The resource type of a child collection that the annotated field
     /// references. This is useful for annotating the `parent` field that
@@ -231,12 +666,12 @@ pub struct ResourceReference {
     ///
     /// Example:
     ///
-    ///     message ListLogEntriesRequest {
-    ///       string parent = 1 [(google.api.resource_reference) = {
-    ///         child_type: "logging.googleapis.com/LogEntry"
-    ///       };
-    ///     }
-    #[prost(string, tag="2")]
+    ///      message ListLogEntriesRequest {
+    ///        string parent = 1 [(google.api.resource_reference) = {
+    ///          child_type: "logging.googleapis.com/LogEntry"
+    ///        };
+    ///      }
+    #[prost(string, tag = "2")]
     pub child_type: ::prost::alloc::string::String,
 }
 /// Specifies the routing information that should be sent along with the request
@@ -247,27 +682,27 @@ pub struct ResourceReference {
 ///
 /// Message Definition:
 ///
-///     message Request {
-///       // The name of the Table
-///       // Values can be of the following formats:
-///       // - `projects/<project>/tables/<table>`
-///       // - `projects/<project>/instances/<instance>/tables/<table>`
-///       // - `region/<region>/zones/<zone>/tables/<table>`
-///       string table_name = 1;
+///      message Request {
+///        // The name of the Table
+///        // Values can be of the following formats:
+///        // - `projects/<project>/tables/<table>`
+///        // - `projects/<project>/instances/<instance>/tables/<table>`
+///        // - `region/<region>/zones/<zone>/tables/<table>`
+///        string table_name = 1;
 ///
-///       // This value specifies routing for replication.
-///       // It can be in the following formats:
-///       // - `profiles/<profile_id>`
-///       // - a legacy `profile_id` that can be any string
-///       string app_profile_id = 2;
-///     }
+///        // This value specifies routing for replication.
+///        // It can be in the following formats:
+///        // - `profiles/<profile_id>`
+///        // - a legacy `profile_id` that can be any string
+///        string app_profile_id = 2;
+///      }
 ///
 /// Example message:
 ///
-///     {
-///       table_name: projects/proj_foo/instances/instance_bar/table/table_baz,
-///       app_profile_id: profiles/prof_qux
-///     }
+///      {
+///        table_name: projects/proj_foo/instances/instance_bar/table/table_baz,
+///        app_profile_id: profiles/prof_qux
+///      }
 ///
 /// The routing header consists of one or multiple key-value pairs. Every key
 /// and value must be percent-encoded, and joined together in the format of
@@ -281,16 +716,16 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // Take the `app_profile_id`.
-///       routing_parameters {
-///         field: "app_profile_id"
-///       }
-///     };
+///      option (google.api.routing) = {
+///        // Take the `app_profile_id`.
+///        routing_parameters {
+///          field: "app_profile_id"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params: app_profile_id=profiles/prof_qux
+///      x-goog-request-params: app_profile_id=profiles/prof_qux
 ///
 /// Example 2
 ///
@@ -299,17 +734,17 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // Take the `app_profile_id`, but name it `routing_id` in the header.
-///       routing_parameters {
-///         field: "app_profile_id"
-///         path_template: "{routing_id=**}"
-///       }
-///     };
+///      option (google.api.routing) = {
+///        // Take the `app_profile_id`, but name it `routing_id` in the header.
+///        routing_parameters {
+///          field: "app_profile_id"
+///          path_template: "{routing_id=**}"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params: routing_id=profiles/prof_qux
+///      x-goog-request-params: routing_id=profiles/prof_qux
 ///
 /// Example 3
 ///
@@ -325,19 +760,19 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // Take the `table_name`, if it's well-formed (with project-based
-///       // syntax).
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{table_name=projects/*/instances/*/**}"
-///       }
-///     };
+///      option (google.api.routing) = {
+///        // Take the `table_name`, if it's well-formed (with project-based
+///        // syntax).
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{table_name=projects/*/instances/*/**}"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params:
-///     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+///      x-goog-request-params:
+///      table_name=projects/proj_foo/instances/instance_bar/table/table_baz
 ///
 /// Sub-example 3b
 ///
@@ -345,18 +780,18 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // Take the `table_name`, if it's well-formed (with region-based
-///       // syntax).
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{table_name=regions/*/zones/*/**}"
-///       }
-///     };
+///      option (google.api.routing) = {
+///        // Take the `table_name`, if it's well-formed (with region-based
+///        // syntax).
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{table_name=regions/*/zones/*/**}"
+///        }
+///      };
 ///
 /// result:
 ///
-///     <no routing header will be sent>
+///      <no routing header will be sent>
 ///
 /// Sub-example 3c
 ///
@@ -365,24 +800,24 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // Take the `table_name`, if it's well-formed, whether
-///       // using the region- or projects-based syntax.
+///      option (google.api.routing) = {
+///        // Take the `table_name`, if it's well-formed, whether
+///        // using the region- or projects-based syntax.
 ///
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{table_name=regions/*/zones/*/**}"
-///       }
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{table_name=projects/*/instances/*/**}"
-///       }
-///     };
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{table_name=regions/*/zones/*/**}"
+///        }
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{table_name=projects/*/instances/*/**}"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params:
-///     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+///      x-goog-request-params:
+///      table_name=projects/proj_foo/instances/instance_bar/table/table_baz
 ///
 /// Example 4
 ///
@@ -391,17 +826,17 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // Take just the project id from the `table_name` field.
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{routing_id=projects/*}/**"
-///       }
-///     };
+///      option (google.api.routing) = {
+///        // Take just the project id from the `table_name` field.
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{routing_id=projects/*}/**"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params: routing_id=projects/proj_foo
+///      x-goog-request-params: routing_id=projects/proj_foo
 ///
 /// Example 5
 ///
@@ -411,25 +846,25 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // If the `table_name` does not have instances information,
-///       // take just the project id for routing.
-///       // Otherwise take project + instance.
+///      option (google.api.routing) = {
+///        // If the `table_name` does not have instances information,
+///        // take just the project id for routing.
+///        // Otherwise take project + instance.
 ///
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{routing_id=projects/*}/**"
-///       }
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{routing_id=projects/*/instances/*}/**"
-///       }
-///     };
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{routing_id=projects/*}/**"
+///        }
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{routing_id=projects/*/instances/*}/**"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params:
-///     routing_id=projects/proj_foo/instances/instance_bar
+///      x-goog-request-params:
+///      routing_id=projects/proj_foo/instances/instance_bar
 ///
 /// Example 6
 ///
@@ -443,25 +878,25 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // The routing code needs two keys instead of one composite
-///       // but works only for the tables with the "project-instance" name
-///       // syntax.
+///      option (google.api.routing) = {
+///        // The routing code needs two keys instead of one composite
+///        // but works only for the tables with the "project-instance" name
+///        // syntax.
 ///
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{project_id=projects/*}/instances/*/**"
-///       }
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "projects/*/{instance_id=instances/*}/**"
-///       }
-///     };
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{project_id=projects/*}/instances/*/**"
+///        }
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "projects/*/{instance_id=instances/*}/**"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params:
-///     project_id=projects/proj_foo&instance_id=instances/instance_bar
+///      x-goog-request-params:
+///      project_id=projects/proj_foo&instance_id=instances/instance_bar
 ///
 /// Sub-example 6b
 ///
@@ -470,26 +905,26 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // The routing code wants two keys instead of one composite
-///       // but will work with just the `project_id` for tables without
-///       // an instance in the `table_name`.
+///      option (google.api.routing) = {
+///        // The routing code wants two keys instead of one composite
+///        // but will work with just the `project_id` for tables without
+///        // an instance in the `table_name`.
 ///
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{project_id=projects/*}/**"
-///       }
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "projects/*/{instance_id=instances/*}/**"
-///       }
-///     };
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{project_id=projects/*}/**"
+///        }
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "projects/*/{instance_id=instances/*}/**"
+///        }
+///      };
 ///
 /// result (is the same as 6a for our example message because it has the instance
 /// information):
 ///
-///     x-goog-request-params:
-///     project_id=projects/proj_foo&instance_id=instances/instance_bar
+///      x-goog-request-params:
+///      project_id=projects/proj_foo&instance_id=instances/instance_bar
 ///
 /// Example 7
 ///
@@ -504,24 +939,24 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // The routing needs both `project_id` and `routing_id`
-///       // (from the `app_profile_id` field) for routing.
+///      option (google.api.routing) = {
+///        // The routing needs both `project_id` and `routing_id`
+///        // (from the `app_profile_id` field) for routing.
 ///
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{project_id=projects/*}/**"
-///       }
-///       routing_parameters {
-///         field: "app_profile_id"
-///         path_template: "{routing_id=**}"
-///       }
-///     };
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{project_id=projects/*}/**"
+///        }
+///        routing_parameters {
+///          field: "app_profile_id"
+///          path_template: "{routing_id=**}"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params:
-///     project_id=projects/proj_foo&routing_id=profiles/prof_qux
+///      x-goog-request-params:
+///      project_id=projects/proj_foo&routing_id=profiles/prof_qux
 ///
 /// Example 8
 ///
@@ -531,28 +966,28 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // The `routing_id` can be a project id or a region id depending on
-///       // the table name format, but only if the `app_profile_id` is not set.
-///       // If `app_profile_id` is set it should be used instead.
+///      option (google.api.routing) = {
+///        // The `routing_id` can be a project id or a region id depending on
+///        // the table name format, but only if the `app_profile_id` is not set.
+///        // If `app_profile_id` is set it should be used instead.
 ///
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{routing_id=projects/*}/**"
-///       }
-///       routing_parameters {
+///        routing_parameters {
 ///          field: "table_name"
-///          path_template: "{routing_id=regions/*}/**"
-///       }
-///       routing_parameters {
-///         field: "app_profile_id"
-///         path_template: "{routing_id=**}"
-///       }
-///     };
+///          path_template: "{routing_id=projects/*}/**"
+///        }
+///        routing_parameters {
+///           field: "table_name"
+///           path_template: "{routing_id=regions/*}/**"
+///        }
+///        routing_parameters {
+///          field: "app_profile_id"
+///          path_template: "{routing_id=**}"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params: routing_id=profiles/prof_qux
+///      x-goog-request-params: routing_id=profiles/prof_qux
 ///
 /// Example 9
 ///
@@ -560,44 +995,45 @@ pub struct ResourceReference {
 ///
 /// annotation:
 ///
-///     option (google.api.routing) = {
-///       // For routing both `table_location` and a `routing_id` are needed.
-///       //
-///       // table_location can be either an instance id or a region+zone id.
-///       //
-///       // For `routing_id`, take the value of `app_profile_id`
-///       // - If it's in the format `profiles/<profile_id>`, send
-///       // just the `<profile_id>` part.
-///       // - If it's any other literal, send it as is.
-///       // If the `app_profile_id` is empty, and the `table_name` starts with
-///       // the project_id, send that instead.
+///      option (google.api.routing) = {
+///        // For routing both `table_location` and a `routing_id` are needed.
+///        //
+///        // table_location can be either an instance id or a region+zone id.
+///        //
+///        // For `routing_id`, take the value of `app_profile_id`
+///        // - If it's in the format `profiles/<profile_id>`, send
+///        // just the `<profile_id>` part.
+///        // - If it's any other literal, send it as is.
+///        // If the `app_profile_id` is empty, and the `table_name` starts with
+///        // the project_id, send that instead.
 ///
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "projects/*/{table_location=instances/*}/tables/*"
-///       }
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{table_location=regions/*/zones/*}/tables/*"
-///       }
-///       routing_parameters {
-///         field: "table_name"
-///         path_template: "{routing_id=projects/*}/**"
-///       }
-///       routing_parameters {
-///         field: "app_profile_id"
-///         path_template: "{routing_id=**}"
-///       }
-///       routing_parameters {
-///         field: "app_profile_id"
-///         path_template: "profiles/{routing_id=*}"
-///       }
-///     };
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "projects/*/{table_location=instances/*}/tables/*"
+///        }
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{table_location=regions/*/zones/*}/tables/*"
+///        }
+///        routing_parameters {
+///          field: "table_name"
+///          path_template: "{routing_id=projects/*}/**"
+///        }
+///        routing_parameters {
+///          field: "app_profile_id"
+///          path_template: "{routing_id=**}"
+///        }
+///        routing_parameters {
+///          field: "app_profile_id"
+///          path_template: "profiles/{routing_id=*}"
+///        }
+///      };
 ///
 /// result:
 ///
-///     x-goog-request-params:
-///     table_location=instances/instance_bar&routing_id=prof_qux
+///      x-goog-request-params:
+///      table_location=instances/instance_bar&routing_id=prof_qux
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoutingRule {
     /// A collection of Routing Parameter specifications.
@@ -606,14 +1042,15 @@ pub struct RoutingRule {
     /// `path_template` is not provided), "last one wins" rule
     /// determines which Parameter gets used.
     /// See the examples for more details.
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub routing_parameters: ::prost::alloc::vec::Vec<RoutingParameter>,
 }
 /// A projection from an input message to the GRPC or REST header.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RoutingParameter {
     /// A request field to extract the header key-value pair from.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub field: ::prost::alloc::string::String,
     /// A pattern matching the key-value field. Optional.
     /// If not specified, the whole field specified in the `field` field will be
@@ -627,60 +1064,61 @@ pub struct RoutingParameter {
     ///
     /// Example:
     ///
-    ///               -- This is a field in the request message
-    ///              |   that the header value will be extracted from.
-    ///              |
-    ///              |                     -- This is the key name in the
-    ///              |                    |   routing header.
-    ///              V                    |
-    ///     field: "table_name"           v
-    ///     path_template: "projects/*/{table_location=instances/*}/tables/*"
-    ///                                                ^            ^
-    ///                                                |            |
-    ///       In the {} brackets is the pattern that --             |
-    ///       specifies what to extract from the                    |
-    ///       field as a value to be sent.                          |
-    ///                                                             |
-    ///      The string in the field must match the whole pattern --
-    ///      before brackets, inside brackets, after brackets.
+    ///                -- This is a field in the request message
+    ///               |   that the header value will be extracted from.
+    ///               |
+    ///               |                     -- This is the key name in the
+    ///               |                    |   routing header.
+    ///               V                    |
+    ///      field: "table_name"           v
+    ///      path_template: "projects/*/{table_location=instances/*}/tables/*"
+    ///                                                 ^            ^
+    ///                                                 |            |
+    ///        In the {} brackets is the pattern that --             |
+    ///        specifies what to extract from the                    |
+    ///        field as a value to be sent.                          |
+    ///                                                              |
+    ///       The string in the field must match the whole pattern --
+    ///       before brackets, inside brackets, after brackets.
     ///
     /// When looking at this specific example, we can see that:
     /// - A key-value pair with the key `table_location`
-    ///   and the value matching `instances/*` should be added
-    ///   to the x-goog-request-params routing header.
+    ///    and the value matching `instances/*` should be added
+    ///    to the x-goog-request-params routing header.
     /// - The value is extracted from the request message's `table_name` field
-    ///   if it matches the full pattern specified:
-    ///   `projects/*/instances/*/tables/*`.
+    ///    if it matches the full pattern specified:
+    ///    `projects/*/instances/*/tables/*`.
     ///
     /// **NB:** If the `path_template` field is not provided, the key name is
     /// equal to the field name, and the whole field should be sent as a value.
     /// This makes the pattern for the field and the value functionally equivalent
     /// to `**`, and the configuration
     ///
-    ///     {
-    ///       field: "table_name"
-    ///     }
+    ///      {
+    ///        field: "table_name"
+    ///      }
     ///
     /// is a functionally equivalent shorthand to:
     ///
-    ///     {
-    ///       field: "table_name"
-    ///       path_template: "{table_name=**}"
-    ///     }
+    ///      {
+    ///        field: "table_name"
+    ///        path_template: "{table_name=**}"
+    ///      }
     ///
     /// See Example 1 for more details.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub path_template: ::prost::alloc::string::String,
 }
 /// Defines the HTTP configuration for an API service. It contains a list of
 /// \[HttpRule][google.api.HttpRule\], each specifying the mapping of an RPC method
 /// to one or more HTTP REST API methods.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Http {
     /// A list of HTTP configuration rules that apply to individual API methods.
     ///
     /// **NOTE:** All service configuration rules follow "last one wins" order.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub rules: ::prost::alloc::vec::Vec<HttpRule>,
     /// When set to true, URL path parameters will be fully URI-decoded except in
     /// cases of single segment matches in reserved expansion, where "%2F" will be
@@ -688,7 +1126,7 @@ pub struct Http {
     ///
     /// The default behavior is to not decode RFC 6570 reserved characters in multi
     /// segment matches.
-    #[prost(bool, tag="2")]
+    #[prost(bool, tag = "2")]
     pub fully_decode_reserved_expansion: bool,
 }
 /// # gRPC Transcoding
@@ -716,19 +1154,19 @@ pub struct Http {
 ///
 /// Example:
 ///
-///     service Messaging {
-///       rpc GetMessage(GetMessageRequest) returns (Message) {
-///         option (google.api.http) = {
-///             get: "/v1/{name=messages/*}"
-///         };
-///       }
-///     }
-///     message GetMessageRequest {
-///       string name = 1; // Mapped to URL path.
-///     }
-///     message Message {
-///       string text = 1; // The resource content.
-///     }
+///      service Messaging {
+///        rpc GetMessage(GetMessageRequest) returns (Message) {
+///          option (google.api.http) = {
+///              get: "/v1/{name=messages/*}"
+///          };
+///        }
+///      }
+///      message GetMessageRequest {
+///        string name = 1; // Mapped to URL path.
+///      }
+///      message Message {
+///        string text = 1; // The resource content.
+///      }
 ///
 /// This enables an HTTP REST to gRPC mapping as below:
 ///
@@ -740,21 +1178,21 @@ pub struct Http {
 /// automatically become HTTP query parameters if there is no HTTP request body.
 /// For example:
 ///
-///     service Messaging {
-///       rpc GetMessage(GetMessageRequest) returns (Message) {
-///         option (google.api.http) = {
-///             get:"/v1/messages/{message_id}"
-///         };
-///       }
-///     }
-///     message GetMessageRequest {
-///       message SubMessage {
-///         string subfield = 1;
-///       }
-///       string message_id = 1; // Mapped to URL path.
-///       int64 revision = 2;    // Mapped to URL query parameter `revision`.
-///       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
-///     }
+///      service Messaging {
+///        rpc GetMessage(GetMessageRequest) returns (Message) {
+///          option (google.api.http) = {
+///              get:"/v1/messages/{message_id}"
+///          };
+///        }
+///      }
+///      message GetMessageRequest {
+///        message SubMessage {
+///          string subfield = 1;
+///        }
+///        string message_id = 1; // Mapped to URL path.
+///        int64 revision = 2;    // Mapped to URL query parameter `revision`.
+///        SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+///      }
 ///
 /// This enables a HTTP JSON to RPC mapping as below:
 ///
@@ -775,18 +1213,18 @@ pub struct Http {
 /// specifies the mapping. Consider a REST update method on the
 /// message resource collection:
 ///
-///     service Messaging {
-///       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
-///         option (google.api.http) = {
-///           patch: "/v1/messages/{message_id}"
-///           body: "message"
-///         };
-///       }
-///     }
-///     message UpdateMessageRequest {
-///       string message_id = 1; // mapped to the URL
-///       Message message = 2;   // mapped to the body
-///     }
+///      service Messaging {
+///        rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+///          option (google.api.http) = {
+///            patch: "/v1/messages/{message_id}"
+///            body: "message"
+///          };
+///        }
+///      }
+///      message UpdateMessageRequest {
+///        string message_id = 1; // mapped to the URL
+///        Message message = 2;   // mapped to the body
+///      }
 ///
 /// The following HTTP JSON to RPC mapping is enabled, where the
 /// representation of the JSON in the request body is determined by
@@ -802,18 +1240,18 @@ pub struct Http {
 /// request body.  This enables the following alternative definition of
 /// the update method:
 ///
-///     service Messaging {
-///       rpc UpdateMessage(Message) returns (Message) {
-///         option (google.api.http) = {
-///           patch: "/v1/messages/{message_id}"
-///           body: "*"
-///         };
-///       }
-///     }
-///     message Message {
-///       string message_id = 1;
-///       string text = 2;
-///     }
+///      service Messaging {
+///        rpc UpdateMessage(Message) returns (Message) {
+///          option (google.api.http) = {
+///            patch: "/v1/messages/{message_id}"
+///            body: "*"
+///          };
+///        }
+///      }
+///      message Message {
+///        string message_id = 1;
+///        string text = 2;
+///      }
 ///
 ///
 /// The following HTTP JSON to RPC mapping is enabled:
@@ -832,20 +1270,20 @@ pub struct Http {
 /// It is possible to define multiple HTTP methods for one RPC by using
 /// the `additional_bindings` option. Example:
 ///
-///     service Messaging {
-///       rpc GetMessage(GetMessageRequest) returns (Message) {
-///         option (google.api.http) = {
-///           get: "/v1/messages/{message_id}"
-///           additional_bindings {
-///             get: "/v1/users/{user_id}/messages/{message_id}"
-///           }
-///         };
-///       }
-///     }
-///     message GetMessageRequest {
-///       string message_id = 1;
-///       string user_id = 2;
-///     }
+///      service Messaging {
+///        rpc GetMessage(GetMessageRequest) returns (Message) {
+///          option (google.api.http) = {
+///            get: "/v1/messages/{message_id}"
+///            additional_bindings {
+///              get: "/v1/users/{user_id}/messages/{message_id}"
+///            }
+///          };
+///        }
+///      }
+///      message GetMessageRequest {
+///        string message_id = 1;
+///        string user_id = 2;
+///      }
 ///
 /// This enables the following two alternative HTTP JSON to RPC mappings:
 ///
@@ -858,27 +1296,27 @@ pub struct Http {
 /// ## Rules for HTTP mapping
 ///
 /// 1. Leaf request fields (recursive expansion nested messages in the request
-///    message) are classified into three categories:
-///    - Fields referred by the path template. They are passed via the URL path.
-///    - Fields referred by the \[HttpRule.body][google.api.HttpRule.body\]. They are passed via the HTTP
-///      request body.
-///    - All other fields are passed via the URL query parameters, and the
-///      parameter name is the field path in the request message. A repeated
-///      field can be represented as multiple query parameters under the same
-///      name.
-///  2. If \[HttpRule.body][google.api.HttpRule.body\] is "*", there is no URL query parameter, all fields
-///     are passed via URL path and HTTP request body.
-///  3. If \[HttpRule.body][google.api.HttpRule.body\] is omitted, there is no HTTP request body, all
-///     fields are passed via URL path and URL query parameters.
+///     message) are classified into three categories:
+///     - Fields referred by the path template. They are passed via the URL path.
+///     - Fields referred by the \[HttpRule.body][google.api.HttpRule.body\]. They are passed via the HTTP
+///       request body.
+///     - All other fields are passed via the URL query parameters, and the
+///       parameter name is the field path in the request message. A repeated
+///       field can be represented as multiple query parameters under the same
+///       name.
+///   2. If \[HttpRule.body][google.api.HttpRule.body\] is "*", there is no URL query parameter, all fields
+///      are passed via URL path and HTTP request body.
+///   3. If \[HttpRule.body][google.api.HttpRule.body\] is omitted, there is no HTTP request body, all
+///      fields are passed via URL path and URL query parameters.
 ///
 /// ### Path template syntax
 ///
-///     Template = "/" Segments [ Verb ] ;
-///     Segments = Segment { "/" Segment } ;
-///     Segment  = "*" | "**" | LITERAL | Variable ;
-///     Variable = "{" FieldPath [ "=" Segments ] "}" ;
-///     FieldPath = IDENT { "." IDENT } ;
-///     Verb     = ":" LITERAL ;
+///      Template = "/" Segments [ Verb ] ;
+///      Segments = Segment { "/" Segment } ;
+///      Segment  = "*" | "**" | LITERAL | Variable ;
+///      Variable = "{" FieldPath [ "=" Segments ] "}" ;
+///      FieldPath = IDENT { "." IDENT } ;
+///      Verb     = ":" LITERAL ;
 ///
 /// The syntax `*` matches a single URL path segment. The syntax `**` matches
 /// zero or more URL path segments, which must be the last part of the URL path
@@ -927,11 +1365,11 @@ pub struct Http {
 ///
 /// Example:
 ///
-///     http:
-///       rules:
-///         # Selects a gRPC method and applies HttpRule to it.
-///         - selector: example.v1.Messaging.GetMessage
-///           get: /v1/messages/{message_id}/{sub.subfield}
+///      http:
+///        rules:
+///          # Selects a gRPC method and applies HttpRule to it.
+///          - selector: example.v1.Messaging.GetMessage
+///            get: /v1/messages/{message_id}/{sub.subfield}
 ///
 /// ## Special notes
 ///
@@ -960,12 +1398,13 @@ pub struct Http {
 /// If an API needs to use a JSON array for request or response body, it can map
 /// the request or response body to a repeated field. However, some gRPC
 /// Transcoding implementations may not support this feature.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpRule {
     /// Selects a method to which this rule applies.
     ///
     /// Refer to \[selector][google.api.DocumentationRule.selector\] for syntax details.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub selector: ::prost::alloc::string::String,
     /// The name of the request field whose value is mapped to the HTTP request
     /// body, or `*` for mapping all request fields not captured by the path
@@ -973,7 +1412,7 @@ pub struct HttpRule {
     ///
     /// NOTE: the referred field must be present at the top-level of the request
     /// message type.
-    #[prost(string, tag="7")]
+    #[prost(string, tag = "7")]
     pub body: ::prost::alloc::string::String,
     /// Optional. The name of the response field whose value is mapped to the HTTP
     /// response body. When omitted, the entire response message will be used
@@ -981,17 +1420,17 @@ pub struct HttpRule {
     ///
     /// NOTE: The referred field must be present at the top-level of the response
     /// message type.
-    #[prost(string, tag="12")]
+    #[prost(string, tag = "12")]
     pub response_body: ::prost::alloc::string::String,
     /// Additional HTTP bindings for the selector. Nested bindings must
     /// not contain an `additional_bindings` field themselves (that is,
     /// the nesting may only be one level deep).
-    #[prost(message, repeated, tag="11")]
+    #[prost(message, repeated, tag = "11")]
     pub additional_bindings: ::prost::alloc::vec::Vec<HttpRule>,
     /// Determines the URL pattern is matched by this rules. This pattern can be
     /// used with any of the {get|put|post|delete|patch} methods. A custom method
     /// can be defined using the 'custom' field.
-    #[prost(oneof="http_rule::Pattern", tags="2, 3, 4, 5, 6, 8")]
+    #[prost(oneof = "http_rule::Pattern", tags = "2, 3, 4, 5, 6, 8")]
     pub pattern: ::core::option::Option<http_rule::Pattern>,
 }
 /// Nested message and enum types in `HttpRule`.
@@ -999,39 +1438,41 @@ pub mod http_rule {
     /// Determines the URL pattern is matched by this rules. This pattern can be
     /// used with any of the {get|put|post|delete|patch} methods. A custom method
     /// can be defined using the 'custom' field.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Pattern {
         /// Maps to HTTP GET. Used for listing and getting information about
         /// resources.
-        #[prost(string, tag="2")]
+        #[prost(string, tag = "2")]
         Get(::prost::alloc::string::String),
         /// Maps to HTTP PUT. Used for replacing a resource.
-        #[prost(string, tag="3")]
+        #[prost(string, tag = "3")]
         Put(::prost::alloc::string::String),
         /// Maps to HTTP POST. Used for creating a resource or performing an action.
-        #[prost(string, tag="4")]
+        #[prost(string, tag = "4")]
         Post(::prost::alloc::string::String),
         /// Maps to HTTP DELETE. Used for deleting a resource.
-        #[prost(string, tag="5")]
+        #[prost(string, tag = "5")]
         Delete(::prost::alloc::string::String),
         /// Maps to HTTP PATCH. Used for updating a resource.
-        #[prost(string, tag="6")]
+        #[prost(string, tag = "6")]
         Patch(::prost::alloc::string::String),
         /// The custom pattern is used for specifying an HTTP method that is not
         /// included in the `pattern` field, such as HEAD, or "*" to leave the
         /// HTTP method unspecified for this rule. The wild-card rule is useful
         /// for services that provide content to Web (HTML) clients.
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         Custom(super::CustomHttpPattern),
     }
 }
 /// A custom pattern is used for defining custom HTTP verb.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CustomHttpPattern {
     /// The name of this custom HTTP verb.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub kind: ::prost::alloc::string::String,
     /// The path matched by this custom verb.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub path: ::prost::alloc::string::String,
 }

--- a/googleapis/src/google.iam.v1.rs
+++ b/googleapis/src/google.iam.v1.rs
@@ -1,5 +1,6 @@
 /// Encapsulates settings provided to GetIamPolicy.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPolicyOptions {
     /// Optional. The maximum policy version that will be used to format the
     /// policy.
@@ -41,55 +42,56 @@ pub struct GetPolicyOptions {
 ///
 /// **JSON example:**
 ///
-///     {
-///       "bindings": [
-///         {
-///           "role": "roles/resourcemanager.organizationAdmin",
-///           "members": [
-///             "user:mike@example.com",
-///             "group:admins@example.com",
-///             "domain:google.com",
-///             "serviceAccount:my-project-id@appspot.gserviceaccount.com"
-///           ]
-///         },
-///         {
-///           "role": "roles/resourcemanager.organizationViewer",
-///           "members": [
-///             "user:eve@example.com"
-///           ],
-///           "condition": {
-///             "title": "expirable access",
-///             "description": "Does not grant access after Sep 2020",
-///             "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')",
-///           }
-///         }
-///       ],
-///       "etag": "BwWWja0YfJA=",
-///       "version": 3
-///     }
+///      {
+///        "bindings": [
+///          {
+///            "role": "roles/resourcemanager.organizationAdmin",
+///            "members": [
+///              "user:mike@example.com",
+///              "group:admins@example.com",
+///              "domain:google.com",
+///              "serviceAccount:my-project-id@appspot.gserviceaccount.com"
+///            ]
+///          },
+///          {
+///            "role": "roles/resourcemanager.organizationViewer",
+///            "members": [
+///              "user:eve@example.com"
+///            ],
+///            "condition": {
+///              "title": "expirable access",
+///              "description": "Does not grant access after Sep 2020",
+///              "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')",
+///            }
+///          }
+///        ],
+///        "etag": "BwWWja0YfJA=",
+///        "version": 3
+///      }
 ///
 /// **YAML example:**
 ///
-///     bindings:
-///     - members:
-///       - user:mike@example.com
-///       - group:admins@example.com
-///       - domain:google.com
-///       - serviceAccount:my-project-id@appspot.gserviceaccount.com
-///       role: roles/resourcemanager.organizationAdmin
-///     - members:
-///       - user:eve@example.com
-///       role: roles/resourcemanager.organizationViewer
-///       condition:
-///         title: expirable access
-///         description: Does not grant access after Sep 2020
-///         expression: request.time < timestamp('2020-10-01T00:00:00.000Z')
-///     etag: BwWWja0YfJA=
-///     version: 3
+///      bindings:
+///      - members:
+///        - user:mike@example.com
+///        - group:admins@example.com
+///        - domain:google.com
+///        - serviceAccount:my-project-id@appspot.gserviceaccount.com
+///        role: roles/resourcemanager.organizationAdmin
+///      - members:
+///        - user:eve@example.com
+///        role: roles/resourcemanager.organizationViewer
+///        condition:
+///          title: expirable access
+///          description: Does not grant access after Sep 2020
+///          expression: request.time < timestamp('2020-10-01T00:00:00.000Z')
+///      etag: BwWWja0YfJA=
+///      version: 3
 ///
 /// For a description of IAM and its features, see the
 /// [IAM documentation](<https://cloud.google.com/iam/docs/>).
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Policy {
     /// Specifies the format of the policy.
     ///
@@ -103,7 +105,7 @@ pub struct Policy {
     /// * Adding a conditional role binding to a policy
     /// * Changing a conditional role binding in a policy
     /// * Removing any role binding, with or without a condition, from a policy
-    ///   that includes conditions
+    ///    that includes conditions
     ///
     /// **Important:** If you use IAM Conditions, you must include the `etag` field
     /// whenever you call `setIamPolicy`. If you omit this field, then IAM allows
@@ -148,7 +150,8 @@ pub struct Policy {
     pub etag: ::prost::alloc::vec::Vec<u8>,
 }
 /// Associates `members`, or principals, with a `role`.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Binding {
     /// Role that is assigned to the list of `members`, or principals.
     /// For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
@@ -158,44 +161,44 @@ pub struct Binding {
     /// `members` can have the following values:
     ///
     /// * `allUsers`: A special identifier that represents anyone who is
-    ///    on the internet; with or without a Google account.
+    ///     on the internet; with or without a Google account.
     ///
     /// * `allAuthenticatedUsers`: A special identifier that represents anyone
-    ///    who is authenticated with a Google account or a service account.
+    ///     who is authenticated with a Google account or a service account.
     ///
     /// * `user:{emailid}`: An email address that represents a specific Google
-    ///    account. For example, `alice@example.com` .
+    ///     account. For example, `alice@example.com` .
     ///
     ///
     /// * `serviceAccount:{emailid}`: An email address that represents a service
-    ///    account. For example, `my-other-app@appspot.gserviceaccount.com`.
+    ///     account. For example, `my-other-app@appspot.gserviceaccount.com`.
     ///
     /// * `group:{emailid}`: An email address that represents a Google group.
-    ///    For example, `admins@example.com`.
+    ///     For example, `admins@example.com`.
     ///
     /// * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique
-    ///    identifier) representing a user that has been recently deleted. For
-    ///    example, `alice@example.com?uid=123456789012345678901`. If the user is
-    ///    recovered, this value reverts to `user:{emailid}` and the recovered user
-    ///    retains the role in the binding.
+    ///     identifier) representing a user that has been recently deleted. For
+    ///     example, `alice@example.com?uid=123456789012345678901`. If the user is
+    ///     recovered, this value reverts to `user:{emailid}` and the recovered user
+    ///     retains the role in the binding.
     ///
     /// * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus
-    ///    unique identifier) representing a service account that has been recently
-    ///    deleted. For example,
-    ///    `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.
-    ///    If the service account is undeleted, this value reverts to
-    ///    `serviceAccount:{emailid}` and the undeleted service account retains the
-    ///    role in the binding.
+    ///     unique identifier) representing a service account that has been recently
+    ///     deleted. For example,
+    ///     `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.
+    ///     If the service account is undeleted, this value reverts to
+    ///     `serviceAccount:{emailid}` and the undeleted service account retains the
+    ///     role in the binding.
     ///
     /// * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique
-    ///    identifier) representing a Google group that has been recently
-    ///    deleted. For example, `admins@example.com?uid=123456789012345678901`. If
-    ///    the group is recovered, this value reverts to `group:{emailid}` and the
-    ///    recovered group retains the role in the binding.
+    ///     identifier) representing a Google group that has been recently
+    ///     deleted. For example, `admins@example.com?uid=123456789012345678901`. If
+    ///     the group is recovered, this value reverts to `group:{emailid}` and the
+    ///     recovered group retains the role in the binding.
     ///
     ///
     /// * `domain:{domain}`: The G Suite domain (primary) that represents all the
-    ///    users of that domain. For example, `google.com` or `example.com`.
+    ///     users of that domain. For example, `google.com` or `example.com`.
     ///
     ///
     #[prost(string, repeated, tag = "2")]
@@ -227,46 +230,47 @@ pub struct Binding {
 ///
 /// Example Policy with multiple AuditConfigs:
 ///
-///     {
-///       "audit_configs": [
-///         {
-///           "service": "allServices",
-///           "audit_log_configs": [
-///             {
-///               "log_type": "DATA_READ",
-///               "exempted_members": [
-///                 "user:jose@example.com"
-///               ]
-///             },
-///             {
-///               "log_type": "DATA_WRITE"
-///             },
-///             {
-///               "log_type": "ADMIN_READ"
-///             }
-///           ]
-///         },
-///         {
-///           "service": "sampleservice.googleapis.com",
-///           "audit_log_configs": [
-///             {
-///               "log_type": "DATA_READ"
-///             },
-///             {
-///               "log_type": "DATA_WRITE",
-///               "exempted_members": [
-///                 "user:aliya@example.com"
-///               ]
-///             }
-///           ]
-///         }
-///       ]
-///     }
+///      {
+///        "audit_configs": [
+///          {
+///            "service": "allServices",
+///            "audit_log_configs": [
+///              {
+///                "log_type": "DATA_READ",
+///                "exempted_members": [
+///                  "user:jose@example.com"
+///                ]
+///              },
+///              {
+///                "log_type": "DATA_WRITE"
+///              },
+///              {
+///                "log_type": "ADMIN_READ"
+///              }
+///            ]
+///          },
+///          {
+///            "service": "sampleservice.googleapis.com",
+///            "audit_log_configs": [
+///              {
+///                "log_type": "DATA_READ"
+///              },
+///              {
+///                "log_type": "DATA_WRITE",
+///                "exempted_members": [
+///                  "user:aliya@example.com"
+///                ]
+///              }
+///            ]
+///          }
+///        ]
+///      }
 ///
 /// For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ
 /// logging. It also exempts jose@example.com from DATA_READ logging, and
 /// aliya@example.com from DATA_WRITE logging.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuditConfig {
     /// Specifies a service that will be enabled for audit logging.
     /// For example, `storage.googleapis.com`, `cloudsql.googleapis.com`.
@@ -280,23 +284,24 @@ pub struct AuditConfig {
 /// Provides the configuration for logging a type of permissions.
 /// Example:
 ///
-///     {
-///       "audit_log_configs": [
-///         {
-///           "log_type": "DATA_READ",
-///           "exempted_members": [
-///             "user:jose@example.com"
-///           ]
-///         },
-///         {
-///           "log_type": "DATA_WRITE"
-///         }
-///       ]
-///     }
+///      {
+///        "audit_log_configs": [
+///          {
+///            "log_type": "DATA_READ",
+///            "exempted_members": [
+///              "user:jose@example.com"
+///            ]
+///          },
+///          {
+///            "log_type": "DATA_WRITE"
+///          }
+///        ]
+///      }
 ///
 /// This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting
 /// jose@example.com from DATA_READ logging.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuditLogConfig {
     /// The log type that this config enables.
     #[prost(enumeration = "audit_log_config::LogType", tag = "1")]
@@ -311,7 +316,17 @@ pub struct AuditLogConfig {
 pub mod audit_log_config {
     /// The list of valid permission types for which logging can be configured.
     /// Admin writes are always logged, and are not configurable.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum LogType {
         /// Default case. Should never be this.
@@ -323,9 +338,24 @@ pub mod audit_log_config {
         /// Data reads. Example: CloudSQL Users list
         DataRead = 3,
     }
+    impl LogType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                LogType::Unspecified => "LOG_TYPE_UNSPECIFIED",
+                LogType::AdminRead => "ADMIN_READ",
+                LogType::DataWrite => "DATA_WRITE",
+                LogType::DataRead => "DATA_READ",
+            }
+        }
+    }
 }
 /// The difference delta between two policies.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PolicyDelta {
     /// The delta for Bindings between two policies.
     #[prost(message, repeated, tag = "1")]
@@ -336,7 +366,8 @@ pub struct PolicyDelta {
 }
 /// One delta entry for Binding. Each individual change (only one member in each
 /// entry) to a binding will be a separate entry.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BindingDelta {
     /// The action that was performed on a Binding.
     /// Required
@@ -359,7 +390,17 @@ pub struct BindingDelta {
 /// Nested message and enum types in `BindingDelta`.
 pub mod binding_delta {
     /// The type of action performed on a Binding in a policy.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Action {
         /// Unspecified.
@@ -369,10 +410,24 @@ pub mod binding_delta {
         /// Removal of a Binding.
         Remove = 2,
     }
+    impl Action {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Action::Unspecified => "ACTION_UNSPECIFIED",
+                Action::Add => "ADD",
+                Action::Remove => "REMOVE",
+            }
+        }
+    }
 }
 /// One delta entry for AuditConfig. Each individual change (only one
 /// exempted_member in each entry) to a AuditConfig will be a separate entry.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuditConfigDelta {
     /// The action that was performed on an audit configuration in a policy.
     /// Required
@@ -398,7 +453,17 @@ pub struct AuditConfigDelta {
 /// Nested message and enum types in `AuditConfigDelta`.
 pub mod audit_config_delta {
     /// The type of action performed on an audit configuration in a policy.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Action {
         /// Unspecified.
@@ -408,8 +473,22 @@ pub mod audit_config_delta {
         /// Removal of an audit configuration.
         Remove = 2,
     }
+    impl Action {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Action::Unspecified => "ACTION_UNSPECIFIED",
+                Action::Add => "ADD",
+                Action::Remove => "REMOVE",
+            }
+        }
+    }
 }
 /// Request message for `SetIamPolicy` method.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetIamPolicyRequest {
     /// REQUIRED: The resource for which the policy is being specified.
@@ -431,7 +510,8 @@ pub struct SetIamPolicyRequest {
     pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Request message for `GetIamPolicy` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetIamPolicyRequest {
     /// REQUIRED: The resource for which the policy is being requested.
     /// See the operation documentation for the appropriate value for this field.
@@ -443,7 +523,8 @@ pub struct GetIamPolicyRequest {
     pub options: ::core::option::Option<GetPolicyOptions>,
 }
 /// Request message for `TestIamPermissions` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TestIamPermissionsRequest {
     /// REQUIRED: The resource for which the policy detail is being requested.
     /// See the operation documentation for the appropriate value for this field.
@@ -457,7 +538,8 @@ pub struct TestIamPermissionsRequest {
     pub permissions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Response message for `TestIamPermissions` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TestIamPermissionsResponse {
     /// A subset of `TestPermissionsRequest.permissions` that the caller is
     /// allowed.
@@ -468,6 +550,7 @@ pub struct TestIamPermissionsResponse {
 pub mod iam_policy_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// API Overview
     ///
     ///
@@ -520,31 +603,42 @@ pub mod iam_policy_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> IamPolicyClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> IamPolicyClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             IamPolicyClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Sets the access control policy on the specified resource. Replaces any
@@ -555,11 +649,19 @@ pub mod iam_policy_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SetIamPolicyRequest>,
         ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/SetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.iam.v1.IAMPolicy/SetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the access control policy for a resource.
@@ -569,11 +671,19 @@ pub mod iam_policy_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetIamPolicyRequest>,
         ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/GetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.iam.v1.IAMPolicy/GetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns permissions that a caller has on the specified resource.
@@ -587,11 +697,19 @@ pub mod iam_policy_client {
             &mut self,
             request: impl tonic::IntoRequest<super::TestIamPermissionsRequest>,
         ) -> Result<tonic::Response<super::TestIamPermissionsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/TestIamPermissions");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.iam.v1.IAMPolicy/TestIamPermissions",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.iam.v1.rs
+++ b/googleapis/src/google.iam.v1.rs
@@ -316,17 +316,7 @@ pub struct AuditLogConfig {
 pub mod audit_log_config {
     /// The list of valid permission types for which logging can be configured.
     /// Admin writes are always logged, and are not configurable.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum LogType {
         /// Default case. Should never be this.
@@ -390,17 +380,7 @@ pub struct BindingDelta {
 /// Nested message and enum types in `BindingDelta`.
 pub mod binding_delta {
     /// The type of action performed on a Binding in a policy.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Action {
         /// Unspecified.
@@ -453,17 +433,7 @@ pub struct AuditConfigDelta {
 /// Nested message and enum types in `AuditConfigDelta`.
 pub mod audit_config_delta {
     /// The type of action performed on an audit configuration in a policy.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Action {
         /// Unspecified.
@@ -549,8 +519,8 @@ pub struct TestIamPermissionsResponse {
 /// Generated client implementations.
 pub mod iam_policy_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// API Overview
     ///
     ///
@@ -607,22 +577,15 @@ pub mod iam_policy_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> IamPolicyClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> IamPolicyClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             IamPolicyClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -649,19 +612,11 @@ pub mod iam_policy_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SetIamPolicyRequest>,
         ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.iam.v1.IAMPolicy/SetIamPolicy",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/SetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the access control policy for a resource.
@@ -671,19 +626,11 @@ pub mod iam_policy_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetIamPolicyRequest>,
         ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.iam.v1.IAMPolicy/GetIamPolicy",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/GetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns permissions that a caller has on the specified resource.
@@ -697,19 +644,11 @@ pub mod iam_policy_client {
             &mut self,
             request: impl tonic::IntoRequest<super::TestIamPermissionsRequest>,
         ) -> Result<tonic::Response<super::TestIamPermissionsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.iam.v1.IAMPolicy/TestIamPermissions",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/TestIamPermissions");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.longrunning.rs
+++ b/googleapis/src/google.longrunning.rs
@@ -1,5 +1,6 @@
 /// This resource represents a long-running operation that is the result of a
 /// network API call.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     /// The server-assigned name, which is only unique within the same service that
@@ -29,6 +30,7 @@ pub mod operation {
     /// The operation result, which can be either an `error` or a valid `response`.
     /// If `done` == `false`, neither `error` nor `response` is set.
     /// If `done` == `true`, exactly one of `error` or `response` is set.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Result {
         /// The error result of the operation in case of failure or cancellation.
@@ -47,14 +49,16 @@ pub mod operation {
     }
 }
 /// The request message for \[Operations.GetOperation][google.longrunning.Operations.GetOperation\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetOperationRequest {
     /// The name of the operation resource.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 /// The request message for \[Operations.ListOperations][google.longrunning.Operations.ListOperations\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListOperationsRequest {
     /// The name of the operation's parent resource.
     #[prost(string, tag = "4")]
@@ -70,6 +74,7 @@ pub struct ListOperationsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// The response message for \[Operations.ListOperations][google.longrunning.Operations.ListOperations\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListOperationsResponse {
     /// A list of operations that matches the specified filter in the request.
@@ -80,20 +85,23 @@ pub struct ListOperationsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// The request message for \[Operations.CancelOperation][google.longrunning.Operations.CancelOperation\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelOperationRequest {
     /// The name of the operation resource to be cancelled.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 /// The request message for \[Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteOperationRequest {
     /// The name of the operation resource to be deleted.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 /// The request message for \[Operations.WaitOperation][google.longrunning.Operations.WaitOperation\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WaitOperationRequest {
     /// The name of the operation resource to wait on.
@@ -109,14 +117,15 @@ pub struct WaitOperationRequest {
 ///
 /// Example:
 ///
-///   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-///       returns (google.longrunning.Operation) {
-///     option (google.longrunning.operation_info) = {
-///       response_type: "LongRunningRecognizeResponse"
-///       metadata_type: "LongRunningRecognizeMetadata"
-///     };
-///   }
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+///    rpc LongRunningRecognize(LongRunningRecognizeRequest)
+///        returns (google.longrunning.Operation) {
+///      option (google.longrunning.operation_info) = {
+///        response_type: "LongRunningRecognizeResponse"
+///        metadata_type: "LongRunningRecognizeMetadata"
+///      };
+///    }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OperationInfo {
     /// Required. The message name of the primary return type for this
     /// long-running operation.
@@ -142,6 +151,7 @@ pub struct OperationInfo {
 pub mod operations_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Manages long-running operations with an API service.
     ///
     /// When an API method normally takes long time to complete, it can be designed
@@ -177,31 +187,42 @@ pub mod operations_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> OperationsClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> OperationsClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             OperationsClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Lists operations that match the specified filter in the request. If the
@@ -218,11 +239,19 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListOperationsRequest>,
         ) -> Result<tonic::Response<super::ListOperationsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/ListOperations");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/ListOperations",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the latest state of a long-running operation.  Clients can use this
@@ -232,11 +261,19 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetOperationRequest>,
         ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/GetOperation");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/GetOperation",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a long-running operation. This method indicates that the client is
@@ -247,11 +284,19 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteOperationRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/DeleteOperation");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/DeleteOperation",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Starts asynchronous cancellation on a long-running operation.  The server
@@ -268,11 +313,19 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CancelOperationRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/CancelOperation");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/CancelOperation",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Waits until the specified long-running operation is done or reaches at most
@@ -288,11 +341,19 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::WaitOperationRequest>,
         ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/WaitOperation");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.longrunning.Operations/WaitOperation",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.longrunning.rs
+++ b/googleapis/src/google.longrunning.rs
@@ -150,8 +150,8 @@ pub struct OperationInfo {
 /// Generated client implementations.
 pub mod operations_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// Manages long-running operations with an API service.
     ///
     /// When an API method normally takes long time to complete, it can be designed
@@ -191,22 +191,15 @@ pub mod operations_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> OperationsClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> OperationsClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             OperationsClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -239,19 +232,11 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListOperationsRequest>,
         ) -> Result<tonic::Response<super::ListOperationsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.longrunning.Operations/ListOperations",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/ListOperations");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the latest state of a long-running operation.  Clients can use this
@@ -261,19 +246,11 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetOperationRequest>,
         ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.longrunning.Operations/GetOperation",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/GetOperation");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a long-running operation. This method indicates that the client is
@@ -284,19 +261,11 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteOperationRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.longrunning.Operations/DeleteOperation",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/DeleteOperation");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Starts asynchronous cancellation on a long-running operation.  The server
@@ -313,19 +282,11 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CancelOperationRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.longrunning.Operations/CancelOperation",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/CancelOperation");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Waits until the specified long-running operation is done or reaches at most
@@ -341,19 +302,11 @@ pub mod operations_client {
             &mut self,
             request: impl tonic::IntoRequest<super::WaitOperationRequest>,
         ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.longrunning.Operations/WaitOperation",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/WaitOperation");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.pubsub.v1.rs
+++ b/googleapis/src/google.pubsub.v1.rs
@@ -1,5 +1,6 @@
 /// A schema resource.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Schema {
     /// Required. Name of the schema.
     /// Format is `projects/{project}/schemas/{schema}`.
@@ -17,7 +18,17 @@ pub struct Schema {
 /// Nested message and enum types in `Schema`.
 pub mod schema {
     /// Possible schema definition types.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Type {
         /// Default value. This value is unused.
@@ -27,9 +38,23 @@ pub mod schema {
         /// An Avro schema definition.
         Avro = 2,
     }
+    impl Type {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Type::Unspecified => "TYPE_UNSPECIFIED",
+                Type::ProtocolBuffer => "PROTOCOL_BUFFER",
+                Type::Avro => "AVRO",
+            }
+        }
+    }
 }
 /// Request for the CreateSchema method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateSchemaRequest {
     /// Required. The name of the project in which to create the schema.
     /// Format is `projects/{project-id}`.
@@ -51,7 +76,8 @@ pub struct CreateSchemaRequest {
     pub schema_id: ::prost::alloc::string::String,
 }
 /// Request for the GetSchema method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSchemaRequest {
     /// Required. The name of the schema to get.
     /// Format is `projects/{project}/schemas/{schema}`.
@@ -64,7 +90,8 @@ pub struct GetSchemaRequest {
     pub view: i32,
 }
 /// Request for the `ListSchemas` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSchemasRequest {
     /// Required. The name of the project in which to list schemas.
     /// Format is `projects/{project-id}`.
@@ -85,7 +112,8 @@ pub struct ListSchemasRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// Response for the `ListSchemas` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSchemasResponse {
     /// The resulting schemas.
     #[prost(message, repeated, tag = "1")]
@@ -96,7 +124,8 @@ pub struct ListSchemasResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request for the `DeleteSchema` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteSchemaRequest {
     /// Required. Name of the schema to delete.
     /// Format is `projects/{project}/schemas/{schema}`.
@@ -104,7 +133,8 @@ pub struct DeleteSchemaRequest {
     pub name: ::prost::alloc::string::String,
 }
 /// Request for the `ValidateSchema` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidateSchemaRequest {
     /// Required. The name of the project in which to validate schemas.
     /// Format is `projects/{project-id}`.
@@ -116,10 +146,12 @@ pub struct ValidateSchemaRequest {
 }
 /// Response for the `ValidateSchema` method.
 /// Empty for now.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidateSchemaResponse {}
 /// Request for the `ValidateMessage` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidateMessageRequest {
     /// Required. The name of the project in which to validate schemas.
     /// Format is `projects/{project-id}`.
@@ -136,7 +168,8 @@ pub struct ValidateMessageRequest {
 }
 /// Nested message and enum types in `ValidateMessageRequest`.
 pub mod validate_message_request {
-    #[derive(Clone, PartialEq, Eq, ::prost::Oneof)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum SchemaSpec {
         /// Name of the schema against which to validate.
         ///
@@ -150,7 +183,8 @@ pub mod validate_message_request {
 }
 /// Response for the `ValidateMessage` method.
 /// Empty for now.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidateMessageResponse {}
 /// View of Schema object fields to be returned by GetSchema and ListSchemas.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -164,6 +198,19 @@ pub enum SchemaView {
     /// Include all Schema object fields.
     Full = 2,
 }
+impl SchemaView {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            SchemaView::Unspecified => "SCHEMA_VIEW_UNSPECIFIED",
+            SchemaView::Basic => "BASIC",
+            SchemaView::Full => "FULL",
+        }
+    }
+}
 /// Possible encoding types for messages.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -176,10 +223,24 @@ pub enum Encoding {
     /// binary encoding may not be available.
     Binary = 2,
 }
+impl Encoding {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Encoding::Unspecified => "ENCODING_UNSPECIFIED",
+            Encoding::Json => "JSON",
+            Encoding::Binary => "BINARY",
+        }
+    }
+}
 /// Generated client implementations.
 pub mod schema_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Service for doing schema-related operations.
     #[derive(Debug, Clone)]
     pub struct SchemaServiceClient<T> {
@@ -207,31 +268,42 @@ pub mod schema_service_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> SchemaServiceClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SchemaServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             SchemaServiceClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Creates a schema.
@@ -239,11 +311,19 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSchemaRequest>,
         ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/CreateSchema");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.SchemaService/CreateSchema",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets a schema.
@@ -251,11 +331,19 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSchemaRequest>,
         ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/GetSchema");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.SchemaService/GetSchema",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists schemas in a project.
@@ -263,11 +351,19 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSchemasRequest>,
         ) -> Result<tonic::Response<super::ListSchemasResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ListSchemas");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.SchemaService/ListSchemas",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a schema.
@@ -275,11 +371,19 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSchemaRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/DeleteSchema");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.SchemaService/DeleteSchema",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Validates a schema.
@@ -287,11 +391,19 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateSchemaRequest>,
         ) -> Result<tonic::Response<super::ValidateSchemaResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateSchema");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.SchemaService/ValidateSchema",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Validates a message against a schema.
@@ -299,17 +411,26 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateMessageRequest>,
         ) -> Result<tonic::Response<super::ValidateMessageResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateMessage");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.SchemaService/ValidateMessage",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }
 /// A policy constraining the storage of messages published to the topic.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MessageStoragePolicy {
     /// A list of IDs of GCP regions where messages that are published to the topic
     /// may be persisted in storage. Messages published by publishers running in
@@ -317,10 +438,13 @@ pub struct MessageStoragePolicy {
     /// routed for storage in one of the allowed regions. An empty list means that
     /// no regions are allowed, and is not a valid configuration.
     #[prost(string, repeated, tag = "1")]
-    pub allowed_persistence_regions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub allowed_persistence_regions: ::prost::alloc::vec::Vec<
+        ::prost::alloc::string::String,
+    >,
 }
 /// Settings for validating messages published against a schema.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SchemaSettings {
     /// Required. The name of the schema that messages published should be
     /// validated against. Format is `projects/{project}/schemas/{schema}`. The
@@ -333,6 +457,7 @@ pub struct SchemaSettings {
     pub encoding: i32,
 }
 /// A topic resource.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Topic {
     /// Required. The name of the topic. It must have the format
@@ -346,7 +471,10 @@ pub struct Topic {
     /// See [Creating and managing labels]
     /// (<https://cloud.google.com/pubsub/docs/labels>).
     #[prost(map = "string, string", tag = "2")]
-    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// Policy constraining the set of Google Cloud Platform regions where messages
     /// published to the topic may be stored. If not present, then no constraints
     /// are in effect.
@@ -384,7 +512,8 @@ pub struct Topic {
 /// more information. See [quotas and limits]
 /// (<https://cloud.google.com/pubsub/quotas>) for more information about message
 /// limits.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PubsubMessage {
     /// The message data field. If this field is empty, the message must contain
     /// at least one attribute.
@@ -394,7 +523,10 @@ pub struct PubsubMessage {
     /// contain non-empty data. This can be used to filter messages on the
     /// subscription.
     #[prost(map = "string, string", tag = "2")]
-    pub attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub attributes: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// ID of this message, assigned by the server when the message is published.
     /// Guaranteed to be unique within the topic. This value may be read by a
     /// subscriber that receives a `PubsubMessage` via a `Pull` call or a push
@@ -416,7 +548,8 @@ pub struct PubsubMessage {
     pub ordering_key: ::prost::alloc::string::String,
 }
 /// Request for the GetTopic method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTopicRequest {
     /// Required. The name of the topic to get.
     /// Format is `projects/{project}/topics/{topic}`.
@@ -424,6 +557,7 @@ pub struct GetTopicRequest {
     pub topic: ::prost::alloc::string::String,
 }
 /// Request for the UpdateTopic method.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateTopicRequest {
     /// Required. The updated topic object.
@@ -438,7 +572,8 @@ pub struct UpdateTopicRequest {
     pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Request for the Publish method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishRequest {
     /// Required. The messages in the request will be published on this topic.
     /// Format is `projects/{project}/topics/{topic}`.
@@ -449,7 +584,8 @@ pub struct PublishRequest {
     pub messages: ::prost::alloc::vec::Vec<PubsubMessage>,
 }
 /// Response for the `Publish` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PublishResponse {
     /// The server-assigned ID of each published message, in the same order as
     /// the messages in the request. IDs are guaranteed to be unique within
@@ -458,7 +594,8 @@ pub struct PublishResponse {
     pub message_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Request for the `ListTopics` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListTopicsRequest {
     /// Required. The name of the project in which to list topics.
     /// Format is `projects/{project-id}`.
@@ -474,6 +611,7 @@ pub struct ListTopicsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// Response for the `ListTopics` method.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListTopicsResponse {
     /// The resulting topics.
@@ -485,7 +623,8 @@ pub struct ListTopicsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request for the `ListTopicSubscriptions` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListTopicSubscriptionsRequest {
     /// Required. The name of the topic that subscriptions are attached to.
     /// Format is `projects/{project}/topics/{topic}`.
@@ -501,7 +640,8 @@ pub struct ListTopicSubscriptionsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// Response for the `ListTopicSubscriptions` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListTopicSubscriptionsResponse {
     /// The names of subscriptions attached to the topic specified in the request.
     #[prost(string, repeated, tag = "1")]
@@ -513,7 +653,8 @@ pub struct ListTopicSubscriptionsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request for the `ListTopicSnapshots` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListTopicSnapshotsRequest {
     /// Required. The name of the topic that snapshots are attached to.
     /// Format is `projects/{project}/topics/{topic}`.
@@ -529,7 +670,8 @@ pub struct ListTopicSnapshotsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// Response for the `ListTopicSnapshots` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListTopicSnapshotsResponse {
     /// The names of the snapshots that match the request.
     #[prost(string, repeated, tag = "1")]
@@ -541,7 +683,8 @@ pub struct ListTopicSnapshotsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request for the `DeleteTopic` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteTopicRequest {
     /// Required. Name of the topic to delete.
     /// Format is `projects/{project}/topics/{topic}`.
@@ -549,7 +692,8 @@ pub struct DeleteTopicRequest {
     pub topic: ::prost::alloc::string::String,
 }
 /// Request for the DetachSubscription method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DetachSubscriptionRequest {
     /// Required. The subscription to detach.
     /// Format is `projects/{project}/subscriptions/{subscription}`.
@@ -558,9 +702,11 @@ pub struct DetachSubscriptionRequest {
 }
 /// Response for the DetachSubscription method.
 /// Reserved for future use.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DetachSubscriptionResponse {}
 /// A subscription resource.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Subscription {
     /// Required. The name of the subscription. It must have the format
@@ -629,7 +775,10 @@ pub struct Subscription {
     /// See <a href="<https://cloud.google.com/pubsub/docs/labels">> Creating and
     /// managing labels</a>.
     #[prost(map = "string, string", tag = "9")]
-    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// If true, messages published with the same `ordering_key` in `PubsubMessage`
     /// will be delivered to the subscribers in the order in which they
     /// are received by the Pub/Sub system. Otherwise, they may be delivered in
@@ -697,7 +846,9 @@ pub struct Subscription {
     /// the `message_retention_duration` field in `Topic`. This field is set only
     /// in responses from the server; it is ignored if it is set in any requests.
     #[prost(message, optional, tag = "17")]
-    pub topic_message_retention_duration: ::core::option::Option<::prost_types::Duration>,
+    pub topic_message_retention_duration: ::core::option::Option<
+        ::prost_types::Duration,
+    >,
     /// Output only. An output-only field indicating whether or not the subscription can receive
     /// messages.
     #[prost(enumeration = "subscription::State", tag = "19")]
@@ -706,7 +857,17 @@ pub struct Subscription {
 /// Nested message and enum types in `Subscription`.
 pub mod subscription {
     /// Possible states for a subscription.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum State {
         /// Default value. This value is unused.
@@ -717,6 +878,19 @@ pub mod subscription {
         /// resource to which it pushes messages. See the more detailed error state
         /// in the corresponding configuration.
         ResourceError = 2,
+    }
+    impl State {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                State::Unspecified => "STATE_UNSPECIFIED",
+                State::Active => "ACTIVE",
+                State::ResourceError => "RESOURCE_ERROR",
+            }
+        }
     }
 }
 /// A policy that specifies how Cloud Pub/Sub retries message delivery.
@@ -730,6 +904,7 @@ pub mod subscription {
 /// Retry Policy is implemented on a best effort basis. At times, the delay
 /// between consecutive deliveries may not match the configuration. That is,
 /// delay can be more or less than configured backoff.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RetryPolicy {
     /// The minimum delay between consecutive deliveries of a given message.
@@ -746,7 +921,8 @@ pub struct RetryPolicy {
 ///
 /// If validation on any of the fields fails at subscription creation/updation,
 /// the create/update subscription request will fail.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeadLetterPolicy {
     /// The name of the topic to which dead letter messages should be published.
     /// Format is `projects/{project}/topics/{topic}`.The Cloud Pub/Sub service
@@ -777,6 +953,7 @@ pub struct DeadLetterPolicy {
 }
 /// A policy that specifies the conditions for resource expiration (i.e.,
 /// automatic resource deletion).
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExpirationPolicy {
     /// Specifies the "time-to-live" duration for an associated resource. The
@@ -789,7 +966,8 @@ pub struct ExpirationPolicy {
     pub ttl: ::core::option::Option<::prost_types::Duration>,
 }
 /// Configuration for a push delivery endpoint.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PushConfig {
     /// A URL locating the endpoint to which messages should be pushed.
     /// For example, a Webhook endpoint might use `<https://example.com/push`.>
@@ -817,7 +995,10 @@ pub struct PushConfig {
     /// For example:
     /// <pre><code>attributes { "x-goog-version": "v1" } </code></pre>
     #[prost(map = "string, string", tag = "2")]
-    pub attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub attributes: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// An authentication method used by push endpoints to verify the source of
     /// push requests. This can be used with push endpoints that are private by
     /// default to allow requests only from the Cloud Pub/Sub system, for example.
@@ -831,7 +1012,8 @@ pub mod push_config {
     /// Contains information needed for generating an
     /// [OpenID Connect
     /// token](<https://developers.google.com/identity/protocols/OpenIDConnect>).
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct OidcToken {
         /// [Service account
         /// email](<https://cloud.google.com/iam/docs/service-accounts>)
@@ -854,7 +1036,8 @@ pub mod push_config {
     /// default to allow requests only from the Cloud Pub/Sub system, for example.
     /// This field is optional and should be set only by users interested in
     /// authenticated push.
-    #[derive(Clone, PartialEq, Eq, ::prost::Oneof)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum AuthenticationMethod {
         /// If specified, Pub/Sub will generate and attach an OIDC JWT token as an
         /// `Authorization` header in the HTTP request for every pushed message.
@@ -863,7 +1046,8 @@ pub mod push_config {
     }
 }
 /// Configuration for a BigQuery subscription.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BigQueryConfig {
     /// The name of the table to which to write data, of the form
     /// {projectId}:{datasetId}.{tableId}
@@ -895,7 +1079,17 @@ pub struct BigQueryConfig {
 /// Nested message and enum types in `BigQueryConfig`.
 pub mod big_query_config {
     /// Possible states for a BigQuery subscription.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum State {
         /// Default value. This value is unused.
@@ -909,9 +1103,25 @@ pub mod big_query_config {
         /// Cannot write to the BigQuery table due to a schema mismatch.
         SchemaMismatch = 4,
     }
+    impl State {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                State::Unspecified => "STATE_UNSPECIFIED",
+                State::Active => "ACTIVE",
+                State::PermissionDenied => "PERMISSION_DENIED",
+                State::NotFound => "NOT_FOUND",
+                State::SchemaMismatch => "SCHEMA_MISMATCH",
+            }
+        }
+    }
 }
 /// A message and its corresponding acknowledgment ID.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReceivedMessage {
     /// This ID can be used to acknowledge the received message.
     #[prost(string, tag = "1")]
@@ -939,7 +1149,8 @@ pub struct ReceivedMessage {
     pub delivery_attempt: i32,
 }
 /// Request for the GetSubscription method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSubscriptionRequest {
     /// Required. The name of the subscription to get.
     /// Format is `projects/{project}/subscriptions/{sub}`.
@@ -947,6 +1158,7 @@ pub struct GetSubscriptionRequest {
     pub subscription: ::prost::alloc::string::String,
 }
 /// Request for the UpdateSubscription method.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateSubscriptionRequest {
     /// Required. The updated subscription object.
@@ -958,7 +1170,8 @@ pub struct UpdateSubscriptionRequest {
     pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Request for the `ListSubscriptions` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSubscriptionsRequest {
     /// Required. The name of the project in which to list subscriptions.
     /// Format is `projects/{project-id}`.
@@ -974,6 +1187,7 @@ pub struct ListSubscriptionsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// Response for the `ListSubscriptions` method.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSubscriptionsResponse {
     /// The subscriptions that match the request.
@@ -986,7 +1200,8 @@ pub struct ListSubscriptionsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request for the DeleteSubscription method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteSubscriptionRequest {
     /// Required. The subscription to delete.
     /// Format is `projects/{project}/subscriptions/{sub}`.
@@ -994,7 +1209,8 @@ pub struct DeleteSubscriptionRequest {
     pub subscription: ::prost::alloc::string::String,
 }
 /// Request for the ModifyPushConfig method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModifyPushConfigRequest {
     /// Required. The name of the subscription.
     /// Format is `projects/{project}/subscriptions/{sub}`.
@@ -1010,7 +1226,8 @@ pub struct ModifyPushConfigRequest {
     pub push_config: ::core::option::Option<PushConfig>,
 }
 /// Request for the `Pull` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PullRequest {
     /// Required. The subscription from which messages should be pulled.
     /// Format is `projects/{project}/subscriptions/{sub}`.
@@ -1033,7 +1250,8 @@ pub struct PullRequest {
     pub max_messages: i32,
 }
 /// Response for the `Pull` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PullResponse {
     /// Received Pub/Sub messages. The list will be empty if there are no more
     /// messages available in the backlog. For JSON, the response can be entirely
@@ -1043,7 +1261,8 @@ pub struct PullResponse {
     pub received_messages: ::prost::alloc::vec::Vec<ReceivedMessage>,
 }
 /// Request for the ModifyAckDeadline method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModifyAckDeadlineRequest {
     /// Required. The name of the subscription.
     /// Format is `projects/{project}/subscriptions/{sub}`.
@@ -1064,7 +1283,8 @@ pub struct ModifyAckDeadlineRequest {
     pub ack_deadline_seconds: i32,
 }
 /// Request for the Acknowledge method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AcknowledgeRequest {
     /// Required. The subscription whose message is being acknowledged.
     /// Format is `projects/{project}/subscriptions/{sub}`.
@@ -1079,7 +1299,8 @@ pub struct AcknowledgeRequest {
 /// Request for the `StreamingPull` streaming RPC method. This request is used to
 /// establish the initial stream as well as to stream acknowledgements and ack
 /// deadline modifications from the client to the server.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamingPullRequest {
     /// Required. The subscription for which to initialize the new stream. This
     /// must be provided in the first request on the stream, and must not be set in
@@ -1113,7 +1334,9 @@ pub struct StreamingPullRequest {
     /// subscriber, or to make the message available for redelivery if the
     /// processing was interrupted.
     #[prost(string, repeated, tag = "4")]
-    pub modify_deadline_ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    pub modify_deadline_ack_ids: ::prost::alloc::vec::Vec<
+        ::prost::alloc::string::String,
+    >,
     /// Required. The ack deadline to use for the stream. This must be provided in
     /// the first request on the stream, but it can also be updated on subsequent
     /// requests from client to server. The minimum deadline you can specify is 10
@@ -1153,7 +1376,8 @@ pub struct StreamingPullRequest {
 }
 /// Response for the `StreamingPull` method. This response is used to stream
 /// messages from the server to the client.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamingPullResponse {
     /// Received Pub/Sub messages. This will not be empty.
     #[prost(message, repeated, tag = "1")]
@@ -1161,21 +1385,27 @@ pub struct StreamingPullResponse {
     /// This field will only be set if `enable_exactly_once_delivery` is set to
     /// `true`.
     #[prost(message, optional, tag = "5")]
-    pub acknowledge_confirmation: ::core::option::Option<streaming_pull_response::AcknowledgeConfirmation>,
+    pub acknowledge_confirmation: ::core::option::Option<
+        streaming_pull_response::AcknowledgeConfirmation,
+    >,
     /// This field will only be set if `enable_exactly_once_delivery` is set to
     /// `true`.
     #[prost(message, optional, tag = "3")]
-    pub modify_ack_deadline_confirmation:
-        ::core::option::Option<streaming_pull_response::ModifyAckDeadlineConfirmation>,
+    pub modify_ack_deadline_confirmation: ::core::option::Option<
+        streaming_pull_response::ModifyAckDeadlineConfirmation,
+    >,
     /// Properties associated with this subscription.
     #[prost(message, optional, tag = "4")]
-    pub subscription_properties: ::core::option::Option<streaming_pull_response::SubscriptionProperties>,
+    pub subscription_properties: ::core::option::Option<
+        streaming_pull_response::SubscriptionProperties,
+    >,
 }
 /// Nested message and enum types in `StreamingPullResponse`.
 pub mod streaming_pull_response {
     /// Acknowledgement IDs sent in one or more previous requests to acknowledge a
     /// previously received message.
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AcknowledgeConfirmation {
         /// Successfully processed acknowledgement IDs.
         #[prost(string, repeated, tag = "1")]
@@ -1190,7 +1420,8 @@ pub mod streaming_pull_response {
     }
     /// Acknowledgement IDs sent in one or more previous requests to modify the
     /// deadline for a specific message.
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ModifyAckDeadlineConfirmation {
         /// Successfully processed acknowledgement IDs.
         #[prost(string, repeated, tag = "1")]
@@ -1201,7 +1432,8 @@ pub mod streaming_pull_response {
         pub invalid_ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     }
     /// Subscription properties sent as part of the response.
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SubscriptionProperties {
         /// True iff exactly once delivery is enabled for this subscription.
         #[prost(bool, tag = "1")]
@@ -1212,7 +1444,8 @@ pub mod streaming_pull_response {
     }
 }
 /// Request for the `CreateSnapshot` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateSnapshotRequest {
     /// Required. User-provided name for this snapshot. If the name is not provided
     /// in the request, the server will assign a random name for this snapshot on
@@ -1224,21 +1457,25 @@ pub struct CreateSnapshotRequest {
     pub name: ::prost::alloc::string::String,
     /// Required. The subscription whose backlog the snapshot retains.
     /// Specifically, the created snapshot is guaranteed to retain:
-    ///  (a) The existing backlog on the subscription. More precisely, this is
-    ///      defined as the messages in the subscription's backlog that are
-    ///      unacknowledged upon the successful completion of the
-    ///      `CreateSnapshot` request; as well as:
-    ///  (b) Any messages published to the subscription's topic following the
-    ///      successful completion of the CreateSnapshot request.
+    ///   (a) The existing backlog on the subscription. More precisely, this is
+    ///       defined as the messages in the subscription's backlog that are
+    ///       unacknowledged upon the successful completion of the
+    ///       `CreateSnapshot` request; as well as:
+    ///   (b) Any messages published to the subscription's topic following the
+    ///       successful completion of the CreateSnapshot request.
     /// Format is `projects/{project}/subscriptions/{sub}`.
     #[prost(string, tag = "2")]
     pub subscription: ::prost::alloc::string::String,
     /// See <a href="<https://cloud.google.com/pubsub/docs/labels">> Creating and
     /// managing labels</a>.
     #[prost(map = "string, string", tag = "3")]
-    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 /// Request for the UpdateSnapshot method.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateSnapshotRequest {
     /// Required. The updated snapshot object.
@@ -1254,7 +1491,8 @@ pub struct UpdateSnapshotRequest {
 /// operations, which allow you to manage message acknowledgments in bulk. That
 /// is, you can set the acknowledgment state of messages in an existing
 /// subscription to the state captured by a snapshot.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Snapshot {
     /// The name of the snapshot.
     #[prost(string, tag = "1")]
@@ -1277,10 +1515,14 @@ pub struct Snapshot {
     /// See [Creating and managing labels]
     /// (<https://cloud.google.com/pubsub/docs/labels>).
     #[prost(map = "string, string", tag = "4")]
-    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 /// Request for the GetSnapshot method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSnapshotRequest {
     /// Required. The name of the snapshot to get.
     /// Format is `projects/{project}/snapshots/{snap}`.
@@ -1288,7 +1530,8 @@ pub struct GetSnapshotRequest {
     pub snapshot: ::prost::alloc::string::String,
 }
 /// Request for the `ListSnapshots` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSnapshotsRequest {
     /// Required. The name of the project in which to list snapshots.
     /// Format is `projects/{project-id}`.
@@ -1304,7 +1547,8 @@ pub struct ListSnapshotsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// Response for the `ListSnapshots` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSnapshotsResponse {
     /// The resulting snapshots.
     #[prost(message, repeated, tag = "1")]
@@ -1315,7 +1559,8 @@ pub struct ListSnapshotsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request for the `DeleteSnapshot` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteSnapshotRequest {
     /// Required. The name of the snapshot to delete.
     /// Format is `projects/{project}/snapshots/{snap}`.
@@ -1323,7 +1568,8 @@ pub struct DeleteSnapshotRequest {
     pub snapshot: ::prost::alloc::string::String,
 }
 /// Request for the `Seek` method.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SeekRequest {
     /// Required. The subscription to affect.
     #[prost(string, tag = "1")]
@@ -1333,7 +1579,8 @@ pub struct SeekRequest {
 }
 /// Nested message and enum types in `SeekRequest`.
 pub mod seek_request {
-    #[derive(Clone, PartialEq, Eq, ::prost::Oneof)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Target {
         /// The time to seek to.
         /// Messages retained in the subscription that were published before this
@@ -1356,12 +1603,14 @@ pub mod seek_request {
     }
 }
 /// Response for the `Seek` method (this response is empty).
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SeekResponse {}
 /// Generated client implementations.
 pub mod publisher_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// The service that an application uses to manipulate topics, and to send
     /// messages to a topic.
     #[derive(Debug, Clone)]
@@ -1390,31 +1639,42 @@ pub mod publisher_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> PublisherClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> PublisherClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             PublisherClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Creates the given topic with the given name. See the [resource name rules]
@@ -1423,11 +1683,19 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Topic>,
         ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/CreateTopic");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/CreateTopic",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an existing topic. Note that certain properties of a
@@ -1436,11 +1704,19 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateTopicRequest>,
         ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/UpdateTopic");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/UpdateTopic",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
@@ -1449,11 +1725,19 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PublishRequest>,
         ) -> Result<tonic::Response<super::PublishResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/Publish");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/Publish",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the configuration of a topic.
@@ -1461,11 +1745,19 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetTopicRequest>,
         ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/GetTopic");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/GetTopic",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists matching topics.
@@ -1473,23 +1765,42 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicsRequest>,
         ) -> Result<tonic::Response<super::ListTopicsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopics");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/ListTopics",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists the names of the attached subscriptions on this topic.
         pub async fn list_topic_subscriptions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSubscriptionsRequest>,
-        ) -> Result<tonic::Response<super::ListTopicSubscriptionsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::ListTopicSubscriptionsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSubscriptions");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/ListTopicSubscriptions",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists the names of the snapshots on this topic. Snapshots are used in
@@ -1501,11 +1812,19 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSnapshotsRequest>,
         ) -> Result<tonic::Response<super::ListTopicSnapshotsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSnapshots");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/ListTopicSnapshots",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
@@ -1517,11 +1836,19 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteTopicRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DeleteTopic");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/DeleteTopic",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Detaches a subscription from this topic. All messages retained in the
@@ -1532,11 +1859,19 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DetachSubscriptionRequest>,
         ) -> Result<tonic::Response<super::DetachSubscriptionResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DetachSubscription");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Publisher/DetachSubscription",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -1545,6 +1880,7 @@ pub mod publisher_client {
 pub mod subscriber_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// The service that an application uses to manipulate subscriptions and to
     /// consume messages from a subscription via the `Pull` method or by
     /// establishing a bi-directional stream using the `StreamingPull` method.
@@ -1574,31 +1910,42 @@ pub mod subscriber_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> SubscriberClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SubscriberClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             SubscriberClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Creates a subscription to a given topic. See the [resource name rules]
@@ -1616,11 +1963,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Subscription>,
         ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSubscription");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/CreateSubscription",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the configuration details of a subscription.
@@ -1628,11 +1983,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSubscriptionRequest>,
         ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSubscription");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/GetSubscription",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an existing subscription. Note that certain properties of a
@@ -1641,11 +2004,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSubscriptionRequest>,
         ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSubscription");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/UpdateSubscription",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists matching subscriptions.
@@ -1653,11 +2024,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSubscriptionsRequest>,
         ) -> Result<tonic::Response<super::ListSubscriptionsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSubscriptions");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/ListSubscriptions",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes an existing subscription. All messages retained in the subscription
@@ -1669,11 +2048,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSubscriptionRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSubscription");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/DeleteSubscription",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Modifies the ack deadline for a specific message. This method is useful
@@ -1685,11 +2072,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyAckDeadlineRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyAckDeadline");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/ModifyAckDeadline",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Acknowledges the messages associated with the `ack_ids` in the
@@ -1703,11 +2098,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::AcknowledgeRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Acknowledge");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/Acknowledge",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Pulls messages from the server. The server may return `UNAVAILABLE` if
@@ -1717,11 +2120,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PullRequest>,
         ) -> Result<tonic::Response<super::PullResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Pull");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/Pull",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Establishes a stream with the server, which sends messages down to the
@@ -1733,16 +2144,27 @@ pub mod subscriber_client {
         /// underlying RPC channel.
         pub async fn streaming_pull(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = super::StreamingPullRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/StreamingPull");
+            request: impl tonic::IntoStreamingRequest<
+                Message = super::StreamingPullRequest,
+            >,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>,
+            tonic::Status,
+        > {
             self.inner
-                .streaming(request.into_streaming_request(), path, codec)
+                .ready()
                 .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/StreamingPull",
+            );
+            self.inner.streaming(request.into_streaming_request(), path, codec).await
         }
         /// Modifies the `PushConfig` for a specified subscription.
         ///
@@ -1754,11 +2176,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyPushConfigRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyPushConfig");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/ModifyPushConfig",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the configuration details of a snapshot. Snapshots are used in
@@ -1770,11 +2200,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSnapshotRequest>,
         ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSnapshot");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/GetSnapshot",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists the existing snapshots. Snapshots are used in [Seek](
@@ -1786,11 +2224,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
         ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSnapshots");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/ListSnapshots",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a snapshot from the requested subscription. Snapshots are used in
@@ -1813,11 +2259,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
         ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSnapshot");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/CreateSnapshot",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an existing snapshot. Snapshots are used in
@@ -1830,11 +2284,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSnapshotRequest>,
         ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSnapshot");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/UpdateSnapshot",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Removes an existing snapshot. Snapshots are used in [Seek]
@@ -1850,11 +2312,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSnapshot");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/DeleteSnapshot",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Seeks an existing subscription to a point in time or to a given snapshot,
@@ -1868,11 +2338,19 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SeekRequest>,
         ) -> Result<tonic::Response<super::SeekResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Seek");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.pubsub.v1.Subscriber/Seek",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.pubsub.v1.rs
+++ b/googleapis/src/google.pubsub.v1.rs
@@ -18,17 +18,7 @@ pub struct Schema {
 /// Nested message and enum types in `Schema`.
 pub mod schema {
     /// Possible schema definition types.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Type {
         /// Default value. This value is unused.
@@ -239,8 +229,8 @@ impl Encoding {
 /// Generated client implementations.
 pub mod schema_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// Service for doing schema-related operations.
     #[derive(Debug, Clone)]
     pub struct SchemaServiceClient<T> {
@@ -272,22 +262,15 @@ pub mod schema_service_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> SchemaServiceClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> SchemaServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             SchemaServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -311,19 +294,11 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSchemaRequest>,
         ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.SchemaService/CreateSchema",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/CreateSchema");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets a schema.
@@ -331,19 +306,11 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSchemaRequest>,
         ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.SchemaService/GetSchema",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/GetSchema");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists schemas in a project.
@@ -351,19 +318,11 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSchemasRequest>,
         ) -> Result<tonic::Response<super::ListSchemasResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.SchemaService/ListSchemas",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ListSchemas");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a schema.
@@ -371,19 +330,11 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSchemaRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.SchemaService/DeleteSchema",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/DeleteSchema");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Validates a schema.
@@ -391,19 +342,11 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateSchemaRequest>,
         ) -> Result<tonic::Response<super::ValidateSchemaResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.SchemaService/ValidateSchema",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateSchema");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Validates a message against a schema.
@@ -411,19 +354,11 @@ pub mod schema_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateMessageRequest>,
         ) -> Result<tonic::Response<super::ValidateMessageResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.SchemaService/ValidateMessage",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateMessage");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -438,9 +373,7 @@ pub struct MessageStoragePolicy {
     /// routed for storage in one of the allowed regions. An empty list means that
     /// no regions are allowed, and is not a valid configuration.
     #[prost(string, repeated, tag = "1")]
-    pub allowed_persistence_regions: ::prost::alloc::vec::Vec<
-        ::prost::alloc::string::String,
-    >,
+    pub allowed_persistence_regions: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Settings for validating messages published against a schema.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -471,10 +404,7 @@ pub struct Topic {
     /// See [Creating and managing labels]
     /// (<https://cloud.google.com/pubsub/docs/labels>).
     #[prost(map = "string, string", tag = "2")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Policy constraining the set of Google Cloud Platform regions where messages
     /// published to the topic may be stored. If not present, then no constraints
     /// are in effect.
@@ -523,10 +453,7 @@ pub struct PubsubMessage {
     /// contain non-empty data. This can be used to filter messages on the
     /// subscription.
     #[prost(map = "string, string", tag = "2")]
-    pub attributes: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// ID of this message, assigned by the server when the message is published.
     /// Guaranteed to be unique within the topic. This value may be read by a
     /// subscriber that receives a `PubsubMessage` via a `Pull` call or a push
@@ -775,10 +702,7 @@ pub struct Subscription {
     /// See <a href="<https://cloud.google.com/pubsub/docs/labels">> Creating and
     /// managing labels</a>.
     #[prost(map = "string, string", tag = "9")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// If true, messages published with the same `ordering_key` in `PubsubMessage`
     /// will be delivered to the subscribers in the order in which they
     /// are received by the Pub/Sub system. Otherwise, they may be delivered in
@@ -846,9 +770,7 @@ pub struct Subscription {
     /// the `message_retention_duration` field in `Topic`. This field is set only
     /// in responses from the server; it is ignored if it is set in any requests.
     #[prost(message, optional, tag = "17")]
-    pub topic_message_retention_duration: ::core::option::Option<
-        ::prost_types::Duration,
-    >,
+    pub topic_message_retention_duration: ::core::option::Option<::prost_types::Duration>,
     /// Output only. An output-only field indicating whether or not the subscription can receive
     /// messages.
     #[prost(enumeration = "subscription::State", tag = "19")]
@@ -857,17 +779,7 @@ pub struct Subscription {
 /// Nested message and enum types in `Subscription`.
 pub mod subscription {
     /// Possible states for a subscription.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum State {
         /// Default value. This value is unused.
@@ -995,10 +907,7 @@ pub struct PushConfig {
     /// For example:
     /// <pre><code>attributes { "x-goog-version": "v1" } </code></pre>
     #[prost(map = "string, string", tag = "2")]
-    pub attributes: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// An authentication method used by push endpoints to verify the source of
     /// push requests. This can be used with push endpoints that are private by
     /// default to allow requests only from the Cloud Pub/Sub system, for example.
@@ -1079,17 +988,7 @@ pub struct BigQueryConfig {
 /// Nested message and enum types in `BigQueryConfig`.
 pub mod big_query_config {
     /// Possible states for a BigQuery subscription.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum State {
         /// Default value. This value is unused.
@@ -1334,9 +1233,7 @@ pub struct StreamingPullRequest {
     /// subscriber, or to make the message available for redelivery if the
     /// processing was interrupted.
     #[prost(string, repeated, tag = "4")]
-    pub modify_deadline_ack_ids: ::prost::alloc::vec::Vec<
-        ::prost::alloc::string::String,
-    >,
+    pub modify_deadline_ack_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Required. The ack deadline to use for the stream. This must be provided in
     /// the first request on the stream, but it can also be updated on subsequent
     /// requests from client to server. The minimum deadline you can specify is 10
@@ -1385,20 +1282,15 @@ pub struct StreamingPullResponse {
     /// This field will only be set if `enable_exactly_once_delivery` is set to
     /// `true`.
     #[prost(message, optional, tag = "5")]
-    pub acknowledge_confirmation: ::core::option::Option<
-        streaming_pull_response::AcknowledgeConfirmation,
-    >,
+    pub acknowledge_confirmation: ::core::option::Option<streaming_pull_response::AcknowledgeConfirmation>,
     /// This field will only be set if `enable_exactly_once_delivery` is set to
     /// `true`.
     #[prost(message, optional, tag = "3")]
-    pub modify_ack_deadline_confirmation: ::core::option::Option<
-        streaming_pull_response::ModifyAckDeadlineConfirmation,
-    >,
+    pub modify_ack_deadline_confirmation:
+        ::core::option::Option<streaming_pull_response::ModifyAckDeadlineConfirmation>,
     /// Properties associated with this subscription.
     #[prost(message, optional, tag = "4")]
-    pub subscription_properties: ::core::option::Option<
-        streaming_pull_response::SubscriptionProperties,
-    >,
+    pub subscription_properties: ::core::option::Option<streaming_pull_response::SubscriptionProperties>,
 }
 /// Nested message and enum types in `StreamingPullResponse`.
 pub mod streaming_pull_response {
@@ -1469,10 +1361,7 @@ pub struct CreateSnapshotRequest {
     /// See <a href="<https://cloud.google.com/pubsub/docs/labels">> Creating and
     /// managing labels</a>.
     #[prost(map = "string, string", tag = "3")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
 /// Request for the UpdateSnapshot method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1515,10 +1404,7 @@ pub struct Snapshot {
     /// See [Creating and managing labels]
     /// (<https://cloud.google.com/pubsub/docs/labels>).
     #[prost(map = "string, string", tag = "4")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
 /// Request for the GetSnapshot method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1609,8 +1495,8 @@ pub struct SeekResponse {}
 /// Generated client implementations.
 pub mod publisher_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// The service that an application uses to manipulate topics, and to send
     /// messages to a topic.
     #[derive(Debug, Clone)]
@@ -1643,22 +1529,15 @@ pub mod publisher_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> PublisherClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> PublisherClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             PublisherClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1683,19 +1562,11 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Topic>,
         ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/CreateTopic",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/CreateTopic");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an existing topic. Note that certain properties of a
@@ -1704,19 +1575,11 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateTopicRequest>,
         ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/UpdateTopic",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/UpdateTopic");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
@@ -1725,19 +1588,11 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PublishRequest>,
         ) -> Result<tonic::Response<super::PublishResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/Publish",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/Publish");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the configuration of a topic.
@@ -1745,19 +1600,11 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetTopicRequest>,
         ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/GetTopic",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/GetTopic");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists matching topics.
@@ -1765,42 +1612,23 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicsRequest>,
         ) -> Result<tonic::Response<super::ListTopicsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/ListTopics",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopics");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists the names of the attached subscriptions on this topic.
         pub async fn list_topic_subscriptions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSubscriptionsRequest>,
-        ) -> Result<
-            tonic::Response<super::ListTopicSubscriptionsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::ListTopicSubscriptionsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/ListTopicSubscriptions",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSubscriptions");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists the names of the snapshots on this topic. Snapshots are used in
@@ -1812,19 +1640,11 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSnapshotsRequest>,
         ) -> Result<tonic::Response<super::ListTopicSnapshotsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/ListTopicSnapshots",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSnapshots");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
@@ -1836,19 +1656,11 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteTopicRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/DeleteTopic",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DeleteTopic");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Detaches a subscription from this topic. All messages retained in the
@@ -1859,19 +1671,11 @@ pub mod publisher_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DetachSubscriptionRequest>,
         ) -> Result<tonic::Response<super::DetachSubscriptionResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Publisher/DetachSubscription",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DetachSubscription");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -1879,8 +1683,8 @@ pub mod publisher_client {
 /// Generated client implementations.
 pub mod subscriber_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// The service that an application uses to manipulate subscriptions and to
     /// consume messages from a subscription via the `Pull` method or by
     /// establishing a bi-directional stream using the `StreamingPull` method.
@@ -1914,22 +1718,15 @@ pub mod subscriber_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> SubscriberClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> SubscriberClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             SubscriberClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1963,19 +1760,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Subscription>,
         ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/CreateSubscription",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSubscription");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the configuration details of a subscription.
@@ -1983,19 +1772,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSubscriptionRequest>,
         ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/GetSubscription",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSubscription");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an existing subscription. Note that certain properties of a
@@ -2004,19 +1785,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSubscriptionRequest>,
         ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/UpdateSubscription",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSubscription");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists matching subscriptions.
@@ -2024,19 +1797,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSubscriptionsRequest>,
         ) -> Result<tonic::Response<super::ListSubscriptionsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/ListSubscriptions",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSubscriptions");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes an existing subscription. All messages retained in the subscription
@@ -2048,19 +1813,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSubscriptionRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/DeleteSubscription",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSubscription");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Modifies the ack deadline for a specific message. This method is useful
@@ -2072,19 +1829,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyAckDeadlineRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/ModifyAckDeadline",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyAckDeadline");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Acknowledges the messages associated with the `ack_ids` in the
@@ -2098,19 +1847,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::AcknowledgeRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/Acknowledge",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Acknowledge");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Pulls messages from the server. The server may return `UNAVAILABLE` if
@@ -2120,19 +1861,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PullRequest>,
         ) -> Result<tonic::Response<super::PullResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/Pull",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Pull");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Establishes a stream with the server, which sends messages down to the
@@ -2144,27 +1877,16 @@ pub mod subscriber_client {
         /// underlying RPC channel.
         pub async fn streaming_pull(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<
-                Message = super::StreamingPullRequest,
-            >,
-        ) -> Result<
-            tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoStreamingRequest<Message = super::StreamingPullRequest>,
+        ) -> Result<tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/StreamingPull",
-            );
-            self.inner.streaming(request.into_streaming_request(), path, codec).await
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/StreamingPull");
+            self.inner
+                .streaming(request.into_streaming_request(), path, codec)
+                .await
         }
         /// Modifies the `PushConfig` for a specified subscription.
         ///
@@ -2176,19 +1898,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyPushConfigRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/ModifyPushConfig",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyPushConfig");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the configuration details of a snapshot. Snapshots are used in
@@ -2200,19 +1914,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSnapshotRequest>,
         ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/GetSnapshot",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSnapshot");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists the existing snapshots. Snapshots are used in [Seek](
@@ -2224,19 +1930,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
         ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/ListSnapshots",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSnapshots");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a snapshot from the requested subscription. Snapshots are used in
@@ -2259,19 +1957,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
         ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/CreateSnapshot",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSnapshot");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an existing snapshot. Snapshots are used in
@@ -2284,19 +1974,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSnapshotRequest>,
         ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/UpdateSnapshot",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSnapshot");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Removes an existing snapshot. Snapshots are used in [Seek]
@@ -2312,19 +1994,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/DeleteSnapshot",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSnapshot");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Seeks an existing subscription to a point in time or to a given snapshot,
@@ -2338,19 +2012,11 @@ pub mod subscriber_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SeekRequest>,
         ) -> Result<tonic::Response<super::SeekResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.pubsub.v1.Subscriber/Seek",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Seek");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.r#type.rs
+++ b/googleapis/src/google.r#type.rs
@@ -4,32 +4,33 @@
 ///
 /// Example (Comparison):
 ///
-///     title: "Summary size limit"
-///     description: "Determines if a summary is less than 100 chars"
-///     expression: "document.summary.size() < 100"
+///      title: "Summary size limit"
+///      description: "Determines if a summary is less than 100 chars"
+///      expression: "document.summary.size() < 100"
 ///
 /// Example (Equality):
 ///
-///     title: "Requestor is owner"
-///     description: "Determines if requestor is the document owner"
-///     expression: "document.owner == request.auth.claims.email"
+///      title: "Requestor is owner"
+///      description: "Determines if requestor is the document owner"
+///      expression: "document.owner == request.auth.claims.email"
 ///
 /// Example (Logic):
 ///
-///     title: "Public documents"
-///     description: "Determine whether the document should be publicly visible"
-///     expression: "document.type != 'private' && document.type != 'internal'"
+///      title: "Public documents"
+///      description: "Determine whether the document should be publicly visible"
+///      expression: "document.type != 'private' && document.type != 'internal'"
 ///
 /// Example (Data Manipulation):
 ///
-///     title: "Notification string"
-///     description: "Create a notification string with a timestamp."
-///     expression: "'New message received at ' + string(document.create_time)"
+///      title: "Notification string"
+///      description: "Create a notification string with a timestamp."
+///      expression: "'New message received at ' + string(document.create_time)"
 ///
 /// The exact variables and functions that may be referenced within an expression
 /// are determined by the service that evaluates it. See the service
 /// documentation for additional information.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Expr {
     /// Textual representation of an expression in Common Expression Language
     /// syntax.
@@ -62,7 +63,8 @@ pub struct Expr {
 ///
 /// Related types are \[google.type.TimeOfDay][google.type.TimeOfDay\] and
 /// `google.protobuf.Timestamp`.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Date {
     /// Year of the date. Must be from 1 to 9999, or 0 to specify a date without
     /// a year.

--- a/googleapis/src/google.rpc.rs
+++ b/googleapis/src/google.rpc.rs
@@ -5,14 +5,17 @@
 ///
 /// You can find out more about this error model and how to work with it in the
 /// [API Design Guide](<https://cloud.google.com/apis/design/errors>).
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Status {
-    /// The status code, which should be an enum value of \[google.rpc.Code][google.rpc.Code\].
+    /// The status code, which should be an enum value of
+    /// \[google.rpc.Code][google.rpc.Code\].
     #[prost(int32, tag = "1")]
     pub code: i32,
     /// A developer-facing error message, which should be in English. Any
     /// user-facing error message should be localized and sent in the
-    /// \[google.rpc.Status.details][google.rpc.Status.details\] field, or localized by the client.
+    /// \[google.rpc.Status.details][google.rpc.Status.details\] field, or localized
+    /// by the client.
     #[prost(string, tag = "2")]
     pub message: ::prost::alloc::string::String,
     /// A list of messages that carry the error details.  There is a common set of

--- a/googleapis/src/google.spanner.admin.database.v1.rs
+++ b/googleapis/src/google.spanner.admin.database.v1.rs
@@ -1,6 +1,7 @@
 /// Encapsulates progress related information for a Cloud Spanner long
 /// running operation.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OperationProgress {
     /// Percent completion of the operation.
     /// Values are between 0 and 100 inclusive.
@@ -15,7 +16,8 @@ pub struct OperationProgress {
     pub end_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// Encryption configuration for a Cloud Spanner database.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptionConfig {
     /// The Cloud KMS key to be used for encrypting and decrypting
     /// the database. Values are of the form
@@ -24,6 +26,7 @@ pub struct EncryptionConfig {
     pub kms_key_name: ::prost::alloc::string::String,
 }
 /// Encryption information for a Cloud Spanner database or backup.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptionInfo {
     /// Output only. The type of encryption.
@@ -33,7 +36,9 @@ pub struct EncryptionInfo {
     /// for this database or backup. Regardless of status, data is always encrypted
     /// at rest.
     #[prost(message, optional, tag = "4")]
-    pub encryption_status: ::core::option::Option<super::super::super::super::rpc::Status>,
+    pub encryption_status: ::core::option::Option<
+        super::super::super::super::rpc::Status,
+    >,
     /// Output only. A Cloud KMS key version that is being used to protect the database or
     /// backup.
     #[prost(string, tag = "2")]
@@ -42,7 +47,17 @@ pub struct EncryptionInfo {
 /// Nested message and enum types in `EncryptionInfo`.
 pub mod encryption_info {
     /// Possible encryption types.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Type {
         /// Encryption type was not specified, though data at rest remains encrypted.
@@ -55,6 +70,19 @@ pub mod encryption_info {
         /// managed by the customer. The active version of the key. `kms_key_version`
         /// will be populated, and `encryption_status` may be populated.
         CustomerManagedEncryption = 2,
+    }
+    impl Type {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Type::Unspecified => "TYPE_UNSPECIFIED",
+                Type::GoogleDefaultEncryption => "GOOGLE_DEFAULT_ENCRYPTION",
+                Type::CustomerManagedEncryption => "CUSTOMER_MANAGED_ENCRYPTION",
+            }
+        }
     }
 }
 /// Indicates the dialect type of a database.
@@ -69,7 +97,21 @@ pub enum DatabaseDialect {
     /// PostgreSQL supported SQL.
     Postgresql = 2,
 }
+impl DatabaseDialect {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            DatabaseDialect::Unspecified => "DATABASE_DIALECT_UNSPECIFIED",
+            DatabaseDialect::GoogleStandardSql => "GOOGLE_STANDARD_SQL",
+            DatabaseDialect::Postgresql => "POSTGRESQL",
+        }
+    }
+}
 /// A backup of a Cloud Spanner database.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Backup {
     /// Required for the \[CreateBackup][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup\] operation.
@@ -154,7 +196,17 @@ pub struct Backup {
 /// Nested message and enum types in `Backup`.
 pub mod backup {
     /// Indicates the current state of the backup.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum State {
         /// Not specified.
@@ -165,8 +217,22 @@ pub mod backup {
         /// The backup is complete and ready for use.
         Ready = 2,
     }
+    impl State {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                State::Unspecified => "STATE_UNSPECIFIED",
+                State::Creating => "CREATING",
+                State::Ready => "READY",
+            }
+        }
+    }
 }
 /// The request for \[CreateBackup][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateBackupRequest {
     /// Required. The name of the instance in which the backup will be
@@ -195,7 +261,8 @@ pub struct CreateBackupRequest {
 }
 /// Metadata type for the operation returned by
 /// \[CreateBackup][google.spanner.admin.database.v1.DatabaseAdmin.CreateBackup\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateBackupMetadata {
     /// The name of the backup being created.
     #[prost(string, tag = "1")]
@@ -223,7 +290,8 @@ pub struct CreateBackupMetadata {
     pub cancel_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// The request for \[CopyBackup][google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CopyBackupRequest {
     /// Required. The name of the destination instance that will contain the backup copy.
     /// Values are of the form: `projects/<project>/instances/<instance>`.
@@ -259,7 +327,8 @@ pub struct CopyBackupRequest {
 }
 /// Metadata type for the google.longrunning.Operation returned by
 /// \[CopyBackup][google.spanner.admin.database.v1.DatabaseAdmin.CopyBackup\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CopyBackupMetadata {
     /// The name of the backup being created through the copy operation.
     /// Values are of the form
@@ -291,12 +360,13 @@ pub struct CopyBackupMetadata {
     pub cancel_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// The request for \[UpdateBackup][google.spanner.admin.database.v1.DatabaseAdmin.UpdateBackup\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateBackupRequest {
     /// Required. The backup to update. `backup.name`, and the fields to be updated
     /// as specified by `update_mask` are required. Other fields are ignored.
     /// Update is only supported for the following fields:
-    ///  * `backup.expire_time`.
+    ///   * `backup.expire_time`.
     #[prost(message, optional, tag = "1")]
     pub backup: ::core::option::Option<Backup>,
     /// Required. A mask specifying which fields (e.g. `expire_time`) in the
@@ -308,7 +378,8 @@ pub struct UpdateBackupRequest {
     pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// The request for \[GetBackup][google.spanner.admin.database.v1.DatabaseAdmin.GetBackup\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBackupRequest {
     /// Required. Name of the backup.
     /// Values are of the form
@@ -317,7 +388,8 @@ pub struct GetBackupRequest {
     pub name: ::prost::alloc::string::String,
 }
 /// The request for \[DeleteBackup][google.spanner.admin.database.v1.DatabaseAdmin.DeleteBackup\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteBackupRequest {
     /// Required. Name of the backup to delete.
     /// Values are of the form
@@ -326,7 +398,8 @@ pub struct DeleteBackupRequest {
     pub name: ::prost::alloc::string::String,
 }
 /// The request for \[ListBackups][google.spanner.admin.database.v1.DatabaseAdmin.ListBackups\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListBackupsRequest {
     /// Required. The instance to list backups from.  Values are of the
     /// form `projects/<project>/instances/<instance>`.
@@ -342,13 +415,13 @@ pub struct ListBackupsRequest {
     ///
     /// The following fields in the \[Backup][google.spanner.admin.database.v1.Backup\] are eligible for filtering:
     ///
-    ///   * `name`
-    ///   * `database`
-    ///   * `state`
-    ///   * `create_time`  (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
-    ///   * `expire_time`  (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
-    ///   * `version_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
-    ///   * `size_bytes`
+    ///    * `name`
+    ///    * `database`
+    ///    * `state`
+    ///    * `create_time`  (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
+    ///    * `expire_time`  (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
+    ///    * `version_time` (and values are of the format YYYY-MM-DDTHH:MM:SSZ)
+    ///    * `size_bytes`
     ///
     /// You can combine multiple expressions by enclosing each expression in
     /// parentheses. By default, expressions are combined with AND logic, but
@@ -356,17 +429,17 @@ pub struct ListBackupsRequest {
     ///
     /// Here are a few examples:
     ///
-    ///   * `name:Howl` - The backup's name contains the string "howl".
-    ///   * `database:prod`
-    ///          - The database's name contains the string "prod".
-    ///   * `state:CREATING` - The backup is pending creation.
-    ///   * `state:READY` - The backup is fully created and ready for use.
-    ///   * `(name:howl) AND (create_time < \"2018-03-28T14:50:00Z\")`
-    ///          - The backup name contains the string "howl" and `create_time`
-    ///              of the backup is before 2018-03-28T14:50:00Z.
-    ///   * `expire_time < \"2018-03-28T14:50:00Z\"`
-    ///          - The backup `expire_time` is before 2018-03-28T14:50:00Z.
-    ///   * `size_bytes > 10000000000` - The backup's size is greater than 10GB
+    ///    * `name:Howl` - The backup's name contains the string "howl".
+    ///    * `database:prod`
+    ///           - The database's name contains the string "prod".
+    ///    * `state:CREATING` - The backup is pending creation.
+    ///    * `state:READY` - The backup is fully created and ready for use.
+    ///    * `(name:howl) AND (create_time < \"2018-03-28T14:50:00Z\")`
+    ///           - The backup name contains the string "howl" and `create_time`
+    ///               of the backup is before 2018-03-28T14:50:00Z.
+    ///    * `expire_time < \"2018-03-28T14:50:00Z\"`
+    ///           - The backup `expire_time` is before 2018-03-28T14:50:00Z.
+    ///    * `size_bytes > 10000000000` - The backup's size is greater than 10GB
     #[prost(string, tag = "2")]
     pub filter: ::prost::alloc::string::String,
     /// Number of backups to be returned in the response. If 0 or
@@ -381,6 +454,7 @@ pub struct ListBackupsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// The response for \[ListBackups][google.spanner.admin.database.v1.DatabaseAdmin.ListBackups\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListBackupsResponse {
     /// The list of matching backups. Backups returned are ordered by `create_time`
@@ -395,7 +469,8 @@ pub struct ListBackupsResponse {
 }
 /// The request for
 /// \[ListBackupOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListBackupOperationsRequest {
     /// Required. The instance of the backup operations. Values are of
     /// the form `projects/<project>/instances/<instance>`.
@@ -412,17 +487,17 @@ pub struct ListBackupOperationsRequest {
     /// The following fields in the \[operation][google.longrunning.Operation\]
     /// are eligible for filtering:
     ///
-    ///   * `name` - The name of the long-running operation
-    ///   * `done` - False if the operation is in progress, else true.
-    ///   * `metadata.@type` - the type of metadata. For example, the type string
-    ///      for \[CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata\] is
-    ///      `type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata`.
-    ///   * `metadata.<field_name>` - any field in metadata.value.
-    ///      `metadata.@type` must be specified first if filtering on metadata
-    ///      fields.
-    ///   * `error` - Error associated with the long-running operation.
-    ///   * `response.@type` - the type of response.
-    ///   * `response.<field_name>` - any field in response.value.
+    ///    * `name` - The name of the long-running operation
+    ///    * `done` - False if the operation is in progress, else true.
+    ///    * `metadata.@type` - the type of metadata. For example, the type string
+    ///       for \[CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata\] is
+    ///       `type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata`.
+    ///    * `metadata.<field_name>` - any field in metadata.value.
+    ///       `metadata.@type` must be specified first if filtering on metadata
+    ///       fields.
+    ///    * `error` - Error associated with the long-running operation.
+    ///    * `response.@type` - the type of response.
+    ///    * `response.<field_name>` - any field in response.value.
     ///
     /// You can combine multiple expressions by enclosing each expression in
     /// parentheses. By default, expressions are combined with AND logic, but
@@ -430,43 +505,43 @@ pub struct ListBackupOperationsRequest {
     ///
     /// Here are a few examples:
     ///
-    ///   * `done:true` - The operation is complete.
-    ///   * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata) AND` \
-    ///      `metadata.database:prod` - Returns operations where:
+    ///    * `done:true` - The operation is complete.
+    ///    * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata) AND` \
+    ///       `metadata.database:prod` - Returns operations where:
+    ///       * The operation's metadata type is \[CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata\].
+    ///       * The database the backup was taken from has a name containing the
+    ///       string "prod".
+    ///    * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata) AND` \
+    ///      `(metadata.name:howl) AND` \
+    ///      `(metadata.progress.start_time < \"2018-03-28T14:50:00Z\") AND` \
+    ///      `(error:*)` - Returns operations where:
     ///      * The operation's metadata type is \[CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata\].
-    ///      * The database the backup was taken from has a name containing the
-    ///      string "prod".
-    ///   * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata) AND` \
-    ///     `(metadata.name:howl) AND` \
-    ///     `(metadata.progress.start_time < \"2018-03-28T14:50:00Z\") AND` \
-    ///     `(error:*)` - Returns operations where:
-    ///     * The operation's metadata type is \[CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata\].
-    ///     * The backup name contains the string "howl".
-    ///     * The operation started before 2018-03-28T14:50:00Z.
-    ///     * The operation resulted in an error.
-    ///   * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CopyBackupMetadata) AND` \
-    ///     `(metadata.source_backup:test) AND` \
-    ///     `(metadata.progress.start_time < \"2022-01-18T14:50:00Z\") AND` \
-    ///     `(error:*)` - Returns operations where:
-    ///     * The operation's metadata type is \[CopyBackupMetadata][google.spanner.admin.database.v1.CopyBackupMetadata\].
-    ///     * The source backup of the copied backup name contains the string
-    ///     "test".
-    ///     * The operation started before 2022-01-18T14:50:00Z.
-    ///     * The operation resulted in an error.
-    ///   * `((metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata) AND` \
-    ///     `(metadata.database:test_db)) OR` \
-    ///     `((metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CopyBackupMetadata)
-    ///     AND` \
-    ///     `(metadata.source_backup:test_bkp)) AND` \
-    ///     `(error:*)` - Returns operations where:
-    ///     * The operation's metadata matches either of criteria:
-    ///       * The operation's metadata type is \[CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata\] AND the
-    ///       database the backup was taken from has name containing string
-    ///       "test_db"
-    ///       * The operation's metadata type is \[CopyBackupMetadata][google.spanner.admin.database.v1.CopyBackupMetadata\] AND the
-    ///       backup the backup was copied from has name containing string
-    ///       "test_bkp"
-    ///     * The operation resulted in an error.
+    ///      * The backup name contains the string "howl".
+    ///      * The operation started before 2018-03-28T14:50:00Z.
+    ///      * The operation resulted in an error.
+    ///    * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CopyBackupMetadata) AND` \
+    ///      `(metadata.source_backup:test) AND` \
+    ///      `(metadata.progress.start_time < \"2022-01-18T14:50:00Z\") AND` \
+    ///      `(error:*)` - Returns operations where:
+    ///      * The operation's metadata type is \[CopyBackupMetadata][google.spanner.admin.database.v1.CopyBackupMetadata\].
+    ///      * The source backup of the copied backup name contains the string
+    ///      "test".
+    ///      * The operation started before 2022-01-18T14:50:00Z.
+    ///      * The operation resulted in an error.
+    ///    * `((metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata) AND` \
+    ///      `(metadata.database:test_db)) OR` \
+    ///      `((metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.CopyBackupMetadata)
+    ///      AND` \
+    ///      `(metadata.source_backup:test_bkp)) AND` \
+    ///      `(error:*)` - Returns operations where:
+    ///      * The operation's metadata matches either of criteria:
+    ///        * The operation's metadata type is \[CreateBackupMetadata][google.spanner.admin.database.v1.CreateBackupMetadata\] AND the
+    ///        database the backup was taken from has name containing string
+    ///        "test_db"
+    ///        * The operation's metadata type is \[CopyBackupMetadata][google.spanner.admin.database.v1.CopyBackupMetadata\] AND the
+    ///        backup the backup was copied from has name containing string
+    ///        "test_bkp"
+    ///      * The operation resulted in an error.
     #[prost(string, tag = "2")]
     pub filter: ::prost::alloc::string::String,
     /// Number of operations to be returned in the response. If 0 or
@@ -482,6 +557,7 @@ pub struct ListBackupOperationsRequest {
 }
 /// The response for
 /// \[ListBackupOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListBackupOperationsResponse {
     /// The list of matching backup [long-running
@@ -494,7 +570,9 @@ pub struct ListBackupOperationsResponse {
     /// `operation.metadata.value.progress.start_time` in descending order starting
     /// from the most recently started operation.
     #[prost(message, repeated, tag = "1")]
-    pub operations: ::prost::alloc::vec::Vec<super::super::super::super::longrunning::Operation>,
+    pub operations: ::prost::alloc::vec::Vec<
+        super::super::super::super::longrunning::Operation,
+    >,
     /// `next_page_token` can be sent in a subsequent
     /// \[ListBackupOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations\]
     /// call to fetch more of the matching metadata.
@@ -502,7 +580,8 @@ pub struct ListBackupOperationsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Information about a backup.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BackupInfo {
     /// Name of the backup.
     #[prost(string, tag = "1")]
@@ -523,7 +602,8 @@ pub struct BackupInfo {
     pub source_database: ::prost::alloc::string::String,
 }
 /// Encryption configuration for the backup to create.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateBackupEncryptionConfig {
     /// Required. The encryption type of the backup.
     #[prost(enumeration = "create_backup_encryption_config::EncryptionType", tag = "1")]
@@ -539,7 +619,17 @@ pub struct CreateBackupEncryptionConfig {
 /// Nested message and enum types in `CreateBackupEncryptionConfig`.
 pub mod create_backup_encryption_config {
     /// Encryption types for the backup.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum EncryptionType {
         /// Unspecified. Do not use.
@@ -556,9 +646,26 @@ pub mod create_backup_encryption_config {
         /// must contain a valid Cloud KMS key.
         CustomerManagedEncryption = 3,
     }
+    impl EncryptionType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                EncryptionType::Unspecified => "ENCRYPTION_TYPE_UNSPECIFIED",
+                EncryptionType::UseDatabaseEncryption => "USE_DATABASE_ENCRYPTION",
+                EncryptionType::GoogleDefaultEncryption => "GOOGLE_DEFAULT_ENCRYPTION",
+                EncryptionType::CustomerManagedEncryption => {
+                    "CUSTOMER_MANAGED_ENCRYPTION"
+                }
+            }
+        }
+    }
 }
 /// Encryption configuration for the copied backup.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CopyBackupEncryptionConfig {
     /// Required. The encryption type of the backup.
     #[prost(enumeration = "copy_backup_encryption_config::EncryptionType", tag = "1")]
@@ -574,7 +681,17 @@ pub struct CopyBackupEncryptionConfig {
 /// Nested message and enum types in `CopyBackupEncryptionConfig`.
 pub mod copy_backup_encryption_config {
     /// Encryption types for the backup.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum EncryptionType {
         /// Unspecified. Do not use.
@@ -590,9 +707,28 @@ pub mod copy_backup_encryption_config {
         /// must contain a valid Cloud KMS key.
         CustomerManagedEncryption = 3,
     }
+    impl EncryptionType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                EncryptionType::Unspecified => "ENCRYPTION_TYPE_UNSPECIFIED",
+                EncryptionType::UseConfigDefaultOrBackupEncryption => {
+                    "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"
+                }
+                EncryptionType::GoogleDefaultEncryption => "GOOGLE_DEFAULT_ENCRYPTION",
+                EncryptionType::CustomerManagedEncryption => {
+                    "CUSTOMER_MANAGED_ENCRYPTION"
+                }
+            }
+        }
+    }
 }
 /// Information about the database restore.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RestoreInfo {
     /// The type of the restore source.
     #[prost(enumeration = "RestoreSourceType", tag = "1")]
@@ -604,7 +740,8 @@ pub struct RestoreInfo {
 /// Nested message and enum types in `RestoreInfo`.
 pub mod restore_info {
     /// Information about the source used to restore the database.
-    #[derive(Clone, PartialEq, Eq, ::prost::Oneof)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum SourceInfo {
         /// Information about the backup used to restore the database. The backup
         /// may no longer exist.
@@ -613,6 +750,7 @@ pub mod restore_info {
     }
 }
 /// A Cloud Spanner database.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Database {
     /// Required. The name of the database. Values are of the form
@@ -678,7 +816,17 @@ pub struct Database {
 /// Nested message and enum types in `Database`.
 pub mod database {
     /// Indicates the current state of the database.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum State {
         /// Not specified.
@@ -698,9 +846,24 @@ pub mod database {
         /// `READY` state.
         ReadyOptimizing = 3,
     }
+    impl State {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                State::Unspecified => "STATE_UNSPECIFIED",
+                State::Creating => "CREATING",
+                State::Ready => "READY",
+                State::ReadyOptimizing => "READY_OPTIMIZING",
+            }
+        }
+    }
 }
 /// The request for \[ListDatabases][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListDatabasesRequest {
     /// Required. The instance whose databases should be listed.
     /// Values are of the form `projects/<project>/instances/<instance>`.
@@ -717,6 +880,7 @@ pub struct ListDatabasesRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// The response for \[ListDatabases][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabases\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListDatabasesResponse {
     /// Databases that matched the request.
@@ -729,7 +893,8 @@ pub struct ListDatabasesResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// The request for \[CreateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateDatabaseRequest {
     /// Required. The name of the instance that will serve the new database.
     /// Values are of the form `projects/<project>/instances/<instance>`.
@@ -759,14 +924,16 @@ pub struct CreateDatabaseRequest {
 }
 /// Metadata type for the operation returned by
 /// \[CreateDatabase][google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateDatabaseMetadata {
     /// The database being created.
     #[prost(string, tag = "1")]
     pub database: ::prost::alloc::string::String,
 }
 /// The request for \[GetDatabase][google.spanner.admin.database.v1.DatabaseAdmin.GetDatabase\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetDatabaseRequest {
     /// Required. The name of the requested database. Values are of the form
     /// `projects/<project>/instances/<instance>/databases/<database>`.
@@ -789,7 +956,8 @@ pub struct GetDatabaseRequest {
 /// progress. See the
 /// \[operation_id][google.spanner.admin.database.v1.UpdateDatabaseDdlRequest.operation_id\] field for more
 /// details.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateDatabaseDdlRequest {
     /// Required. The database to update.
     #[prost(string, tag = "1")]
@@ -821,7 +989,8 @@ pub struct UpdateDatabaseDdlRequest {
 }
 /// Metadata type for the operation returned by
 /// \[UpdateDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateDatabaseDdlMetadata {
     /// The database being modified.
     #[prost(string, tag = "1")]
@@ -852,14 +1021,16 @@ pub struct UpdateDatabaseDdlMetadata {
     pub progress: ::prost::alloc::vec::Vec<OperationProgress>,
 }
 /// The request for \[DropDatabase][google.spanner.admin.database.v1.DatabaseAdmin.DropDatabase\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DropDatabaseRequest {
     /// Required. The database to be dropped.
     #[prost(string, tag = "1")]
     pub database: ::prost::alloc::string::String,
 }
 /// The request for \[GetDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetDatabaseDdlRequest {
     /// Required. The database whose schema we wish to get.
     /// Values are of the form
@@ -868,7 +1039,8 @@ pub struct GetDatabaseDdlRequest {
     pub database: ::prost::alloc::string::String,
 }
 /// The response for \[GetDatabaseDdl][google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetDatabaseDdlResponse {
     /// A list of formatted DDL statements defining the schema of the database
     /// specified in the request.
@@ -877,7 +1049,8 @@ pub struct GetDatabaseDdlResponse {
 }
 /// The request for
 /// \[ListDatabaseOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListDatabaseOperationsRequest {
     /// Required. The instance of the database operations.
     /// Values are of the form `projects/<project>/instances/<instance>`.
@@ -894,17 +1067,17 @@ pub struct ListDatabaseOperationsRequest {
     /// The following fields in the \[Operation][google.longrunning.Operation\]
     /// are eligible for filtering:
     ///
-    ///   * `name` - The name of the long-running operation
-    ///   * `done` - False if the operation is in progress, else true.
-    ///   * `metadata.@type` - the type of metadata. For example, the type string
-    ///      for \[RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata\] is
-    ///      `type.googleapis.com/google.spanner.admin.database.v1.RestoreDatabaseMetadata`.
-    ///   * `metadata.<field_name>` - any field in metadata.value.
-    ///      `metadata.@type` must be specified first, if filtering on metadata
-    ///      fields.
-    ///   * `error` - Error associated with the long-running operation.
-    ///   * `response.@type` - the type of response.
-    ///   * `response.<field_name>` - any field in response.value.
+    ///    * `name` - The name of the long-running operation
+    ///    * `done` - False if the operation is in progress, else true.
+    ///    * `metadata.@type` - the type of metadata. For example, the type string
+    ///       for \[RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata\] is
+    ///       `type.googleapis.com/google.spanner.admin.database.v1.RestoreDatabaseMetadata`.
+    ///    * `metadata.<field_name>` - any field in metadata.value.
+    ///       `metadata.@type` must be specified first, if filtering on metadata
+    ///       fields.
+    ///    * `error` - Error associated with the long-running operation.
+    ///    * `response.@type` - the type of response.
+    ///    * `response.<field_name>` - any field in response.value.
     ///
     /// You can combine multiple expressions by enclosing each expression in
     /// parentheses. By default, expressions are combined with AND logic. However,
@@ -912,19 +1085,19 @@ pub struct ListDatabaseOperationsRequest {
     ///
     /// Here are a few examples:
     ///
-    ///   * `done:true` - The operation is complete.
-    ///   * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.RestoreDatabaseMetadata) AND` \
-    ///     `(metadata.source_type:BACKUP) AND` \
-    ///     `(metadata.backup_info.backup:backup_howl) AND` \
-    ///     `(metadata.name:restored_howl) AND` \
-    ///     `(metadata.progress.start_time < \"2018-03-28T14:50:00Z\") AND` \
-    ///     `(error:*)` - Return operations where:
-    ///     * The operation's metadata type is \[RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata\].
-    ///     * The database is restored from a backup.
-    ///     * The backup name contains "backup_howl".
-    ///     * The restored database's name contains "restored_howl".
-    ///     * The operation started before 2018-03-28T14:50:00Z.
-    ///     * The operation resulted in an error.
+    ///    * `done:true` - The operation is complete.
+    ///    * `(metadata.@type=type.googleapis.com/google.spanner.admin.database.v1.RestoreDatabaseMetadata) AND` \
+    ///      `(metadata.source_type:BACKUP) AND` \
+    ///      `(metadata.backup_info.backup:backup_howl) AND` \
+    ///      `(metadata.name:restored_howl) AND` \
+    ///      `(metadata.progress.start_time < \"2018-03-28T14:50:00Z\") AND` \
+    ///      `(error:*)` - Return operations where:
+    ///      * The operation's metadata type is \[RestoreDatabaseMetadata][google.spanner.admin.database.v1.RestoreDatabaseMetadata\].
+    ///      * The database is restored from a backup.
+    ///      * The backup name contains "backup_howl".
+    ///      * The restored database's name contains "restored_howl".
+    ///      * The operation started before 2018-03-28T14:50:00Z.
+    ///      * The operation resulted in an error.
     #[prost(string, tag = "2")]
     pub filter: ::prost::alloc::string::String,
     /// Number of operations to be returned in the response. If 0 or
@@ -940,6 +1113,7 @@ pub struct ListDatabaseOperationsRequest {
 }
 /// The response for
 /// \[ListDatabaseOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListDatabaseOperationsResponse {
     /// The list of matching database [long-running
@@ -948,7 +1122,9 @@ pub struct ListDatabaseOperationsResponse {
     /// \[metadata][google.longrunning.Operation.metadata\] field type
     /// `metadata.type_url` describes the type of the metadata.
     #[prost(message, repeated, tag = "1")]
-    pub operations: ::prost::alloc::vec::Vec<super::super::super::super::longrunning::Operation>,
+    pub operations: ::prost::alloc::vec::Vec<
+        super::super::super::super::longrunning::Operation,
+    >,
     /// `next_page_token` can be sent in a subsequent
     /// \[ListDatabaseOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations\]
     /// call to fetch more of the matching metadata.
@@ -957,7 +1133,8 @@ pub struct ListDatabaseOperationsResponse {
 }
 /// The request for
 /// \[RestoreDatabase][google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RestoreDatabaseRequest {
     /// Required. The name of the instance in which to create the
     /// restored database. This instance must be in the same project and
@@ -987,7 +1164,8 @@ pub struct RestoreDatabaseRequest {
 /// Nested message and enum types in `RestoreDatabaseRequest`.
 pub mod restore_database_request {
     /// Required. The source from which to restore.
-    #[derive(Clone, PartialEq, Eq, ::prost::Oneof)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Source {
         /// Name of the backup from which to restore.  Values are of the form
         /// `projects/<project>/instances/<instance>/backups/<backup>`.
@@ -996,10 +1174,14 @@ pub mod restore_database_request {
     }
 }
 /// Encryption configuration for the restored database.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RestoreDatabaseEncryptionConfig {
     /// Required. The encryption type of the restored database.
-    #[prost(enumeration = "restore_database_encryption_config::EncryptionType", tag = "1")]
+    #[prost(
+        enumeration = "restore_database_encryption_config::EncryptionType",
+        tag = "1"
+    )]
     pub encryption_type: i32,
     /// Optional. The Cloud KMS key that will be used to encrypt/decrypt the restored
     /// database. This field should be set only when
@@ -1012,7 +1194,17 @@ pub struct RestoreDatabaseEncryptionConfig {
 /// Nested message and enum types in `RestoreDatabaseEncryptionConfig`.
 pub mod restore_database_encryption_config {
     /// Encryption types for the database to be restored.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum EncryptionType {
         /// Unspecified. Do not use.
@@ -1026,10 +1218,29 @@ pub mod restore_database_encryption_config {
         /// must contain a valid Cloud KMS key.
         CustomerManagedEncryption = 3,
     }
+    impl EncryptionType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                EncryptionType::Unspecified => "ENCRYPTION_TYPE_UNSPECIFIED",
+                EncryptionType::UseConfigDefaultOrBackupEncryption => {
+                    "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"
+                }
+                EncryptionType::GoogleDefaultEncryption => "GOOGLE_DEFAULT_ENCRYPTION",
+                EncryptionType::CustomerManagedEncryption => {
+                    "CUSTOMER_MANAGED_ENCRYPTION"
+                }
+            }
+        }
+    }
 }
 /// Metadata type for the long-running operation returned by
 /// \[RestoreDatabase][google.spanner.admin.database.v1.DatabaseAdmin.RestoreDatabase\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RestoreDatabaseMetadata {
     /// Name of the database being created and restored to.
     #[prost(string, tag = "1")]
@@ -1077,7 +1288,8 @@ pub struct RestoreDatabaseMetadata {
 pub mod restore_database_metadata {
     /// Information about the source used to restore the database, as specified by
     /// `source` in \[RestoreDatabaseRequest][google.spanner.admin.database.v1.RestoreDatabaseRequest\].
-    #[derive(Clone, PartialEq, Eq, ::prost::Oneof)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum SourceInfo {
         /// Information about the backup used to restore the database.
         #[prost(message, tag = "3")]
@@ -1088,7 +1300,8 @@ pub mod restore_database_metadata {
 /// of optimizations performed on a newly restored database. This long-running
 /// operation is automatically created by the system after the successful
 /// completion of a database restore, and cannot be cancelled.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OptimizeRestoredDatabaseMetadata {
     /// Name of the restored database being optimized.
     #[prost(string, tag = "1")]
@@ -1098,7 +1311,8 @@ pub struct OptimizeRestoredDatabaseMetadata {
     pub progress: ::core::option::Option<OperationProgress>,
 }
 /// A Cloud Spanner database role.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DatabaseRole {
     /// Required. The name of the database role. Values are of the form
     /// `projects/<project>/instances/<instance>/databases/<database>/databaseRoles/
@@ -1109,7 +1323,8 @@ pub struct DatabaseRole {
     pub name: ::prost::alloc::string::String,
 }
 /// The request for \[ListDatabaseRoles][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListDatabaseRolesRequest {
     /// Required. The database whose roles should be listed.
     /// Values are of the form
@@ -1127,7 +1342,8 @@ pub struct ListDatabaseRolesRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// The response for \[ListDatabaseRoles][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseRoles\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListDatabaseRolesResponse {
     /// Database roles that matched the request.
     #[prost(message, repeated, tag = "1")]
@@ -1147,10 +1363,23 @@ pub enum RestoreSourceType {
     /// A backup was used as the source of the restore.
     Backup = 1,
 }
+impl RestoreSourceType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            RestoreSourceType::TypeUnspecified => "TYPE_UNSPECIFIED",
+            RestoreSourceType::Backup => "BACKUP",
+        }
+    }
+}
 /// Generated client implementations.
 pub mod database_admin_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Cloud Spanner Database Admin API
     ///
     /// The Cloud Spanner Database Admin API can be used to:
@@ -1184,31 +1413,42 @@ pub mod database_admin_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> DatabaseAdminClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> DatabaseAdminClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             DatabaseAdminClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Lists Cloud Spanner databases.
@@ -1216,12 +1456,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabasesRequest>,
         ) -> Result<tonic::Response<super::ListDatabasesResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabases");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabases",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -1235,13 +1482,23 @@ pub mod database_admin_client {
         pub async fn create_database(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateDatabaseRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CreateDatabase");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/CreateDatabase",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the state of a Cloud Spanner database.
@@ -1249,12 +1506,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseRequest>,
         ) -> Result<tonic::Response<super::Database>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabase");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabase",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates the schema of a Cloud Spanner database by
@@ -1267,10 +1531,19 @@ pub mod database_admin_client {
         pub async fn update_database_ddl(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateDatabaseDdlRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/UpdateDatabaseDdl",
@@ -1286,12 +1559,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DropDatabaseRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/DropDatabase");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/DropDatabase",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -1301,12 +1581,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseDdlRequest>,
         ) -> Result<tonic::Response<super::GetDatabaseDdlResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabaseDdl");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabaseDdl",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Sets the access control policy on a database or backup resource.
@@ -1318,14 +1605,26 @@ pub mod database_admin_client {
         /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
         pub async fn set_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::super::super::iam::v1::SetIamPolicyRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/SetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/SetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the access control policy for a database or backup resource.
@@ -1338,14 +1637,26 @@ pub mod database_admin_client {
         /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
         pub async fn get_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::super::super::iam::v1::GetIamPolicyRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/GetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns permissions that the caller has on the specified database or backup
@@ -1360,14 +1671,24 @@ pub mod database_admin_client {
         /// `spanner.backups.list` permission on the containing instance.
         pub async fn test_iam_permissions(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::TestIamPermissionsRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::super::super::super::iam::v1::TestIamPermissionsRequest,
+            >,
         ) -> Result<
-            tonic::Response<super::super::super::super::super::iam::v1::TestIamPermissionsResponse>,
+            tonic::Response<
+                super::super::super::super::super::iam::v1::TestIamPermissionsResponse,
+            >,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/TestIamPermissions",
@@ -1389,13 +1710,23 @@ pub mod database_admin_client {
         pub async fn create_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBackupRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CreateBackup");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/CreateBackup",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Starts copying a Cloud Spanner Backup.
@@ -1413,13 +1744,23 @@ pub mod database_admin_client {
         pub async fn copy_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CopyBackupRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CopyBackup");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/CopyBackup",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets metadata on a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
@@ -1427,12 +1768,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetBackupRequest>,
         ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetBackup");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/GetBackup",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
@@ -1440,12 +1788,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBackupRequest>,
         ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/UpdateBackup");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/UpdateBackup",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
@@ -1453,12 +1808,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBackupRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/DeleteBackup");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/DeleteBackup",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists completed and pending backups.
@@ -1468,12 +1830,19 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupsRequest>,
         ) -> Result<tonic::Response<super::ListBackupsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/ListBackups");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/ListBackups",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Create a new database by restoring from a completed backup. The new
@@ -1496,13 +1865,23 @@ pub mod database_admin_client {
         pub async fn restore_database(
             &mut self,
             request: impl tonic::IntoRequest<super::RestoreDatabaseRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/RestoreDatabase");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.database.v1.DatabaseAdmin/RestoreDatabase",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -1516,10 +1895,19 @@ pub mod database_admin_client {
         pub async fn list_database_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseOperationsRequest>,
-        ) -> Result<tonic::Response<super::ListDatabaseOperationsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::ListDatabaseOperationsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseOperations",
@@ -1539,10 +1927,19 @@ pub mod database_admin_client {
         pub async fn list_backup_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupOperationsRequest>,
-        ) -> Result<tonic::Response<super::ListBackupOperationsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::ListBackupOperationsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListBackupOperations",
@@ -1554,9 +1951,15 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseRolesRequest>,
         ) -> Result<tonic::Response<super::ListDatabaseRolesResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseRoles",

--- a/googleapis/src/google.spanner.admin.database.v1.rs
+++ b/googleapis/src/google.spanner.admin.database.v1.rs
@@ -36,9 +36,7 @@ pub struct EncryptionInfo {
     /// for this database or backup. Regardless of status, data is always encrypted
     /// at rest.
     #[prost(message, optional, tag = "4")]
-    pub encryption_status: ::core::option::Option<
-        super::super::super::super::rpc::Status,
-    >,
+    pub encryption_status: ::core::option::Option<super::super::super::super::rpc::Status>,
     /// Output only. A Cloud KMS key version that is being used to protect the database or
     /// backup.
     #[prost(string, tag = "2")]
@@ -47,17 +45,7 @@ pub struct EncryptionInfo {
 /// Nested message and enum types in `EncryptionInfo`.
 pub mod encryption_info {
     /// Possible encryption types.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Type {
         /// Encryption type was not specified, though data at rest remains encrypted.
@@ -196,17 +184,7 @@ pub struct Backup {
 /// Nested message and enum types in `Backup`.
 pub mod backup {
     /// Indicates the current state of the backup.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum State {
         /// Not specified.
@@ -570,9 +548,7 @@ pub struct ListBackupOperationsResponse {
     /// `operation.metadata.value.progress.start_time` in descending order starting
     /// from the most recently started operation.
     #[prost(message, repeated, tag = "1")]
-    pub operations: ::prost::alloc::vec::Vec<
-        super::super::super::super::longrunning::Operation,
-    >,
+    pub operations: ::prost::alloc::vec::Vec<super::super::super::super::longrunning::Operation>,
     /// `next_page_token` can be sent in a subsequent
     /// \[ListBackupOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListBackupOperations\]
     /// call to fetch more of the matching metadata.
@@ -619,17 +595,7 @@ pub struct CreateBackupEncryptionConfig {
 /// Nested message and enum types in `CreateBackupEncryptionConfig`.
 pub mod create_backup_encryption_config {
     /// Encryption types for the backup.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum EncryptionType {
         /// Unspecified. Do not use.
@@ -656,9 +622,7 @@ pub mod create_backup_encryption_config {
                 EncryptionType::Unspecified => "ENCRYPTION_TYPE_UNSPECIFIED",
                 EncryptionType::UseDatabaseEncryption => "USE_DATABASE_ENCRYPTION",
                 EncryptionType::GoogleDefaultEncryption => "GOOGLE_DEFAULT_ENCRYPTION",
-                EncryptionType::CustomerManagedEncryption => {
-                    "CUSTOMER_MANAGED_ENCRYPTION"
-                }
+                EncryptionType::CustomerManagedEncryption => "CUSTOMER_MANAGED_ENCRYPTION",
             }
         }
     }
@@ -681,17 +645,7 @@ pub struct CopyBackupEncryptionConfig {
 /// Nested message and enum types in `CopyBackupEncryptionConfig`.
 pub mod copy_backup_encryption_config {
     /// Encryption types for the backup.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum EncryptionType {
         /// Unspecified. Do not use.
@@ -715,13 +669,9 @@ pub mod copy_backup_encryption_config {
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 EncryptionType::Unspecified => "ENCRYPTION_TYPE_UNSPECIFIED",
-                EncryptionType::UseConfigDefaultOrBackupEncryption => {
-                    "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"
-                }
+                EncryptionType::UseConfigDefaultOrBackupEncryption => "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION",
                 EncryptionType::GoogleDefaultEncryption => "GOOGLE_DEFAULT_ENCRYPTION",
-                EncryptionType::CustomerManagedEncryption => {
-                    "CUSTOMER_MANAGED_ENCRYPTION"
-                }
+                EncryptionType::CustomerManagedEncryption => "CUSTOMER_MANAGED_ENCRYPTION",
             }
         }
     }
@@ -816,17 +766,7 @@ pub struct Database {
 /// Nested message and enum types in `Database`.
 pub mod database {
     /// Indicates the current state of the database.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum State {
         /// Not specified.
@@ -1122,9 +1062,7 @@ pub struct ListDatabaseOperationsResponse {
     /// \[metadata][google.longrunning.Operation.metadata\] field type
     /// `metadata.type_url` describes the type of the metadata.
     #[prost(message, repeated, tag = "1")]
-    pub operations: ::prost::alloc::vec::Vec<
-        super::super::super::super::longrunning::Operation,
-    >,
+    pub operations: ::prost::alloc::vec::Vec<super::super::super::super::longrunning::Operation>,
     /// `next_page_token` can be sent in a subsequent
     /// \[ListDatabaseOperations][google.spanner.admin.database.v1.DatabaseAdmin.ListDatabaseOperations\]
     /// call to fetch more of the matching metadata.
@@ -1178,10 +1116,7 @@ pub mod restore_database_request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RestoreDatabaseEncryptionConfig {
     /// Required. The encryption type of the restored database.
-    #[prost(
-        enumeration = "restore_database_encryption_config::EncryptionType",
-        tag = "1"
-    )]
+    #[prost(enumeration = "restore_database_encryption_config::EncryptionType", tag = "1")]
     pub encryption_type: i32,
     /// Optional. The Cloud KMS key that will be used to encrypt/decrypt the restored
     /// database. This field should be set only when
@@ -1194,17 +1129,7 @@ pub struct RestoreDatabaseEncryptionConfig {
 /// Nested message and enum types in `RestoreDatabaseEncryptionConfig`.
 pub mod restore_database_encryption_config {
     /// Encryption types for the database to be restored.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum EncryptionType {
         /// Unspecified. Do not use.
@@ -1226,13 +1151,9 @@ pub mod restore_database_encryption_config {
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 EncryptionType::Unspecified => "ENCRYPTION_TYPE_UNSPECIFIED",
-                EncryptionType::UseConfigDefaultOrBackupEncryption => {
-                    "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION"
-                }
+                EncryptionType::UseConfigDefaultOrBackupEncryption => "USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION",
                 EncryptionType::GoogleDefaultEncryption => "GOOGLE_DEFAULT_ENCRYPTION",
-                EncryptionType::CustomerManagedEncryption => {
-                    "CUSTOMER_MANAGED_ENCRYPTION"
-                }
+                EncryptionType::CustomerManagedEncryption => "CUSTOMER_MANAGED_ENCRYPTION",
             }
         }
     }
@@ -1378,8 +1299,8 @@ impl RestoreSourceType {
 /// Generated client implementations.
 pub mod database_admin_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// Cloud Spanner Database Admin API
     ///
     /// The Cloud Spanner Database Admin API can be used to:
@@ -1417,22 +1338,15 @@ pub mod database_admin_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> DatabaseAdminClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> DatabaseAdminClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             DatabaseAdminClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1456,19 +1370,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabasesRequest>,
         ) -> Result<tonic::Response<super::ListDatabasesResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabases",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabases");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -1482,23 +1389,13 @@ pub mod database_admin_client {
         pub async fn create_database(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateDatabaseRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/CreateDatabase",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CreateDatabase");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the state of a Cloud Spanner database.
@@ -1506,19 +1403,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseRequest>,
         ) -> Result<tonic::Response<super::Database>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabase",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabase");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates the schema of a Cloud Spanner database by
@@ -1531,19 +1421,10 @@ pub mod database_admin_client {
         pub async fn update_database_ddl(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateDatabaseDdlRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/UpdateDatabaseDdl",
@@ -1559,19 +1440,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DropDatabaseRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/DropDatabase",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/DropDatabase");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -1581,19 +1455,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseDdlRequest>,
         ) -> Result<tonic::Response<super::GetDatabaseDdlResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabaseDdl",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabaseDdl");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Sets the access control policy on a database or backup resource.
@@ -1605,26 +1472,14 @@ pub mod database_admin_client {
         /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
         pub async fn set_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::super::super::iam::v1::SetIamPolicyRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::SetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/SetIamPolicy",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/SetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the access control policy for a database or backup resource.
@@ -1637,26 +1492,14 @@ pub mod database_admin_client {
         /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
         pub async fn get_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::super::super::iam::v1::GetIamPolicyRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::GetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/GetIamPolicy",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns permissions that the caller has on the specified database or backup
@@ -1671,24 +1514,14 @@ pub mod database_admin_client {
         /// `spanner.backups.list` permission on the containing instance.
         pub async fn test_iam_permissions(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::super::super::iam::v1::TestIamPermissionsRequest,
-            >,
+            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::TestIamPermissionsRequest>,
         ) -> Result<
-            tonic::Response<
-                super::super::super::super::super::iam::v1::TestIamPermissionsResponse,
-            >,
+            tonic::Response<super::super::super::super::super::iam::v1::TestIamPermissionsResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/TestIamPermissions",
@@ -1710,23 +1543,13 @@ pub mod database_admin_client {
         pub async fn create_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBackupRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/CreateBackup",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CreateBackup");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Starts copying a Cloud Spanner Backup.
@@ -1744,23 +1567,13 @@ pub mod database_admin_client {
         pub async fn copy_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CopyBackupRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/CopyBackup",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CopyBackup");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets metadata on a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
@@ -1768,19 +1581,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetBackupRequest>,
         ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/GetBackup",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetBackup");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
@@ -1788,19 +1594,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBackupRequest>,
         ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/UpdateBackup",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/UpdateBackup");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
@@ -1808,19 +1607,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBackupRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/DeleteBackup",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/DeleteBackup");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists completed and pending backups.
@@ -1830,19 +1622,12 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupsRequest>,
         ) -> Result<tonic::Response<super::ListBackupsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/ListBackups",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/ListBackups");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Create a new database by restoring from a completed backup. The new
@@ -1865,23 +1650,13 @@ pub mod database_admin_client {
         pub async fn restore_database(
             &mut self,
             request: impl tonic::IntoRequest<super::RestoreDatabaseRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.database.v1.DatabaseAdmin/RestoreDatabase",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/RestoreDatabase");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -1895,19 +1670,10 @@ pub mod database_admin_client {
         pub async fn list_database_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseOperationsRequest>,
-        ) -> Result<
-            tonic::Response<super::ListDatabaseOperationsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::ListDatabaseOperationsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseOperations",
@@ -1927,19 +1693,10 @@ pub mod database_admin_client {
         pub async fn list_backup_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupOperationsRequest>,
-        ) -> Result<
-            tonic::Response<super::ListBackupOperationsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::ListBackupOperationsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListBackupOperations",
@@ -1951,15 +1708,9 @@ pub mod database_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseRolesRequest>,
         ) -> Result<tonic::Response<super::ListDatabaseRolesResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseRoles",

--- a/googleapis/src/google.spanner.admin.instance.v1.rs
+++ b/googleapis/src/google.spanner.admin.instance.v1.rs
@@ -36,17 +36,7 @@ pub mod replica_info {
     /// Indicates the type of replica.  See the [replica types
     /// documentation](<https://cloud.google.com/spanner/docs/replication#replica_types>)
     /// for more details.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum ReplicaType {
         /// Not specified.
@@ -143,10 +133,7 @@ pub struct InstanceConfig {
     /// as the string:  name + "_" + value  would prove problematic if we were to
     /// allow "_" in a future release.
     #[prost(map = "string, string", tag = "8")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// etag is used for optimistic concurrency control as a way
     /// to help prevent simultaneous updates of a instance config from overwriting
     /// each other. It is strongly suggested that systems make use of the etag in
@@ -174,17 +161,7 @@ pub struct InstanceConfig {
 /// Nested message and enum types in `InstanceConfig`.
 pub mod instance_config {
     /// The type of this configuration.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Type {
         /// Unspecified.
@@ -208,17 +185,7 @@ pub mod instance_config {
         }
     }
     /// Indicates the current state of the instance config.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum State {
         /// Not specified.
@@ -311,10 +278,7 @@ pub struct Instance {
     /// as the string:  name + "_" + value  would prove problematic if we were to
     /// allow "_" in a future release.
     #[prost(map = "string, string", tag = "7")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Deprecated. This field is not populated.
     #[prost(string, repeated, tag = "8")]
     pub endpoint_uris: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
@@ -328,17 +292,7 @@ pub struct Instance {
 /// Nested message and enum types in `Instance`.
 pub mod instance {
     /// Indicates the current state of the instance.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum State {
         /// Not specified.
@@ -564,9 +518,7 @@ pub struct ListInstanceConfigOperationsResponse {
     /// \[metadata][google.longrunning.Operation.metadata\] field type
     /// `metadata.type_url` describes the type of the metadata.
     #[prost(message, repeated, tag = "1")]
-    pub operations: ::prost::alloc::vec::Vec<
-        super::super::super::super::longrunning::Operation,
-    >,
+    pub operations: ::prost::alloc::vec::Vec<super::super::super::super::longrunning::Operation>,
     /// `next_page_token` can be sent in a subsequent
     /// \[ListInstanceConfigOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations\]
     /// call to fetch more of the matching metadata.
@@ -773,8 +725,8 @@ pub struct UpdateInstanceConfigMetadata {
 /// Generated client implementations.
 pub mod instance_admin_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// Cloud Spanner Instance Admin API
     ///
     /// The Cloud Spanner Instance Admin API can be used to create, delete,
@@ -826,22 +778,15 @@ pub mod instance_admin_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InstanceAdminClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InstanceAdminClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             InstanceAdminClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -865,15 +810,9 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstanceConfigsRequest>,
         ) -> Result<tonic::Response<super::ListInstanceConfigsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigs",
@@ -885,15 +824,9 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceConfigRequest>,
         ) -> Result<tonic::Response<super::InstanceConfig>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/GetInstanceConfig",
@@ -944,19 +877,10 @@ pub mod instance_admin_client {
         pub async fn create_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateInstanceConfigRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstanceConfig",
@@ -1010,19 +934,10 @@ pub mod instance_admin_client {
         pub async fn update_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateInstanceConfigRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstanceConfig",
@@ -1041,15 +956,9 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteInstanceConfigRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstanceConfig",
@@ -1070,19 +979,10 @@ pub mod instance_admin_client {
         pub async fn list_instance_config_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstanceConfigOperationsRequest>,
-        ) -> Result<
-            tonic::Response<super::ListInstanceConfigOperationsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::ListInstanceConfigOperationsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigOperations",
@@ -1094,19 +994,12 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstancesRequest>,
         ) -> Result<tonic::Response<super::ListInstancesResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstances",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/ListInstances");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets information about a particular instance.
@@ -1114,19 +1007,12 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceRequest>,
         ) -> Result<tonic::Response<super::Instance>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.instance.v1.InstanceAdmin/GetInstance",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/GetInstance");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates an instance and begins preparing it to begin serving. The
@@ -1166,23 +1052,13 @@ pub mod instance_admin_client {
         pub async fn create_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateInstanceRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstance",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstance");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an instance, and begins allocating or releasing resources
@@ -1228,23 +1104,13 @@ pub mod instance_admin_client {
         pub async fn update_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateInstanceRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::longrunning::Operation>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstance",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstance");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes an instance.
@@ -1262,19 +1128,12 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteInstanceRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstance",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstance");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Sets the access control policy on an instance resource. Replaces any
@@ -1284,26 +1143,14 @@ pub mod instance_admin_client {
         /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
         pub async fn set_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::super::super::iam::v1::SetIamPolicyRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::SetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.instance.v1.InstanceAdmin/SetIamPolicy",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/SetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the access control policy for an instance resource. Returns an empty
@@ -1313,26 +1160,14 @@ pub mod instance_admin_client {
         /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
         pub async fn get_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::super::super::iam::v1::GetIamPolicyRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::GetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.admin.instance.v1.InstanceAdmin/GetIamPolicy",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/GetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns permissions that the caller has on the specified instance resource.
@@ -1343,24 +1178,14 @@ pub mod instance_admin_client {
         /// empty set of permissions.
         pub async fn test_iam_permissions(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::super::super::iam::v1::TestIamPermissionsRequest,
-            >,
+            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::TestIamPermissionsRequest>,
         ) -> Result<
-            tonic::Response<
-                super::super::super::super::super::iam::v1::TestIamPermissionsResponse,
-            >,
+            tonic::Response<super::super::super::super::super::iam::v1::TestIamPermissionsResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/TestIamPermissions",

--- a/googleapis/src/google.spanner.admin.instance.v1.rs
+++ b/googleapis/src/google.spanner.admin.instance.v1.rs
@@ -1,4 +1,22 @@
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+/// Encapsulates progress related information for a Cloud Spanner long
+/// running instance operations.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OperationProgress {
+    /// Percent completion of the operation.
+    /// Values are between 0 and 100 inclusive.
+    #[prost(int32, tag = "1")]
+    pub progress_percent: i32,
+    /// Time the request was received.
+    #[prost(message, optional, tag = "2")]
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
+    /// If set, the time at which this operation failed or was completed
+    /// successfully.
+    #[prost(message, optional, tag = "3")]
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReplicaInfo {
     /// The location of the serving resources, e.g. "us-central1".
     #[prost(string, tag = "1")]
@@ -18,7 +36,17 @@ pub mod replica_info {
     /// Indicates the type of replica.  See the [replica types
     /// documentation](<https://cloud.google.com/spanner/docs/replication#replica_types>)
     /// for more details.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum ReplicaType {
         /// Not specified.
@@ -47,10 +75,25 @@ pub mod replica_info {
         /// * Participate in leader election but are not eligible to become leader.
         Witness = 3,
     }
+    impl ReplicaType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                ReplicaType::TypeUnspecified => "TYPE_UNSPECIFIED",
+                ReplicaType::ReadWrite => "READ_WRITE",
+                ReplicaType::ReadOnly => "READ_ONLY",
+                ReplicaType::Witness => "WITNESS",
+            }
+        }
+    }
 }
 /// A possible configuration for a Cloud Spanner instance. Configurations
 /// define the geographic placement of nodes and their replication.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstanceConfig {
     /// A unique identifier for the instance configuration.  Values
     /// are of the form
@@ -60,17 +103,149 @@ pub struct InstanceConfig {
     /// The name of this instance configuration as it appears in UIs.
     #[prost(string, tag = "2")]
     pub display_name: ::prost::alloc::string::String,
+    /// Output only. Whether this instance config is a Google or User Managed
+    /// Configuration.
+    #[prost(enumeration = "instance_config::Type", tag = "5")]
+    pub config_type: i32,
     /// The geographic placement of nodes in this instance configuration and their
     /// replication properties.
     #[prost(message, repeated, tag = "3")]
     pub replicas: ::prost::alloc::vec::Vec<ReplicaInfo>,
+    /// Output only. The available optional replicas to choose from for user
+    /// managed configurations. Populated for Google managed configurations.
+    #[prost(message, repeated, tag = "6")]
+    pub optional_replicas: ::prost::alloc::vec::Vec<ReplicaInfo>,
+    /// Base configuration name, e.g. projects/<project_name>/instanceConfigs/nam3,
+    /// based on which this configuration is created. Only set for user managed
+    /// configurations. `base_config` must refer to a configuration of type
+    /// GOOGLE_MANAGED in the same project as this configuration.
+    #[prost(string, tag = "7")]
+    pub base_config: ::prost::alloc::string::String,
+    /// Cloud Labels are a flexible and lightweight mechanism for organizing cloud
+    /// resources into groups that reflect a customer's organizational needs and
+    /// deployment strategies. Cloud Labels can be used to filter collections of
+    /// resources. They can be used to control how resource metrics are aggregated.
+    /// And they can be used as arguments to policy management rules (e.g. route,
+    /// firewall, load balancing, etc.).
+    ///
+    ///   * Label keys must be between 1 and 63 characters long and must conform to
+    ///     the following regular expression: `\[a-z][a-z0-9_-\]{0,62}`.
+    ///   * Label values must be between 0 and 63 characters long and must conform
+    ///     to the regular expression `\[a-z0-9_-\]{0,63}`.
+    ///   * No more than 64 labels can be associated with a given resource.
+    ///
+    /// See <https://goo.gl/xmQnxf> for more information on and examples of labels.
+    ///
+    /// If you plan to use labels in your own code, please note that additional
+    /// characters may be allowed in the future. Therefore, you are advised to use
+    /// an internal label representation, such as JSON, which doesn't rely upon
+    /// specific characters being disallowed.  For example, representing labels
+    /// as the string:  name + "_" + value  would prove problematic if we were to
+    /// allow "_" in a future release.
+    #[prost(map = "string, string", tag = "8")]
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
+    /// etag is used for optimistic concurrency control as a way
+    /// to help prevent simultaneous updates of a instance config from overwriting
+    /// each other. It is strongly suggested that systems make use of the etag in
+    /// the read-modify-write cycle to perform instance config updates in order to
+    /// avoid race conditions: An etag is returned in the response which contains
+    /// instance configs, and systems are expected to put that etag in the request
+    /// to update instance config to ensure that their change will be applied to
+    /// the same version of the instance config.
+    /// If no etag is provided in the call to update instance config, then the
+    /// existing instance config is overwritten blindly.
+    #[prost(string, tag = "9")]
+    pub etag: ::prost::alloc::string::String,
     /// Allowed values of the "default_leader" schema option for databases in
     /// instances that use this instance configuration.
     #[prost(string, repeated, tag = "4")]
     pub leader_options: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Output only. If true, the instance config is being created or updated. If
+    /// false, there are no ongoing operations for the instance config.
+    #[prost(bool, tag = "10")]
+    pub reconciling: bool,
+    /// Output only. The current instance config state.
+    #[prost(enumeration = "instance_config::State", tag = "11")]
+    pub state: i32,
+}
+/// Nested message and enum types in `InstanceConfig`.
+pub mod instance_config {
+    /// The type of this configuration.
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum Type {
+        /// Unspecified.
+        Unspecified = 0,
+        /// Google managed configuration.
+        GoogleManaged = 1,
+        /// User managed configuration.
+        UserManaged = 2,
+    }
+    impl Type {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Type::Unspecified => "TYPE_UNSPECIFIED",
+                Type::GoogleManaged => "GOOGLE_MANAGED",
+                Type::UserManaged => "USER_MANAGED",
+            }
+        }
+    }
+    /// Indicates the current state of the instance config.
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum State {
+        /// Not specified.
+        Unspecified = 0,
+        /// The instance config is still being created.
+        Creating = 1,
+        /// The instance config is fully created and ready to be used to create
+        /// instances.
+        Ready = 2,
+    }
+    impl State {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                State::Unspecified => "STATE_UNSPECIFIED",
+                State::Creating => "CREATING",
+                State::Ready => "READY",
+            }
+        }
+    }
 }
 /// An isolated set of Cloud Spanner resources on which databases can be hosted.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Instance {
     /// Required. A unique identifier for the instance, which cannot be changed
     /// after the instance is created. Values are of the form
@@ -108,10 +283,10 @@ pub struct Instance {
     #[prost(int32, tag = "9")]
     pub processing_units: i32,
     /// Output only. The current instance state. For
-    /// \[CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance\], the state must be
-    /// either omitted or set to `CREATING`. For
-    /// \[UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance\], the state must be
-    /// either omitted or set to `READY`.
+    /// \[CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance\],
+    /// the state must be either omitted or set to `CREATING`. For
+    /// \[UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance\],
+    /// the state must be either omitted or set to `READY`.
     #[prost(enumeration = "instance::State", tag = "6")]
     pub state: i32,
     /// Cloud Labels are a flexible and lightweight mechanism for organizing cloud
@@ -121,11 +296,11 @@ pub struct Instance {
     /// And they can be used as arguments to policy management rules (e.g. route,
     /// firewall, load balancing, etc.).
     ///
-    ///  * Label keys must be between 1 and 63 characters long and must conform to
-    ///    the following regular expression: `\[a-z][a-z0-9_-\]{0,62}`.
-    ///  * Label values must be between 0 and 63 characters long and must conform
-    ///    to the regular expression `\[a-z0-9_-\]{0,63}`.
-    ///  * No more than 64 labels can be associated with a given resource.
+    ///   * Label keys must be between 1 and 63 characters long and must conform to
+    ///     the following regular expression: `\[a-z][a-z0-9_-\]{0,62}`.
+    ///   * Label values must be between 0 and 63 characters long and must conform
+    ///     to the regular expression `\[a-z0-9_-\]{0,63}`.
+    ///   * No more than 64 labels can be associated with a given resource.
     ///
     /// See <https://goo.gl/xmQnxf> for more information on and examples of labels.
     ///
@@ -136,7 +311,10 @@ pub struct Instance {
     /// as the string:  name + "_" + value  would prove problematic if we were to
     /// allow "_" in a future release.
     #[prost(map = "string, string", tag = "7")]
-    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// Deprecated. This field is not populated.
     #[prost(string, repeated, tag = "8")]
     pub endpoint_uris: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
@@ -150,7 +328,17 @@ pub struct Instance {
 /// Nested message and enum types in `Instance`.
 pub mod instance {
     /// Indicates the current state of the instance.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum State {
         /// Not specified.
@@ -163,9 +351,24 @@ pub mod instance {
         /// creating databases.
         Ready = 2,
     }
+    impl State {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                State::Unspecified => "STATE_UNSPECIFIED",
+                State::Creating => "CREATING",
+                State::Ready => "READY",
+            }
+        }
+    }
 }
-/// The request for \[ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+/// The request for
+/// \[ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListInstanceConfigsRequest {
     /// Required. The name of the project for which a list of supported instance
     /// configurations is requested. Values are of the form
@@ -178,46 +381,218 @@ pub struct ListInstanceConfigsRequest {
     pub page_size: i32,
     /// If non-empty, `page_token` should contain a
     /// \[next_page_token][google.spanner.admin.instance.v1.ListInstanceConfigsResponse.next_page_token\]
-    /// from a previous \[ListInstanceConfigsResponse][google.spanner.admin.instance.v1.ListInstanceConfigsResponse\].
+    /// from a previous
+    /// \[ListInstanceConfigsResponse][google.spanner.admin.instance.v1.ListInstanceConfigsResponse\].
     #[prost(string, tag = "3")]
     pub page_token: ::prost::alloc::string::String,
 }
-/// The response for \[ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+/// The response for
+/// \[ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListInstanceConfigsResponse {
     /// The list of requested instance configurations.
     #[prost(message, repeated, tag = "1")]
     pub instance_configs: ::prost::alloc::vec::Vec<InstanceConfig>,
     /// `next_page_token` can be sent in a subsequent
-    /// \[ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs\] call to
-    /// fetch more of the matching instance configurations.
+    /// \[ListInstanceConfigs][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigs\]
+    /// call to fetch more of the matching instance configurations.
     #[prost(string, tag = "2")]
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// The request for
 /// \[GetInstanceConfigRequest][google.spanner.admin.instance.v1.InstanceAdmin.GetInstanceConfig\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetInstanceConfigRequest {
     /// Required. The name of the requested instance configuration. Values are of
     /// the form `projects/<project>/instanceConfigs/<config>`.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
-/// The request for \[GetInstance][google.spanner.admin.instance.v1.InstanceAdmin.GetInstance\].
+/// The request for
+/// \[CreateInstanceConfigRequest][InstanceAdmin.CreateInstanceConfigRequest\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateInstanceConfigRequest {
+    /// Required. The name of the project in which to create the instance config.
+    /// Values are of the form `projects/<project>`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// Required. The ID of the instance config to create.  Valid identifiers are
+    /// of the form `custom-\[-a-z0-9]*[a-z0-9\]` and must be between 2 and 64
+    /// characters in length. The `custom-` prefix is required to avoid name
+    /// conflicts with Google managed configurations.
+    #[prost(string, tag = "2")]
+    pub instance_config_id: ::prost::alloc::string::String,
+    /// Required. The InstanceConfig proto of the configuration to create.
+    /// instance_config.name must be
+    /// `<parent>/instanceConfigs/<instance_config_id>`.
+    /// instance_config.base_config must be a Google managed configuration name,
+    /// e.g. <parent>/instanceConfigs/us-east1, <parent>/instanceConfigs/nam3.
+    #[prost(message, optional, tag = "3")]
+    pub instance_config: ::core::option::Option<InstanceConfig>,
+    /// An option to validate, but not actually execute, a request,
+    /// and provide the same response.
+    #[prost(bool, tag = "4")]
+    pub validate_only: bool,
+}
+/// The request for
+/// \[UpdateInstanceConfigRequest][InstanceAdmin.UpdateInstanceConfigRequest\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateInstanceConfigRequest {
+    /// Required. The user instance config to update, which must always include the
+    /// instance config name. Otherwise, only fields mentioned in
+    /// \[update_mask][google.spanner.admin.instance.v1.UpdateInstanceConfigRequest.update_mask\]
+    /// need be included. To prevent conflicts of concurrent updates,
+    /// \[etag][google.spanner.admin.instance.v1.InstanceConfig.reconciling\] can
+    /// be used.
+    #[prost(message, optional, tag = "1")]
+    pub instance_config: ::core::option::Option<InstanceConfig>,
+    /// Required. A mask specifying which fields in
+    /// \[InstanceConfig][google.spanner.admin.instance.v1.InstanceConfig\] should be
+    /// updated. The field mask must always be specified; this prevents any future
+    /// fields in \[InstanceConfig][google.spanner.admin.instance.v1.InstanceConfig\]
+    /// from being erased accidentally by clients that do not know about them. Only
+    /// display_name and labels can be updated.
+    #[prost(message, optional, tag = "2")]
+    pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
+    /// An option to validate, but not actually execute, a request,
+    /// and provide the same response.
+    #[prost(bool, tag = "3")]
+    pub validate_only: bool,
+}
+/// The request for
+/// \[DeleteInstanceConfigRequest][InstanceAdmin.DeleteInstanceConfigRequest\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteInstanceConfigRequest {
+    /// Required. The name of the instance configuration to be deleted.
+    /// Values are of the form
+    /// `projects/<project>/instanceConfigs/<instance_config>`
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Used for optimistic concurrency control as a way to help prevent
+    /// simultaneous deletes of an instance config from overwriting each
+    /// other. If not empty, the API
+    /// only deletes the instance config when the etag provided matches the current
+    /// status of the requested instance config. Otherwise, deletes the instance
+    /// config without checking the current status of the requested instance
+    /// config.
+    #[prost(string, tag = "2")]
+    pub etag: ::prost::alloc::string::String,
+    /// An option to validate, but not actually execute, a request,
+    /// and provide the same response.
+    #[prost(bool, tag = "3")]
+    pub validate_only: bool,
+}
+/// The request for
+/// \[ListInstanceConfigOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListInstanceConfigOperationsRequest {
+    /// Required. The project of the instance config operations.
+    /// Values are of the form `projects/<project>`.
+    #[prost(string, tag = "1")]
+    pub parent: ::prost::alloc::string::String,
+    /// An expression that filters the list of returned operations.
+    ///
+    /// A filter expression consists of a field name, a
+    /// comparison operator, and a value for filtering.
+    /// The value must be a string, a number, or a boolean. The comparison operator
+    /// must be one of: `<`, `>`, `<=`, `>=`, `!=`, `=`, or `:`.
+    /// Colon `:` is the contains operator. Filter rules are not case sensitive.
+    ///
+    /// The following fields in the \[Operation][google.longrunning.Operation\]
+    /// are eligible for filtering:
+    ///
+    ///    * `name` - The name of the long-running operation
+    ///    * `done` - False if the operation is in progress, else true.
+    ///    * `metadata.@type` - the type of metadata. For example, the type string
+    ///       for
+    ///       \[CreateInstanceConfigMetadata][google.spanner.admin.instance.v1.CreateInstanceConfigMetadata\]
+    ///       is
+    ///       `type.googleapis.com/google.spanner.admin.instance.v1.CreateInstanceConfigMetadata`.
+    ///    * `metadata.<field_name>` - any field in metadata.value.
+    ///       `metadata.@type` must be specified first, if filtering on metadata
+    ///       fields.
+    ///    * `error` - Error associated with the long-running operation.
+    ///    * `response.@type` - the type of response.
+    ///    * `response.<field_name>` - any field in response.value.
+    ///
+    /// You can combine multiple expressions by enclosing each expression in
+    /// parentheses. By default, expressions are combined with AND logic. However,
+    /// you can specify AND, OR, and NOT logic explicitly.
+    ///
+    /// Here are a few examples:
+    ///
+    ///    * `done:true` - The operation is complete.
+    ///    * `(metadata.@type=` \
+    ///      `type.googleapis.com/google.spanner.admin.instance.v1.CreateInstanceConfigMetadata)
+    ///      AND` \
+    ///      `(metadata.instance_config.name:custom-config) AND` \
+    ///      `(metadata.progress.start_time < \"2021-03-28T14:50:00Z\") AND` \
+    ///      `(error:*)` - Return operations where:
+    ///      * The operation's metadata type is
+    ///      \[CreateInstanceConfigMetadata][google.spanner.admin.instance.v1.CreateInstanceConfigMetadata\].
+    ///      * The instance config name contains "custom-config".
+    ///      * The operation started before 2021-03-28T14:50:00Z.
+    ///      * The operation resulted in an error.
+    #[prost(string, tag = "2")]
+    pub filter: ::prost::alloc::string::String,
+    /// Number of operations to be returned in the response. If 0 or
+    /// less, defaults to the server's maximum allowed page size.
+    #[prost(int32, tag = "3")]
+    pub page_size: i32,
+    /// If non-empty, `page_token` should contain a
+    /// \[next_page_token][google.spanner.admin.instance.v1.ListInstanceConfigOperationsResponse.next_page_token\]
+    /// from a previous
+    /// \[ListInstanceConfigOperationsResponse][google.spanner.admin.instance.v1.ListInstanceConfigOperationsResponse\]
+    /// to the same `parent` and with the same `filter`.
+    #[prost(string, tag = "4")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// The response for
+/// \[ListInstanceConfigOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListInstanceConfigOperationsResponse {
+    /// The list of matching instance config [long-running
+    /// operations]\[google.longrunning.Operation\]. Each operation's name will be
+    /// prefixed by the instance config's name. The operation's
+    /// \[metadata][google.longrunning.Operation.metadata\] field type
+    /// `metadata.type_url` describes the type of the metadata.
+    #[prost(message, repeated, tag = "1")]
+    pub operations: ::prost::alloc::vec::Vec<
+        super::super::super::super::longrunning::Operation,
+    >,
+    /// `next_page_token` can be sent in a subsequent
+    /// \[ListInstanceConfigOperations][google.spanner.admin.instance.v1.InstanceAdmin.ListInstanceConfigOperations\]
+    /// call to fetch more of the matching metadata.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+/// The request for
+/// \[GetInstance][google.spanner.admin.instance.v1.InstanceAdmin.GetInstance\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetInstanceRequest {
     /// Required. The name of the requested instance. Values are of the form
     /// `projects/<project>/instances/<instance>`.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    /// If field_mask is present, specifies the subset of \[Instance][google.spanner.admin.instance.v1.Instance\] fields that
-    /// should be returned.
-    /// If absent, all \[Instance][google.spanner.admin.instance.v1.Instance\] fields are returned.
+    /// If field_mask is present, specifies the subset of
+    /// \[Instance][google.spanner.admin.instance.v1.Instance\] fields that should be
+    /// returned. If absent, all
+    /// \[Instance][google.spanner.admin.instance.v1.Instance\] fields are returned.
     #[prost(message, optional, tag = "2")]
     pub field_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
-/// The request for \[CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+/// The request for
+/// \[CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateInstanceRequest {
     /// Required. The name of the project in which to create the instance. Values
     /// are of the form `projects/<project>`.
@@ -233,8 +608,10 @@ pub struct CreateInstanceRequest {
     #[prost(message, optional, tag = "3")]
     pub instance: ::core::option::Option<Instance>,
 }
-/// The request for \[ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+/// The request for
+/// \[ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListInstancesRequest {
     /// Required. The name of the project for which a list of instances is
     /// requested. Values are of the form `projects/<project>`.
@@ -245,60 +622,70 @@ pub struct ListInstancesRequest {
     #[prost(int32, tag = "2")]
     pub page_size: i32,
     /// If non-empty, `page_token` should contain a
-    /// \[next_page_token][google.spanner.admin.instance.v1.ListInstancesResponse.next_page_token\] from a
-    /// previous \[ListInstancesResponse][google.spanner.admin.instance.v1.ListInstancesResponse\].
+    /// \[next_page_token][google.spanner.admin.instance.v1.ListInstancesResponse.next_page_token\]
+    /// from a previous
+    /// \[ListInstancesResponse][google.spanner.admin.instance.v1.ListInstancesResponse\].
     #[prost(string, tag = "3")]
     pub page_token: ::prost::alloc::string::String,
     /// An expression for filtering the results of the request. Filter rules are
     /// case insensitive. The fields eligible for filtering are:
     ///
-    ///   * `name`
-    ///   * `display_name`
-    ///   * `labels.key` where key is the name of a label
+    ///    * `name`
+    ///    * `display_name`
+    ///    * `labels.key` where key is the name of a label
     ///
     /// Some examples of using filters are:
     ///
-    ///   * `name:*` --> The instance has a name.
-    ///   * `name:Howl` --> The instance's name contains the string "howl".
-    ///   * `name:HOWL` --> Equivalent to above.
-    ///   * `NAME:howl` --> Equivalent to above.
-    ///   * `labels.env:*` --> The instance has the label "env".
-    ///   * `labels.env:dev` --> The instance has the label "env" and the value of
-    ///                        the label contains the string "dev".
-    ///   * `name:howl labels.env:dev` --> The instance's name contains "howl" and
-    ///                                  it has the label "env" with its value
-    ///                                  containing "dev".
+    ///    * `name:*` --> The instance has a name.
+    ///    * `name:Howl` --> The instance's name contains the string "howl".
+    ///    * `name:HOWL` --> Equivalent to above.
+    ///    * `NAME:howl` --> Equivalent to above.
+    ///    * `labels.env:*` --> The instance has the label "env".
+    ///    * `labels.env:dev` --> The instance has the label "env" and the value of
+    ///                         the label contains the string "dev".
+    ///    * `name:howl labels.env:dev` --> The instance's name contains "howl" and
+    ///                                   it has the label "env" with its value
+    ///                                   containing "dev".
     #[prost(string, tag = "4")]
     pub filter: ::prost::alloc::string::String,
 }
-/// The response for \[ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+/// The response for
+/// \[ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListInstancesResponse {
     /// The list of requested instances.
     #[prost(message, repeated, tag = "1")]
     pub instances: ::prost::alloc::vec::Vec<Instance>,
     /// `next_page_token` can be sent in a subsequent
-    /// \[ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances\] call to fetch more
-    /// of the matching instances.
+    /// \[ListInstances][google.spanner.admin.instance.v1.InstanceAdmin.ListInstances\]
+    /// call to fetch more of the matching instances.
     #[prost(string, tag = "2")]
     pub next_page_token: ::prost::alloc::string::String,
 }
-/// The request for \[UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance\].
+/// The request for
+/// \[UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstanceRequest {
     /// Required. The instance to update, which must always include the instance
-    /// name.  Otherwise, only fields mentioned in \[field_mask][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask\] need be included.
+    /// name.  Otherwise, only fields mentioned in
+    /// \[field_mask][google.spanner.admin.instance.v1.UpdateInstanceRequest.field_mask\]
+    /// need be included.
     #[prost(message, optional, tag = "1")]
     pub instance: ::core::option::Option<Instance>,
-    /// Required. A mask specifying which fields in \[Instance][google.spanner.admin.instance.v1.Instance\] should be updated.
+    /// Required. A mask specifying which fields in
+    /// \[Instance][google.spanner.admin.instance.v1.Instance\] should be updated.
     /// The field mask must always be specified; this prevents any future fields in
-    /// \[Instance][google.spanner.admin.instance.v1.Instance\] from being erased accidentally by clients that do not know
-    /// about them.
+    /// \[Instance][google.spanner.admin.instance.v1.Instance\] from being erased
+    /// accidentally by clients that do not know about them.
     #[prost(message, optional, tag = "2")]
     pub field_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
-/// The request for \[DeleteInstance][google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstance\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+/// The request for
+/// \[DeleteInstance][google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstance\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteInstanceRequest {
     /// Required. The name of the instance to be deleted. Values are of the form
     /// `projects/<project>/instances/<instance>`
@@ -307,14 +694,15 @@ pub struct DeleteInstanceRequest {
 }
 /// Metadata type for the operation returned by
 /// \[CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateInstanceMetadata {
     /// The instance being created.
     #[prost(message, optional, tag = "1")]
     pub instance: ::core::option::Option<Instance>,
     /// The time at which the
-    /// \[CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance\] request was
-    /// received.
+    /// \[CreateInstance][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance\]
+    /// request was received.
     #[prost(message, optional, tag = "2")]
     pub start_time: ::core::option::Option<::prost_types::Timestamp>,
     /// The time at which this operation was cancelled. If set, this operation is
@@ -328,12 +716,14 @@ pub struct CreateInstanceMetadata {
 }
 /// Metadata type for the operation returned by
 /// \[UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateInstanceMetadata {
     /// The desired end state of the update.
     #[prost(message, optional, tag = "1")]
     pub instance: ::core::option::Option<Instance>,
-    /// The time at which \[UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance\]
+    /// The time at which
+    /// \[UpdateInstance][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance\]
     /// request was received.
     #[prost(message, optional, tag = "2")]
     pub start_time: ::core::option::Option<::prost_types::Timestamp>,
@@ -346,10 +736,45 @@ pub struct UpdateInstanceMetadata {
     #[prost(message, optional, tag = "4")]
     pub end_time: ::core::option::Option<::prost_types::Timestamp>,
 }
+/// Metadata type for the operation returned by
+/// \[CreateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateInstanceConfigMetadata {
+    /// The target instance config end state.
+    #[prost(message, optional, tag = "1")]
+    pub instance_config: ::core::option::Option<InstanceConfig>,
+    /// The progress of the
+    /// \[CreateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.CreateInstanceConfig\]
+    /// operation.
+    #[prost(message, optional, tag = "2")]
+    pub progress: ::core::option::Option<OperationProgress>,
+    /// The time at which this operation was cancelled.
+    #[prost(message, optional, tag = "3")]
+    pub cancel_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+/// Metadata type for the operation returned by
+/// \[UpdateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig\].
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateInstanceConfigMetadata {
+    /// The desired instance config after updating.
+    #[prost(message, optional, tag = "1")]
+    pub instance_config: ::core::option::Option<InstanceConfig>,
+    /// The progress of the
+    /// \[UpdateInstanceConfig][google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstanceConfig\]
+    /// operation.
+    #[prost(message, optional, tag = "2")]
+    pub progress: ::core::option::Option<OperationProgress>,
+    /// The time at which this operation was cancelled.
+    #[prost(message, optional, tag = "3")]
+    pub cancel_time: ::core::option::Option<::prost_types::Timestamp>,
+}
 /// Generated client implementations.
 pub mod instance_admin_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Cloud Spanner Instance Admin API
     ///
     /// The Cloud Spanner Instance Admin API can be used to create, delete,
@@ -397,31 +822,42 @@ pub mod instance_admin_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InstanceAdminClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InstanceAdminClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             InstanceAdminClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Lists the supported instance configurations for a given project.
@@ -429,9 +865,15 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstanceConfigsRequest>,
         ) -> Result<tonic::Response<super::ListInstanceConfigsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigs",
@@ -443,12 +885,207 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceConfigRequest>,
         ) -> Result<tonic::Response<super::InstanceConfig>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/GetInstanceConfig",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Creates an instance config and begins preparing it to be used. The
+        /// returned [long-running operation][google.longrunning.Operation]
+        /// can be used to track the progress of preparing the new
+        /// instance config. The instance config name is assigned by the caller. If the
+        /// named instance config already exists, `CreateInstanceConfig` returns
+        /// `ALREADY_EXISTS`.
+        ///
+        /// Immediately after the request returns:
+        ///
+        ///   * The instance config is readable via the API, with all requested
+        ///     attributes. The instance config's
+        ///     [reconciling][google.spanner.admin.instance.v1.InstanceConfig.reconciling]
+        ///     field is set to true. Its state is `CREATING`.
+        ///
+        /// While the operation is pending:
+        ///
+        ///   * Cancelling the operation renders the instance config immediately
+        ///     unreadable via the API.
+        ///   * Except for deleting the creating resource, all other attempts to modify
+        ///     the instance config are rejected.
+        ///
+        /// Upon completion of the returned operation:
+        ///
+        ///   * Instances can be created using the instance configuration.
+        ///   * The instance config's
+        ///   [reconciling][google.spanner.admin.instance.v1.InstanceConfig.reconciling]
+        ///   field becomes false. Its state becomes `READY`.
+        ///
+        /// The returned [long-running operation][google.longrunning.Operation] will
+        /// have a name of the format
+        /// `<instance_config_name>/operations/<operation_id>` and can be used to track
+        /// creation of the instance config. The
+        /// [metadata][google.longrunning.Operation.metadata] field type is
+        /// [CreateInstanceConfigMetadata][google.spanner.admin.instance.v1.CreateInstanceConfigMetadata].
+        /// The [response][google.longrunning.Operation.response] field type is
+        /// [InstanceConfig][google.spanner.admin.instance.v1.InstanceConfig], if
+        /// successful.
+        ///
+        /// Authorization requires `spanner.instanceConfigs.create` permission on
+        /// the resource
+        /// [parent][google.spanner.admin.instance.v1.CreateInstanceConfigRequest.parent].
+        pub async fn create_instance_config(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CreateInstanceConfigRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstanceConfig",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Updates an instance config. The returned
+        /// [long-running operation][google.longrunning.Operation] can be used to track
+        /// the progress of updating the instance. If the named instance config does
+        /// not exist, returns `NOT_FOUND`.
+        ///
+        /// Only user managed configurations can be updated.
+        ///
+        /// Immediately after the request returns:
+        ///
+        ///   * The instance config's
+        ///     [reconciling][google.spanner.admin.instance.v1.InstanceConfig.reconciling]
+        ///     field is set to true.
+        ///
+        /// While the operation is pending:
+        ///
+        ///   * Cancelling the operation sets its metadata's
+        ///     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceConfigMetadata.cancel_time].
+        ///     The operation is guaranteed to succeed at undoing all changes, after
+        ///     which point it terminates with a `CANCELLED` status.
+        ///   * All other attempts to modify the instance config are rejected.
+        ///   * Reading the instance config via the API continues to give the
+        ///     pre-request values.
+        ///
+        /// Upon completion of the returned operation:
+        ///
+        ///   * Creating instances using the instance configuration uses the new
+        ///     values.
+        ///   * The instance config's new values are readable via the API.
+        ///   * The instance config's
+        ///   [reconciling][google.spanner.admin.instance.v1.InstanceConfig.reconciling]
+        ///   field becomes false.
+        ///
+        /// The returned [long-running operation][google.longrunning.Operation] will
+        /// have a name of the format
+        /// `<instance_config_name>/operations/<operation_id>` and can be used to track
+        /// the instance config modification.  The
+        /// [metadata][google.longrunning.Operation.metadata] field type is
+        /// [UpdateInstanceConfigMetadata][google.spanner.admin.instance.v1.UpdateInstanceConfigMetadata].
+        /// The [response][google.longrunning.Operation.response] field type is
+        /// [InstanceConfig][google.spanner.admin.instance.v1.InstanceConfig], if
+        /// successful.
+        ///
+        /// Authorization requires `spanner.instanceConfigs.update` permission on
+        /// the resource [name][google.spanner.admin.instance.v1.InstanceConfig.name].
+        pub async fn update_instance_config(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateInstanceConfigRequest>,
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstanceConfig",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Deletes the instance config. Deletion is only allowed when no
+        /// instances are using the configuration. If any instances are using
+        /// the config, returns `FAILED_PRECONDITION`.
+        ///
+        /// Only user managed configurations can be deleted.
+        ///
+        /// Authorization requires `spanner.instanceConfigs.delete` permission on
+        /// the resource [name][google.spanner.admin.instance.v1.InstanceConfig.name].
+        pub async fn delete_instance_config(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteInstanceConfigRequest>,
+        ) -> Result<tonic::Response<()>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstanceConfig",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Lists the user-managed instance config [long-running
+        /// operations][google.longrunning.Operation] in the given project. An instance
+        /// config operation has a name of the form
+        /// `projects/<project>/instanceConfigs/<instance_config>/operations/<operation>`.
+        /// The long-running operation
+        /// [metadata][google.longrunning.Operation.metadata] field type
+        /// `metadata.type_url` describes the type of the metadata. Operations returned
+        /// include those that have completed/failed/canceled within the last 7 days,
+        /// and pending operations. Operations returned are ordered by
+        /// `operation.metadata.value.start_time` in descending order starting
+        /// from the most recently started operation.
+        pub async fn list_instance_config_operations(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ListInstanceConfigOperationsRequest>,
+        ) -> Result<
+            tonic::Response<super::ListInstanceConfigOperationsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigOperations",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -457,12 +1094,19 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstancesRequest>,
         ) -> Result<tonic::Response<super::ListInstancesResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/ListInstances");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstances",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets information about a particular instance.
@@ -470,12 +1114,19 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceRequest>,
         ) -> Result<tonic::Response<super::Instance>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/GetInstance");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/GetInstance",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates an instance and begins preparing it to begin serving. The
@@ -515,13 +1166,23 @@ pub mod instance_admin_client {
         pub async fn create_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateInstanceRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstance");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstance",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an instance, and begins allocating or releasing resources
@@ -538,9 +1199,9 @@ pub mod instance_admin_client {
         /// Until completion of the returned operation:
         ///
         ///   * Cancelling the operation sets its metadata's
-        ///     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time], and begins
-        ///     restoring resources to their pre-request values. The operation
-        ///     is guaranteed to succeed at undoing all resource changes,
+        ///     [cancel_time][google.spanner.admin.instance.v1.UpdateInstanceMetadata.cancel_time],
+        ///     and begins restoring resources to their pre-request values. The
+        ///     operation is guaranteed to succeed at undoing all resource changes,
         ///     after which point it terminates with a `CANCELLED` status.
         ///   * All other attempts to modify the instance are rejected.
         ///   * Reading the instance via the API continues to give the pre-request
@@ -567,13 +1228,23 @@ pub mod instance_admin_client {
         pub async fn update_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateInstanceRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstance");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstance",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes an instance.
@@ -591,12 +1262,19 @@ pub mod instance_admin_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteInstanceRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstance");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstance",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Sets the access control policy on an instance resource. Replaces any
@@ -606,14 +1284,26 @@ pub mod instance_admin_client {
         /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
         pub async fn set_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::super::super::iam::v1::SetIamPolicyRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/SetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/SetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the access control policy for an instance resource. Returns an empty
@@ -623,14 +1313,26 @@ pub mod instance_admin_client {
         /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
         pub async fn get_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::super::super::iam::v1::GetIamPolicyRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::super::super::iam::v1::Policy>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/GetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.admin.instance.v1.InstanceAdmin/GetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns permissions that the caller has on the specified instance resource.
@@ -641,14 +1343,24 @@ pub mod instance_admin_client {
         /// empty set of permissions.
         pub async fn test_iam_permissions(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::TestIamPermissionsRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::super::super::super::iam::v1::TestIamPermissionsRequest,
+            >,
         ) -> Result<
-            tonic::Response<super::super::super::super::super::iam::v1::TestIamPermissionsResponse>,
+            tonic::Response<
+                super::super::super::super::super::iam::v1::TestIamPermissionsResponse,
+            >,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/TestIamPermissions",

--- a/googleapis/src/google.spanner.v1.rs
+++ b/googleapis/src/google.spanner.v1.rs
@@ -358,17 +358,7 @@ pub mod plan_node {
     }
     /// The kind of \[PlanNode][google.spanner.v1.PlanNode\]. Distinguishes between the two different kinds of
     /// nodes that can appear in a query plan.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Kind {
         /// Not specified.
@@ -753,17 +743,7 @@ pub mod transaction_options {
     pub mod read_write {
         /// `ReadLockMode` is used to set the read lock mode for read-write
         /// transactions.
-        #[derive(
-            Clone,
-            Copy,
-            Debug,
-            PartialEq,
-            Eq,
-            Hash,
-            PartialOrd,
-            Ord,
-            ::prost::Enumeration
-        )]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
         #[repr(i32)]
         pub enum ReadLockMode {
             /// Default value.
@@ -1400,10 +1380,7 @@ pub struct Session {
     ///
     /// See <https://goo.gl/xmQnxf> for more information on and examples of labels.
     #[prost(map = "string, string", tag = "2")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Output only. The timestamp when the session is created.
     #[prost(message, optional, tag = "3")]
     pub create_time: ::core::option::Option<::prost_types::Timestamp>,
@@ -1524,17 +1501,7 @@ pub mod request_options {
     ///    Cloud Spanner does not guarantee to process the higher priority
     ///    operations first. There may be other constraints to satisfy, such as
     ///    order of operations.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Priority {
         /// `PRIORITY_UNSPECIFIED` is equivalent to `PRIORITY_HIGH`.
@@ -1705,17 +1672,7 @@ pub mod execute_sql_request {
         pub optimizer_statistics_package: ::prost::alloc::string::String,
     }
     /// Mode in which the statement must be processed.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum QueryMode {
         /// The default mode. Only the statement results are returned.
@@ -1809,10 +1766,7 @@ pub mod execute_batch_dml_request {
         /// definition of \[Type][google.spanner.v1.Type\] for more information
         /// about SQL types.
         #[prost(map = "string, message", tag = "3")]
-        pub param_types: ::std::collections::HashMap<
-            ::prost::alloc::string::String,
-            super::Type,
-        >,
+        pub param_types: ::std::collections::HashMap<::prost::alloc::string::String, super::Type>,
     }
 }
 /// The response for \[ExecuteBatchDml][google.spanner.v1.Spanner.ExecuteBatchDml\]. Contains a list
@@ -2129,8 +2083,8 @@ pub struct RollbackRequest {
 /// Generated client implementations.
 pub mod spanner_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// Cloud Spanner API
     ///
     /// The Cloud Spanner API can be used to manage sessions and execute
@@ -2165,22 +2119,15 @@ pub mod spanner_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> SpannerClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> SpannerClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             SpannerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2222,19 +2169,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSessionRequest>,
         ) -> Result<tonic::Response<super::Session>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/CreateSession",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/CreateSession");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates multiple new sessions.
@@ -2245,19 +2184,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BatchCreateSessionsRequest>,
         ) -> Result<tonic::Response<super::BatchCreateSessionsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/BatchCreateSessions",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/BatchCreateSessions");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets a session. Returns `NOT_FOUND` if the session does not exist.
@@ -2267,19 +2198,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSessionRequest>,
         ) -> Result<tonic::Response<super::Session>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/GetSession",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/GetSession");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists all sessions in a given database.
@@ -2287,19 +2210,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSessionsRequest>,
         ) -> Result<tonic::Response<super::ListSessionsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/ListSessions",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ListSessions");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Ends a session, releasing server resources associated with it. This will
@@ -2309,19 +2224,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSessionRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/DeleteSession",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/DeleteSession");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Executes an SQL statement, returning all results in a single reply. This
@@ -2339,19 +2246,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
         ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/ExecuteSql",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteSql");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the result
@@ -2362,23 +2261,12 @@ pub mod spanner_client {
         pub async fn execute_streaming_sql(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
-        ) -> Result<
-            tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/ExecuteStreamingSql",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteStreamingSql");
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
         /// Executes a batch of SQL DML statements. This method allows many statements
@@ -2396,19 +2284,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteBatchDmlRequest>,
         ) -> Result<tonic::Response<super::ExecuteBatchDmlResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/ExecuteBatchDml",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteBatchDml");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Reads rows from the database using key lookups and scans, as a
@@ -2428,19 +2308,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
         ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/Read",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Read");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set as a
@@ -2451,23 +2323,12 @@ pub mod spanner_client {
         pub async fn streaming_read(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
-        ) -> Result<
-            tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/StreamingRead",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/StreamingRead");
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
         /// Begins a new transaction. This step can often be skipped:
@@ -2478,19 +2339,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BeginTransactionRequest>,
         ) -> Result<tonic::Response<super::Transaction>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/BeginTransaction",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/BeginTransaction");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Commits a transaction. The request includes the mutations to be
@@ -2511,19 +2364,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CommitRequest>,
         ) -> Result<tonic::Response<super::CommitResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/Commit",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Commit");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Rolls back a transaction, releasing any locks it holds. It is a good
@@ -2538,19 +2383,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RollbackRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/Rollback",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Rollback");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a query
@@ -2568,19 +2405,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionQueryRequest>,
         ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/PartitionQuery",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/PartitionQuery");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a read
@@ -2600,19 +2429,11 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionReadRequest>,
         ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.spanner.v1.Spanner/PartitionRead",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/PartitionRead");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.spanner.v1.rs
+++ b/googleapis/src/google.spanner.v1.rs
@@ -1,5 +1,6 @@
 /// The response for \[Commit][google.spanner.v1.Spanner.Commit\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommitResponse {
     /// The Cloud Spanner timestamp at which the transaction committed.
     #[prost(message, optional, tag = "1")]
@@ -13,7 +14,8 @@ pub struct CommitResponse {
 /// Nested message and enum types in `CommitResponse`.
 pub mod commit_response {
     /// Additional statistics about a commit.
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CommitStats {
         /// The total number of mutations for the transaction. Knowing the
         /// `mutation_count` value can help you maximize the number of mutations
@@ -38,15 +40,15 @@ pub mod commit_response {
 ///
 /// For example, consider the following table definition:
 ///
-///     CREATE TABLE UserEvents (
-///       UserName STRING(MAX),
-///       EventDate STRING(10)
-///     ) PRIMARY KEY(UserName, EventDate);
+///      CREATE TABLE UserEvents (
+///        UserName STRING(MAX),
+///        EventDate STRING(10)
+///      ) PRIMARY KEY(UserName, EventDate);
 ///
 /// The following keys name rows in this table:
 ///
-///     ["Bob", "2014-09-23"]
-///     ["Alfred", "2015-06-12"]
+///      ["Bob", "2014-09-23"]
+///      ["Alfred", "2015-06-12"]
 ///
 /// Since the `UserEvents` table's `PRIMARY KEY` clause names two
 /// columns, each `UserEvents` key has two elements; the first is the
@@ -57,8 +59,8 @@ pub mod commit_response {
 /// sort order. For example, the following range returns all events for
 /// user `"Bob"` that occurred in the year 2015:
 ///
-///     "start_closed": ["Bob", "2015-01-01"]
-///     "end_closed": ["Bob", "2015-12-31"]
+///      "start_closed": ["Bob", "2015-01-01"]
+///      "end_closed": ["Bob", "2015-12-31"]
 ///
 /// Start and end keys can omit trailing key components. This affects the
 /// inclusion and exclusion of rows that exactly match the provided key
@@ -69,51 +71,52 @@ pub mod commit_response {
 /// For example, the following range includes all events for `"Bob"` that
 /// occurred during and after the year 2000:
 ///
-///     "start_closed": ["Bob", "2000-01-01"]
-///     "end_closed": \["Bob"\]
+///      "start_closed": ["Bob", "2000-01-01"]
+///      "end_closed": \["Bob"\]
 ///
 /// The next example retrieves all events for `"Bob"`:
 ///
-///     "start_closed": \["Bob"\]
-///     "end_closed": \["Bob"\]
+///      "start_closed": \["Bob"\]
+///      "end_closed": \["Bob"\]
 ///
 /// To retrieve events before the year 2000:
 ///
-///     "start_closed": \["Bob"\]
-///     "end_open": ["Bob", "2000-01-01"]
+///      "start_closed": \["Bob"\]
+///      "end_open": ["Bob", "2000-01-01"]
 ///
 /// The following range includes all rows in the table:
 ///
-///     "start_closed": []
-///     "end_closed": []
+///      "start_closed": []
+///      "end_closed": []
 ///
 /// This range returns all users whose `UserName` begins with any
 /// character from A to C:
 ///
-///     "start_closed": \["A"\]
-///     "end_open": \["D"\]
+///      "start_closed": \["A"\]
+///      "end_open": \["D"\]
 ///
 /// This range returns all users whose `UserName` begins with B:
 ///
-///     "start_closed": \["B"\]
-///     "end_open": \["C"\]
+///      "start_closed": \["B"\]
+///      "end_open": \["C"\]
 ///
 /// Key ranges honor column sort order. For example, suppose a table is
 /// defined as follows:
 ///
-///     CREATE TABLE DescendingSortedTable {
-///       Key INT64,
-///       ...
-///     ) PRIMARY KEY(Key DESC);
+///      CREATE TABLE DescendingSortedTable {
+///        Key INT64,
+///        ...
+///      ) PRIMARY KEY(Key DESC);
 ///
 /// The following range retrieves all rows with key values between 1
 /// and 100 inclusive:
 ///
-///     "start_closed": \["100"\]
-///     "end_closed": \["1"\]
+///      "start_closed": \["100"\]
+///      "end_closed": \["1"\]
 ///
 /// Note that 100 is passed as the start, and 1 is passed as the end,
 /// because `Key` is a descending column in the schema.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyRange {
     /// The start key must be provided. It can be either closed or open.
@@ -126,6 +129,7 @@ pub struct KeyRange {
 /// Nested message and enum types in `KeyRange`.
 pub mod key_range {
     /// The start key must be provided. It can be either closed or open.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum StartKeyType {
         /// If the start is closed, then the range includes all rows whose
@@ -138,6 +142,7 @@ pub mod key_range {
         StartOpen(::prost_types::ListValue),
     }
     /// The end key must be provided. It can be either closed or open.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum EndKeyType {
         /// If the end is closed, then the range includes all rows whose
@@ -157,6 +162,7 @@ pub mod key_range {
 /// If the same key is specified multiple times in the set (for example
 /// if two ranges, two keys, or a key and a range overlap), Cloud Spanner
 /// behaves as if the key were only specified once.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeySet {
     /// A list of specific keys. Entries in `keys` should have exactly as
@@ -178,6 +184,7 @@ pub struct KeySet {
 /// A modification to one or more Cloud Spanner rows.  Mutations can be
 /// applied to a Cloud Spanner database by sending them in a
 /// \[Commit][google.spanner.v1.Spanner.Commit\] call.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Mutation {
     /// Required. The operation to perform.
@@ -188,6 +195,7 @@ pub struct Mutation {
 pub mod mutation {
     /// Arguments to \[insert][google.spanner.v1.Mutation.insert\], \[update][google.spanner.v1.Mutation.update\], \[insert_or_update][google.spanner.v1.Mutation.insert_or_update\], and
     /// \[replace][google.spanner.v1.Mutation.replace\] operations.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Write {
         /// Required. The table whose rows will be written.
@@ -212,6 +220,7 @@ pub mod mutation {
         pub values: ::prost::alloc::vec::Vec<::prost_types::ListValue>,
     }
     /// Arguments to \[delete][google.spanner.v1.Mutation.delete\] operations.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Delete {
         /// Required. The table whose rows will be deleted.
@@ -227,6 +236,7 @@ pub mod mutation {
         pub key_set: ::core::option::Option<super::KeySet>,
     }
     /// Required. The operation to perform.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Operation {
         /// Insert new rows in a table. If any of the rows already exist,
@@ -264,6 +274,7 @@ pub mod mutation {
     }
 }
 /// Node information for nodes appearing in a \[QueryPlan.plan_nodes][google.spanner.v1.QueryPlan.plan_nodes\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PlanNode {
     /// The `PlanNode`'s index in [node list]\[google.spanner.v1.QueryPlan.plan_nodes\].
@@ -289,10 +300,10 @@ pub struct PlanNode {
     /// For example, a Parameter Reference node could have the following
     /// information in its metadata:
     ///
-    ///     {
-    ///       "parameter_reference": "param1",
-    ///       "parameter_type": "array"
-    ///     }
+    ///      {
+    ///        "parameter_reference": "param1",
+    ///        "parameter_type": "array"
+    ///      }
     #[prost(message, optional, tag = "6")]
     pub metadata: ::core::option::Option<::prost_types::Struct>,
     /// The execution statistics associated with the node, contained in a group of
@@ -306,7 +317,8 @@ pub struct PlanNode {
 pub mod plan_node {
     /// Metadata associated with a parent-child relationship appearing in a
     /// \[PlanNode][google.spanner.v1.PlanNode\].
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ChildLink {
         /// The node to which the link points.
         #[prost(int32, tag = "1")]
@@ -330,7 +342,8 @@ pub mod plan_node {
     }
     /// Condensed representation of a node and its subtree. Only present for
     /// `SCALAR` \[PlanNode(s)][google.spanner.v1.PlanNode\].
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ShortRepresentation {
         /// A string representation of the expression subtree rooted at this node.
         #[prost(string, tag = "1")]
@@ -345,7 +358,17 @@ pub mod plan_node {
     }
     /// The kind of \[PlanNode][google.spanner.v1.PlanNode\]. Distinguishes between the two different kinds of
     /// nodes that can appear in a query plan.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Kind {
         /// Not specified.
@@ -360,8 +383,22 @@ pub mod plan_node {
         /// to column names.
         Scalar = 2,
     }
+    impl Kind {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Kind::Unspecified => "KIND_UNSPECIFIED",
+                Kind::Relational => "RELATIONAL",
+                Kind::Scalar => "SCALAR",
+            }
+        }
+    }
 }
 /// Contains an ordered list of nodes appearing in the query plan.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPlan {
     /// The nodes in the query plan. Plan nodes are returned in pre-order starting
@@ -382,31 +419,32 @@ pub struct QueryPlan {
 ///
 /// Cloud Spanner supports three transaction modes:
 ///
-///   1. Locking read-write. This type of transaction is the only way
-///      to write data into Cloud Spanner. These transactions rely on
-///      pessimistic locking and, if necessary, two-phase commit.
-///      Locking read-write transactions may abort, requiring the
-///      application to retry.
+///    1. Locking read-write. This type of transaction is the only way
+///       to write data into Cloud Spanner. These transactions rely on
+///       pessimistic locking and, if necessary, two-phase commit.
+///       Locking read-write transactions may abort, requiring the
+///       application to retry.
 ///
-///   2. Snapshot read-only. Snapshot read-only transactions provide guaranteed
-///      consistency across several reads, but do not allow
-///      writes. Snapshot read-only transactions can be configured to read at
-///      timestamps in the past, or configured to perform a strong read
-///      (where Spanner will select a timestamp such that the read is
-///      guaranteed to see the effects of all transactions that have committed
-///      before the start of the read). Snapshot read-only transactions do not
-///      need to be committed.
+///    2. Snapshot read-only. Snapshot read-only transactions provide guaranteed
+///       consistency across several reads, but do not allow
+///       writes. Snapshot read-only transactions can be configured to read at
+///       timestamps in the past, or configured to perform a strong read
+///       (where Spanner will select a timestamp such that the read is
+///       guaranteed to see the effects of all transactions that have committed
+///       before the start of the read). Snapshot read-only transactions do not
+///       need to be committed.
 ///
-///      Queries on change streams must be performed with the snapshot read-only
-///      transaction mode, specifying a strong read. Please see
-///      \[TransactionOptions.ReadOnly.strong][google.spanner.v1.TransactionOptions.ReadOnly.strong\] for more details.
+///       Queries on change streams must be performed with the snapshot read-only
+///       transaction mode, specifying a strong read. Please see
+///       \[TransactionOptions.ReadOnly.strong][google.spanner.v1.TransactionOptions.ReadOnly.strong\]
+///       for more details.
 ///
-///   3. Partitioned DML. This type of transaction is used to execute
-///      a single Partitioned DML statement. Partitioned DML partitions
-///      the key space and runs the DML statement over each partition
-///      in parallel using separate, internal transactions that commit
-///      independently. Partitioned DML transactions do not need to be
-///      committed.
+///    3. Partitioned DML. This type of transaction is used to execute
+///       a single Partitioned DML statement. Partitioned DML partitions
+///       the key space and runs the DML statement over each partition
+///       in parallel using separate, internal transactions that commit
+///       independently. Partitioned DML transactions do not need to be
+///       committed.
 ///
 /// For transactions that only read, snapshot read-only transactions
 /// provide simpler semantics and are almost always faster. In
@@ -509,9 +547,9 @@ pub struct QueryPlan {
 ///
 /// The types of timestamp bound are:
 ///
-///   - Strong (the default).
-///   - Bounded staleness.
-///   - Exact staleness.
+///    - Strong (the default).
+///    - Bounded staleness.
+///    - Exact staleness.
 ///
 /// If the Cloud Spanner database to be read is geographically distributed,
 /// stale read-only transactions can execute more quickly than strong
@@ -535,7 +573,8 @@ pub struct QueryPlan {
 /// Queries on change streams (see below for more details) must also specify
 /// the strong read timestamp bound.
 ///
-/// See \[TransactionOptions.ReadOnly.strong][google.spanner.v1.TransactionOptions.ReadOnly.strong\].
+/// See
+/// \[TransactionOptions.ReadOnly.strong][google.spanner.v1.TransactionOptions.ReadOnly.strong\].
 ///
 /// Exact staleness:
 ///
@@ -556,7 +595,9 @@ pub struct QueryPlan {
 /// equivalent boundedly stale concurrency modes. On the other hand,
 /// boundedly stale reads usually return fresher results.
 ///
-/// See \[TransactionOptions.ReadOnly.read_timestamp][google.spanner.v1.TransactionOptions.ReadOnly.read_timestamp\] and
+/// See
+/// \[TransactionOptions.ReadOnly.read_timestamp][google.spanner.v1.TransactionOptions.ReadOnly.read_timestamp\]
+/// and
 /// \[TransactionOptions.ReadOnly.exact_staleness][google.spanner.v1.TransactionOptions.ReadOnly.exact_staleness\].
 ///
 /// Bounded staleness:
@@ -586,7 +627,9 @@ pub struct QueryPlan {
 /// which rows will be read, it can only be used with single-use
 /// read-only transactions.
 ///
-/// See \[TransactionOptions.ReadOnly.max_staleness][google.spanner.v1.TransactionOptions.ReadOnly.max_staleness\] and
+/// See
+/// \[TransactionOptions.ReadOnly.max_staleness][google.spanner.v1.TransactionOptions.ReadOnly.max_staleness\]
+/// and
 /// \[TransactionOptions.ReadOnly.min_read_timestamp][google.spanner.v1.TransactionOptions.ReadOnly.min_read_timestamp\].
 ///
 /// Old read timestamps and garbage collection:
@@ -652,42 +695,43 @@ pub struct QueryPlan {
 /// That said, Partitioned DML is not a drop-in replacement for standard DML used
 /// in ReadWrite transactions.
 ///
-///  - The DML statement must be fully-partitionable. Specifically, the statement
-///    must be expressible as the union of many statements which each access only
-///    a single row of the table.
+///   - The DML statement must be fully-partitionable. Specifically, the statement
+///     must be expressible as the union of many statements which each access only
+///     a single row of the table.
 ///
-///  - The statement is not applied atomically to all rows of the table. Rather,
-///    the statement is applied atomically to partitions of the table, in
-///    independent transactions. Secondary index rows are updated atomically
-///    with the base table rows.
+///   - The statement is not applied atomically to all rows of the table. Rather,
+///     the statement is applied atomically to partitions of the table, in
+///     independent transactions. Secondary index rows are updated atomically
+///     with the base table rows.
 ///
-///  - Partitioned DML does not guarantee exactly-once execution semantics
-///    against a partition. The statement will be applied at least once to each
-///    partition. It is strongly recommended that the DML statement should be
-///    idempotent to avoid unexpected results. For instance, it is potentially
-///    dangerous to run a statement such as
-///    `UPDATE table SET column = column + 1` as it could be run multiple times
-///    against some rows.
+///   - Partitioned DML does not guarantee exactly-once execution semantics
+///     against a partition. The statement will be applied at least once to each
+///     partition. It is strongly recommended that the DML statement should be
+///     idempotent to avoid unexpected results. For instance, it is potentially
+///     dangerous to run a statement such as
+///     `UPDATE table SET column = column + 1` as it could be run multiple times
+///     against some rows.
 ///
-///  - The partitions are committed automatically - there is no support for
-///    Commit or Rollback. If the call returns an error, or if the client issuing
-///    the ExecuteSql call dies, it is possible that some rows had the statement
-///    executed on them successfully. It is also possible that statement was
-///    never executed against other rows.
+///   - The partitions are committed automatically - there is no support for
+///     Commit or Rollback. If the call returns an error, or if the client issuing
+///     the ExecuteSql call dies, it is possible that some rows had the statement
+///     executed on them successfully. It is also possible that statement was
+///     never executed against other rows.
 ///
-///  - Partitioned DML transactions may only contain the execution of a single
-///    DML statement via ExecuteSql or ExecuteStreamingSql.
+///   - Partitioned DML transactions may only contain the execution of a single
+///     DML statement via ExecuteSql or ExecuteStreamingSql.
 ///
-///  - If any error is encountered during the execution of the partitioned DML
-///    operation (for instance, a UNIQUE INDEX violation, division by zero, or a
-///    value that cannot be stored due to schema constraints), then the
-///    operation is stopped at that point and an error is returned. It is
-///    possible that at this point, some partitions have been committed (or even
-///    committed multiple times), and other partitions have not been run at all.
+///   - If any error is encountered during the execution of the partitioned DML
+///     operation (for instance, a UNIQUE INDEX violation, division by zero, or a
+///     value that cannot be stored due to schema constraints), then the
+///     operation is stopped at that point and an error is returned. It is
+///     possible that at this point, some partitions have been committed (or even
+///     committed multiple times), and other partitions have not been run at all.
 ///
 /// Given the above, Partitioned DML is good fit for large, database-wide,
 /// operations that are idempotent, such as deleting old rows from a very large
 /// table.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionOptions {
     /// Required. The type of transaction.
@@ -698,16 +742,70 @@ pub struct TransactionOptions {
 pub mod transaction_options {
     /// Message type to initiate a read-write transaction. Currently this
     /// transaction type has no options.
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
-    pub struct ReadWrite {}
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ReadWrite {
+        /// Read lock mode for the transaction.
+        #[prost(enumeration = "read_write::ReadLockMode", tag = "1")]
+        pub read_lock_mode: i32,
+    }
+    /// Nested message and enum types in `ReadWrite`.
+    pub mod read_write {
+        /// `ReadLockMode` is used to set the read lock mode for read-write
+        /// transactions.
+        #[derive(
+            Clone,
+            Copy,
+            Debug,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            ::prost::Enumeration
+        )]
+        #[repr(i32)]
+        pub enum ReadLockMode {
+            /// Default value.
+            ///
+            /// If the value is not specified, the pessimistic read lock is used.
+            Unspecified = 0,
+            /// Pessimistic lock mode.
+            ///
+            /// Read locks are acquired immediately on read.
+            Pessimistic = 1,
+            /// Optimistic lock mode.
+            ///
+            /// Locks for reads within the transaction are not acquired on read.
+            /// Instead the locks are acquired on a commit to validate that
+            /// read/queried data has not changed since the transaction started.
+            Optimistic = 2,
+        }
+        impl ReadLockMode {
+            /// String value of the enum field names used in the ProtoBuf definition.
+            ///
+            /// The values are not transformed in any way and thus are considered stable
+            /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+            pub fn as_str_name(&self) -> &'static str {
+                match self {
+                    ReadLockMode::Unspecified => "READ_LOCK_MODE_UNSPECIFIED",
+                    ReadLockMode::Pessimistic => "PESSIMISTIC",
+                    ReadLockMode::Optimistic => "OPTIMISTIC",
+                }
+            }
+        }
+    }
     /// Message type to initiate a Partitioned DML transaction.
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PartitionedDml {}
     /// Message type to initiate a read-only transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ReadOnly {
         /// If true, the Cloud Spanner-selected read timestamp is included in
-        /// the \[Transaction][google.spanner.v1.Transaction\] message that describes the transaction.
+        /// the \[Transaction][google.spanner.v1.Transaction\] message that describes
+        /// the transaction.
         #[prost(bool, tag = "6")]
         pub return_read_timestamp: bool,
         /// How to choose the timestamp for the read-only transaction.
@@ -717,6 +815,7 @@ pub mod transaction_options {
     /// Nested message and enum types in `ReadOnly`.
     pub mod read_only {
         /// How to choose the timestamp for the read-only transaction.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum TimestampBound {
             /// Read at a timestamp where all previously committed transactions
@@ -780,6 +879,7 @@ pub mod transaction_options {
         }
     }
     /// Required. The type of transaction.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Mode {
         /// Transaction may write.
@@ -806,7 +906,8 @@ pub mod transaction_options {
     }
 }
 /// A transaction.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transaction {
     /// `id` may be used to identify the transaction in subsequent
     /// \[Read][google.spanner.v1.Spanner.Read\],
@@ -831,7 +932,9 @@ pub struct Transaction {
 /// \[Read][google.spanner.v1.Spanner.Read\] or
 /// \[ExecuteSql][google.spanner.v1.Spanner.ExecuteSql\] call runs.
 ///
-/// See \[TransactionOptions][google.spanner.v1.TransactionOptions\] for more information about transactions.
+/// See \[TransactionOptions][google.spanner.v1.TransactionOptions\] for more
+/// information about transactions.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionSelector {
     /// If no fields are set, the default is a single use transaction
@@ -843,6 +946,7 @@ pub struct TransactionSelector {
 pub mod transaction_selector {
     /// If no fields are set, the default is a single use transaction
     /// with strong concurrency.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Selector {
         /// Execute the read or SQL query in a temporary transaction.
@@ -855,13 +959,15 @@ pub mod transaction_selector {
         Id(::prost::alloc::vec::Vec<u8>),
         /// Begin a new transaction and execute this read or SQL query in
         /// it. The transaction ID of the new transaction is returned in
-        /// \[ResultSetMetadata.transaction][google.spanner.v1.ResultSetMetadata.transaction\], which is a \[Transaction][google.spanner.v1.Transaction\].
+        /// \[ResultSetMetadata.transaction][google.spanner.v1.ResultSetMetadata.transaction\],
+        /// which is a \[Transaction][google.spanner.v1.Transaction\].
         #[prost(message, tag = "3")]
         Begin(super::TransactionOptions),
     }
 }
 /// `Type` indicates the type of a Cloud Spanner value, as might be stored in a
 /// table cell or returned from an SQL query.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Type {
     /// Required. The \[TypeCode][google.spanner.v1.TypeCode\] for this type.
@@ -885,6 +991,7 @@ pub struct Type {
     pub type_annotation: i32,
 }
 /// `StructType` defines the fields of a \[STRUCT][google.spanner.v1.TypeCode.STRUCT\] type.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StructType {
     /// The list of fields that make up this struct. Order is
@@ -899,6 +1006,7 @@ pub struct StructType {
 /// Nested message and enum types in `StructType`.
 pub mod struct_type {
     /// Message representing a single field of a struct.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Field {
         /// The name of the field. For reads, this is the column name. For
@@ -973,9 +1081,31 @@ pub enum TypeCode {
     /// - Whitespace characters are not preserved.
     /// - If a JSON object has duplicate keys, only the first key is preserved.
     /// - Members of a JSON object are not guaranteed to have their order
-    ///   preserved.
+    ///    preserved.
     /// - JSON array elements will have their order preserved.
     Json = 11,
+}
+impl TypeCode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TypeCode::Unspecified => "TYPE_CODE_UNSPECIFIED",
+            TypeCode::Bool => "BOOL",
+            TypeCode::Int64 => "INT64",
+            TypeCode::Float64 => "FLOAT64",
+            TypeCode::Timestamp => "TIMESTAMP",
+            TypeCode::Date => "DATE",
+            TypeCode::String => "STRING",
+            TypeCode::Bytes => "BYTES",
+            TypeCode::Array => "ARRAY",
+            TypeCode::Struct => "STRUCT",
+            TypeCode::Numeric => "NUMERIC",
+            TypeCode::Json => "JSON",
+        }
+    }
 }
 /// `TypeAnnotationCode` is used as a part of \[Type][google.spanner.v1.Type\] to
 /// disambiguate SQL types that should be used for a given Cloud Spanner value.
@@ -994,9 +1124,30 @@ pub enum TypeAnnotationCode {
     /// \[NUMERIC][google.spanner.v1.TypeCode.NUMERIC\] when a client interacts with PostgreSQL-enabled
     /// Spanner databases.
     PgNumeric = 2,
+    /// PostgreSQL compatible JSONB type. This annotation needs to be applied to
+    /// \[Type][google.spanner.v1.Type\] instances having \[JSON][google.spanner.v1.TypeCode.JSON\]
+    /// type code to specify that values of this type should be treated as
+    /// PostgreSQL JSONB values. Currently this annotation is always needed for
+    /// \[JSON][google.spanner.v1.TypeCode.JSON\] when a client interacts with PostgreSQL-enabled
+    /// Spanner databases.
+    PgJsonb = 3,
+}
+impl TypeAnnotationCode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TypeAnnotationCode::Unspecified => "TYPE_ANNOTATION_CODE_UNSPECIFIED",
+            TypeAnnotationCode::PgNumeric => "PG_NUMERIC",
+            TypeAnnotationCode::PgJsonb => "PG_JSONB",
+        }
+    }
 }
 /// Results from \[Read][google.spanner.v1.Spanner.Read\] or
 /// \[ExecuteSql][google.spanner.v1.Spanner.ExecuteSql\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResultSet {
     /// Metadata about the result set, such as row type information.
@@ -1024,6 +1175,7 @@ pub struct ResultSet {
 /// Partial results from a streaming read or SQL query. Streaming reads and
 /// SQL queries better tolerate large result sets, large rows, and large
 /// values, but are a little trickier to consume.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartialResultSet {
     /// Metadata about the result set, such as row type information.
@@ -1045,60 +1197,60 @@ pub struct PartialResultSet {
     /// field. Two or more chunked values can be merged to form a
     /// complete value as follows:
     ///
-    ///   * `bool/number/null`: cannot be chunked
-    ///   * `string`: concatenate the strings
-    ///   * `list`: concatenate the lists. If the last element in a list is a
-    ///     `string`, `list`, or `object`, merge it with the first element in
-    ///     the next list by applying these rules recursively.
-    ///   * `object`: concatenate the (field name, field value) pairs. If a
-    ///     field name is duplicated, then apply these rules recursively
-    ///     to merge the field values.
+    ///    * `bool/number/null`: cannot be chunked
+    ///    * `string`: concatenate the strings
+    ///    * `list`: concatenate the lists. If the last element in a list is a
+    ///      `string`, `list`, or `object`, merge it with the first element in
+    ///      the next list by applying these rules recursively.
+    ///    * `object`: concatenate the (field name, field value) pairs. If a
+    ///      field name is duplicated, then apply these rules recursively
+    ///      to merge the field values.
     ///
     /// Some examples of merging:
     ///
-    ///     # Strings are concatenated.
-    ///     "foo", "bar" => "foobar"
+    ///      # Strings are concatenated.
+    ///      "foo", "bar" => "foobar"
     ///
-    ///     # Lists of non-strings are concatenated.
-    ///     [2, 3], \[4\] => [2, 3, 4]
+    ///      # Lists of non-strings are concatenated.
+    ///      [2, 3], \[4\] => [2, 3, 4]
     ///
-    ///     # Lists are concatenated, but the last and first elements are merged
-    ///     # because they are strings.
-    ///     ["a", "b"], ["c", "d"] => ["a", "bc", "d"]
+    ///      # Lists are concatenated, but the last and first elements are merged
+    ///      # because they are strings.
+    ///      ["a", "b"], ["c", "d"] => ["a", "bc", "d"]
     ///
-    ///     # Lists are concatenated, but the last and first elements are merged
-    ///     # because they are lists. Recursively, the last and first elements
-    ///     # of the inner lists are merged because they are strings.
-    ///     ["a", ["b", "c"]], \[["d"\], "e"] => ["a", ["b", "cd"], "e"]
+    ///      # Lists are concatenated, but the last and first elements are merged
+    ///      # because they are lists. Recursively, the last and first elements
+    ///      # of the inner lists are merged because they are strings.
+    ///      ["a", ["b", "c"]], \[["d"\], "e"] => ["a", ["b", "cd"], "e"]
     ///
-    ///     # Non-overlapping object fields are combined.
-    ///     {"a": "1"}, {"b": "2"} => {"a": "1", "b": 2"}
+    ///      # Non-overlapping object fields are combined.
+    ///      {"a": "1"}, {"b": "2"} => {"a": "1", "b": 2"}
     ///
-    ///     # Overlapping object fields are merged.
-    ///     {"a": "1"}, {"a": "2"} => {"a": "12"}
+    ///      # Overlapping object fields are merged.
+    ///      {"a": "1"}, {"a": "2"} => {"a": "12"}
     ///
-    ///     # Examples of merging objects containing lists of strings.
-    ///     {"a": \["1"\]}, {"a": \["2"\]} => {"a": \["12"\]}
+    ///      # Examples of merging objects containing lists of strings.
+    ///      {"a": \["1"\]}, {"a": \["2"\]} => {"a": \["12"\]}
     ///
     /// For a more complete example, suppose a streaming SQL query is
     /// yielding a result set whose rows contain a single string
     /// field. The following `PartialResultSet`s might be yielded:
     ///
-    ///     {
-    ///       "metadata": { ... }
-    ///       "values": ["Hello", "W"]
-    ///       "chunked_value": true
-    ///       "resume_token": "Af65..."
-    ///     }
-    ///     {
-    ///       "values": \["orl"\]
-    ///       "chunked_value": true
-    ///       "resume_token": "Bqp2..."
-    ///     }
-    ///     {
-    ///       "values": \["d"\]
-    ///       "resume_token": "Zx1B..."
-    ///     }
+    ///      {
+    ///        "metadata": { ... }
+    ///        "values": ["Hello", "W"]
+    ///        "chunked_value": true
+    ///        "resume_token": "Af65..."
+    ///      }
+    ///      {
+    ///        "values": \["orl"\]
+    ///        "chunked_value": true
+    ///        "resume_token": "Bqp2..."
+    ///      }
+    ///      {
+    ///        "values": \["d"\]
+    ///        "resume_token": "Zx1B..."
+    ///      }
     ///
     /// This sequence of `PartialResultSet`s encodes two rows, one
     /// containing the field value `"Hello"`, and a second containing the
@@ -1127,24 +1279,38 @@ pub struct PartialResultSet {
     pub stats: ::core::option::Option<ResultSetStats>,
 }
 /// Metadata about a \[ResultSet][google.spanner.v1.ResultSet\] or \[PartialResultSet][google.spanner.v1.PartialResultSet\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResultSetMetadata {
     /// Indicates the field names and types for the rows in the result
     /// set.  For example, a SQL query like `"SELECT UserId, UserName FROM
     /// Users"` could return a `row_type` value like:
     ///
-    ///     "fields": [
-    ///       { "name": "UserId", "type": { "code": "INT64" } },
-    ///       { "name": "UserName", "type": { "code": "STRING" } },
-    ///     ]
+    ///      "fields": [
+    ///        { "name": "UserId", "type": { "code": "INT64" } },
+    ///        { "name": "UserName", "type": { "code": "STRING" } },
+    ///      ]
     #[prost(message, optional, tag = "1")]
     pub row_type: ::core::option::Option<StructType>,
     /// If the read or SQL query began a transaction as a side-effect, the
     /// information about the new transaction is yielded here.
     #[prost(message, optional, tag = "2")]
     pub transaction: ::core::option::Option<Transaction>,
+    /// A SQL query can be parameterized. In PLAN mode, these parameters can be
+    /// undeclared. This indicates the field names and types for those undeclared
+    /// parameters in the SQL query. For example, a SQL query like `"SELECT * FROM
+    /// Users where UserId = @userId and UserName = @userName "` could return a
+    /// `undeclared_parameters` value like:
+    ///
+    ///      "fields": [
+    ///        { "name": "UserId", "type": { "code": "INT64" } },
+    ///        { "name": "UserName", "type": { "code": "STRING" } },
+    ///      ]
+    #[prost(message, optional, tag = "3")]
+    pub undeclared_parameters: ::core::option::Option<StructType>,
 }
 /// Additional statistics about a \[ResultSet][google.spanner.v1.ResultSet\] or \[PartialResultSet][google.spanner.v1.PartialResultSet\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResultSetStats {
     /// \[QueryPlan][google.spanner.v1.QueryPlan\] for the query associated with this result.
@@ -1154,11 +1320,11 @@ pub struct ResultSetStats {
     /// the query is profiled. For example, a query could return the statistics as
     /// follows:
     ///
-    ///     {
-    ///       "rows_returned": "3",
-    ///       "elapsed_time": "1.22 secs",
-    ///       "cpu_time": "1.19 secs"
-    ///     }
+    ///      {
+    ///        "rows_returned": "3",
+    ///        "elapsed_time": "1.22 secs",
+    ///        "cpu_time": "1.19 secs"
+    ///      }
     #[prost(message, optional, tag = "2")]
     pub query_stats: ::core::option::Option<::prost_types::Struct>,
     /// The number of rows modified by the DML statement.
@@ -1168,7 +1334,8 @@ pub struct ResultSetStats {
 /// Nested message and enum types in `ResultSetStats`.
 pub mod result_set_stats {
     /// The number of rows modified by the DML statement.
-    #[derive(Clone, PartialEq, Eq, ::prost::Oneof)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum RowCount {
         /// Standard DML returns an exact count of rows that were modified.
         #[prost(int64, tag = "3")]
@@ -1180,7 +1347,8 @@ pub mod result_set_stats {
     }
 }
 /// The request for \[CreateSession][google.spanner.v1.Spanner.CreateSession\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateSessionRequest {
     /// Required. The database in which the new session is created.
     #[prost(string, tag = "1")]
@@ -1190,7 +1358,8 @@ pub struct CreateSessionRequest {
     pub session: ::core::option::Option<Session>,
 }
 /// The request for \[BatchCreateSessions][google.spanner.v1.Spanner.BatchCreateSessions\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchCreateSessionsRequest {
     /// Required. The database in which the new sessions are created.
     #[prost(string, tag = "1")]
@@ -1207,29 +1376,34 @@ pub struct BatchCreateSessionsRequest {
     pub session_count: i32,
 }
 /// The response for \[BatchCreateSessions][google.spanner.v1.Spanner.BatchCreateSessions\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchCreateSessionsResponse {
     /// The freshly created sessions.
     #[prost(message, repeated, tag = "1")]
     pub session: ::prost::alloc::vec::Vec<Session>,
 }
 /// A session in the Cloud Spanner API.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Session {
     /// Output only. The name of the session. This is always system-assigned.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// The labels for the session.
     ///
-    ///  * Label keys must be between 1 and 63 characters long and must conform to
-    ///    the following regular expression: `\[a-z]([-a-z0-9]*[a-z0-9\])?`.
-    ///  * Label values must be between 0 and 63 characters long and must conform
-    ///    to the regular expression `(\[a-z]([-a-z0-9]*[a-z0-9\])?)?`.
-    ///  * No more than 64 labels can be associated with a given session.
+    ///   * Label keys must be between 1 and 63 characters long and must conform to
+    ///     the following regular expression: `\[a-z]([-a-z0-9]*[a-z0-9\])?`.
+    ///   * Label values must be between 0 and 63 characters long and must conform
+    ///     to the regular expression `(\[a-z]([-a-z0-9]*[a-z0-9\])?)?`.
+    ///   * No more than 64 labels can be associated with a given session.
     ///
     /// See <https://goo.gl/xmQnxf> for more information on and examples of labels.
     #[prost(map = "string, string", tag = "2")]
-    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// Output only. The timestamp when the session is created.
     #[prost(message, optional, tag = "3")]
     pub create_time: ::core::option::Option<::prost_types::Timestamp>,
@@ -1242,14 +1416,16 @@ pub struct Session {
     pub creator_role: ::prost::alloc::string::String,
 }
 /// The request for \[GetSession][google.spanner.v1.Spanner.GetSession\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSessionRequest {
     /// Required. The name of the session to retrieve.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 /// The request for \[ListSessions][google.spanner.v1.Spanner.ListSessions\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSessionsRequest {
     /// Required. The database in which to list sessions.
     #[prost(string, tag = "1")]
@@ -1266,18 +1442,19 @@ pub struct ListSessionsRequest {
     /// An expression for filtering the results of the request. Filter rules are
     /// case insensitive. The fields eligible for filtering are:
     ///
-    ///   * `labels.key` where key is the name of a label
+    ///    * `labels.key` where key is the name of a label
     ///
     /// Some examples of using filters are:
     ///
-    ///   * `labels.env:*` --> The session has the label "env".
-    ///   * `labels.env:dev` --> The session has the label "env" and the value of
-    ///                        the label contains the string "dev".
+    ///    * `labels.env:*` --> The session has the label "env".
+    ///    * `labels.env:dev` --> The session has the label "env" and the value of
+    ///                         the label contains the string "dev".
     #[prost(string, tag = "4")]
     pub filter: ::prost::alloc::string::String,
 }
 /// The response for \[ListSessions][google.spanner.v1.Spanner.ListSessions\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSessionsResponse {
     /// The list of requested sessions.
     #[prost(message, repeated, tag = "1")]
@@ -1289,14 +1466,16 @@ pub struct ListSessionsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// The request for \[DeleteSession][google.spanner.v1.Spanner.DeleteSession\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteSessionRequest {
     /// Required. The name of the session to delete.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 /// Common request options for various APIs.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RequestOptions {
     /// Priority for the request.
     #[prost(enumeration = "request_options::Priority", tag = "1")]
@@ -1336,16 +1515,26 @@ pub mod request_options {
     /// guarantee priority or order of execution. For example:
     ///
     /// * Some parts of a write operation always execute at `PRIORITY_HIGH`,
-    ///   regardless of the specified priority. This may cause you to see an
-    ///   increase in high priority workload even when executing a low priority
-    ///   request. This can also potentially cause a priority inversion where a
-    ///   lower priority request will be fulfilled ahead of a higher priority
-    ///   request.
+    ///    regardless of the specified priority. This may cause you to see an
+    ///    increase in high priority workload even when executing a low priority
+    ///    request. This can also potentially cause a priority inversion where a
+    ///    lower priority request will be fulfilled ahead of a higher priority
+    ///    request.
     /// * If a transaction contains multiple operations with different priorities,
-    ///   Cloud Spanner does not guarantee to process the higher priority
-    ///   operations first. There may be other constraints to satisfy, such as
-    ///   order of operations.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    ///    Cloud Spanner does not guarantee to process the higher priority
+    ///    operations first. There may be other constraints to satisfy, such as
+    ///    order of operations.
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Priority {
         /// `PRIORITY_UNSPECIFIED` is equivalent to `PRIORITY_HIGH`.
@@ -1357,9 +1546,24 @@ pub mod request_options {
         /// This specifies that the request is high priority.
         High = 3,
     }
+    impl Priority {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Priority::Unspecified => "PRIORITY_UNSPECIFIED",
+                Priority::Low => "PRIORITY_LOW",
+                Priority::Medium => "PRIORITY_MEDIUM",
+                Priority::High => "PRIORITY_HIGH",
+            }
+        }
+    }
 }
 /// The request for \[ExecuteSql][google.spanner.v1.Spanner.ExecuteSql\] and
 /// \[ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteSqlRequest {
     /// Required. The session in which the SQL query should be performed.
@@ -1446,7 +1650,8 @@ pub struct ExecuteSqlRequest {
 /// Nested message and enum types in `ExecuteSqlRequest`.
 pub mod execute_sql_request {
     /// Query optimizer configuration.
-    #[derive(Clone, PartialEq, Eq, ::prost::Message)]
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct QueryOptions {
         /// An option to control the selection of optimizer version.
         ///
@@ -1500,7 +1705,17 @@ pub mod execute_sql_request {
         pub optimizer_statistics_package: ::prost::alloc::string::String,
     }
     /// Mode in which the statement must be processed.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum QueryMode {
         /// The default mode. Only the statement results are returned.
@@ -1512,8 +1727,22 @@ pub mod execute_sql_request {
         /// with the results.
         Profile = 2,
     }
+    impl QueryMode {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                QueryMode::Normal => "NORMAL",
+                QueryMode::Plan => "PLAN",
+                QueryMode::Profile => "PROFILE",
+            }
+        }
+    }
 }
 /// The request for \[ExecuteBatchDml][google.spanner.v1.Spanner.ExecuteBatchDml\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteBatchDmlRequest {
     /// Required. The session in which the DML statements should be performed.
@@ -1551,6 +1780,7 @@ pub struct ExecuteBatchDmlRequest {
 /// Nested message and enum types in `ExecuteBatchDmlRequest`.
 pub mod execute_batch_dml_request {
     /// A single DML statement.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Statement {
         /// Required. The DML string.
@@ -1579,7 +1809,10 @@ pub mod execute_batch_dml_request {
         /// definition of \[Type][google.spanner.v1.Type\] for more information
         /// about SQL types.
         #[prost(map = "string, message", tag = "3")]
-        pub param_types: ::std::collections::HashMap<::prost::alloc::string::String, super::Type>,
+        pub param_types: ::std::collections::HashMap<
+            ::prost::alloc::string::String,
+            super::Type,
+        >,
     }
 }
 /// The response for \[ExecuteBatchDml][google.spanner.v1.Spanner.ExecuteBatchDml\]. Contains a list
@@ -1590,10 +1823,10 @@ pub mod execute_batch_dml_request {
 /// To check for DML statements that failed, use the following approach:
 ///
 /// 1. Check the status in the response message. The \[google.rpc.Code][google.rpc.Code\] enum
-///    value `OK` indicates that all statements were executed successfully.
+///     value `OK` indicates that all statements were executed successfully.
 /// 2. If the status was not `OK`, check the number of result sets in the
-///    response. If the response contains `N` \[ResultSet][google.spanner.v1.ResultSet\] messages, then
-///    statement `N+1` in the request failed.
+///     response. If the response contains `N` \[ResultSet][google.spanner.v1.ResultSet\] messages, then
+///     statement `N+1` in the request failed.
 ///
 /// Example 1:
 ///
@@ -1604,8 +1837,9 @@ pub mod execute_batch_dml_request {
 ///
 /// * Request: 5 DML statements. The third statement has a syntax error.
 /// * Response: 2 \[ResultSet][google.spanner.v1.ResultSet\] messages, and a syntax error (`INVALID_ARGUMENT`)
-///   status. The number of \[ResultSet][google.spanner.v1.ResultSet\] messages indicates that the third
-///   statement failed, and the fourth and fifth statements were not executed.
+///    status. The number of \[ResultSet][google.spanner.v1.ResultSet\] messages indicates that the third
+///    statement failed, and the fourth and fifth statements were not executed.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecuteBatchDmlResponse {
     /// One \[ResultSet][google.spanner.v1.ResultSet\] for each statement in the request that ran successfully,
@@ -1624,7 +1858,8 @@ pub struct ExecuteBatchDmlResponse {
 }
 /// Options for a PartitionQueryRequest and
 /// PartitionReadRequest.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartitionOptions {
     /// **Note:** This hint is currently ignored by PartitionQuery and
     /// PartitionRead requests.
@@ -1646,6 +1881,7 @@ pub struct PartitionOptions {
     pub max_partitions: i64,
 }
 /// The request for \[PartitionQuery][google.spanner.v1.Spanner.PartitionQuery\]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartitionQueryRequest {
     /// Required. The session used to create the partitions.
@@ -1696,6 +1932,7 @@ pub struct PartitionQueryRequest {
     pub partition_options: ::core::option::Option<PartitionOptions>,
 }
 /// The request for \[PartitionRead][google.spanner.v1.Spanner.PartitionRead\]
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartitionReadRequest {
     /// Required. The session used to create the partitions.
@@ -1732,7 +1969,8 @@ pub struct PartitionReadRequest {
 }
 /// Information returned for each partition returned in a
 /// PartitionResponse.
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Partition {
     /// This token can be passed to Read, StreamingRead, ExecuteSql, or
     /// ExecuteStreamingSql requests to restrict the results to those identified by
@@ -1742,7 +1980,8 @@ pub struct Partition {
 }
 /// The response for \[PartitionQuery][google.spanner.v1.Spanner.PartitionQuery\]
 /// or \[PartitionRead][google.spanner.v1.Spanner.PartitionRead\]
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PartitionResponse {
     /// Partitions created by this request.
     #[prost(message, repeated, tag = "1")]
@@ -1753,6 +1992,7 @@ pub struct PartitionResponse {
 }
 /// The request for \[Read][google.spanner.v1.Spanner.Read\] and
 /// \[StreamingRead][google.spanner.v1.Spanner.StreamingRead\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReadRequest {
     /// Required. The session in which the read should be performed.
@@ -1812,6 +2052,7 @@ pub struct ReadRequest {
     pub request_options: ::core::option::Option<RequestOptions>,
 }
 /// The request for \[BeginTransaction][google.spanner.v1.Spanner.BeginTransaction\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BeginTransactionRequest {
     /// Required. The session in which the transaction runs.
@@ -1829,6 +2070,7 @@ pub struct BeginTransactionRequest {
     pub request_options: ::core::option::Option<RequestOptions>,
 }
 /// The request for \[Commit][google.spanner.v1.Spanner.Commit\].
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommitRequest {
     /// Required. The session in which the transaction to be committed is running.
@@ -1854,6 +2096,7 @@ pub struct CommitRequest {
 /// Nested message and enum types in `CommitRequest`.
 pub mod commit_request {
     /// Required. The transaction in which to commit.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Transaction {
         /// Commit a previously-started transaction.
@@ -1873,7 +2116,8 @@ pub mod commit_request {
     }
 }
 /// The request for \[Rollback][google.spanner.v1.Spanner.Rollback\].
-#[derive(Clone, PartialEq, Eq, ::prost::Message)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RollbackRequest {
     /// Required. The session in which the transaction to roll back is running.
     #[prost(string, tag = "1")]
@@ -1886,6 +2130,7 @@ pub struct RollbackRequest {
 pub mod spanner_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// Cloud Spanner API
     ///
     /// The Cloud Spanner API can be used to manage sessions and execute
@@ -1916,31 +2161,42 @@ pub mod spanner_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> SpannerClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> SpannerClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             SpannerClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Creates a new session. A session can be used to perform
@@ -1966,11 +2222,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSessionRequest>,
         ) -> Result<tonic::Response<super::Session>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/CreateSession");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/CreateSession",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates multiple new sessions.
@@ -1981,11 +2245,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BatchCreateSessionsRequest>,
         ) -> Result<tonic::Response<super::BatchCreateSessionsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/BatchCreateSessions");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/BatchCreateSessions",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets a session. Returns `NOT_FOUND` if the session does not exist.
@@ -1995,11 +2267,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetSessionRequest>,
         ) -> Result<tonic::Response<super::Session>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/GetSession");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/GetSession",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists all sessions in a given database.
@@ -2007,11 +2287,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListSessionsRequest>,
         ) -> Result<tonic::Response<super::ListSessionsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ListSessions");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/ListSessions",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Ends a session, releasing server resources associated with it. This will
@@ -2021,11 +2309,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSessionRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/DeleteSession");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/DeleteSession",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Executes an SQL statement, returning all results in a single reply. This
@@ -2043,11 +2339,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
         ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteSql");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/ExecuteSql",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the result
@@ -2058,12 +2362,23 @@ pub mod spanner_client {
         pub async fn execute_streaming_sql(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteStreamingSql");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/ExecuteStreamingSql",
+            );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
         /// Executes a batch of SQL DML statements. This method allows many statements
@@ -2081,11 +2396,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteBatchDmlRequest>,
         ) -> Result<tonic::Response<super::ExecuteBatchDmlResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteBatchDml");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/ExecuteBatchDml",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Reads rows from the database using key lookups and scans, as a
@@ -2105,11 +2428,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
         ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Read");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/Read",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set as a
@@ -2120,12 +2451,23 @@ pub mod spanner_client {
         pub async fn streaming_read(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/StreamingRead");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/StreamingRead",
+            );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
         /// Begins a new transaction. This step can often be skipped:
@@ -2136,11 +2478,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BeginTransactionRequest>,
         ) -> Result<tonic::Response<super::Transaction>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/BeginTransaction");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/BeginTransaction",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Commits a transaction. The request includes the mutations to be
@@ -2161,11 +2511,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CommitRequest>,
         ) -> Result<tonic::Response<super::CommitResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Commit");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/Commit",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Rolls back a transaction, releasing any locks it holds. It is a good
@@ -2180,11 +2538,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RollbackRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Rollback");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/Rollback",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a query
@@ -2202,11 +2568,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionQueryRequest>,
         ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/PartitionQuery");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/PartitionQuery",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a read
@@ -2226,11 +2600,19 @@ pub mod spanner_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionReadRequest>,
         ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/PartitionRead");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.spanner.v1.Spanner/PartitionRead",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.storage.v2.rs
+++ b/googleapis/src/google.storage.v2.rs
@@ -1,4 +1,5 @@
 /// Request message for DeleteBucket.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteBucketRequest {
     /// Required. Name of a bucket to delete.
@@ -13,6 +14,7 @@ pub struct DeleteBucketRequest {
     pub if_metageneration_not_match: ::core::option::Option<i64>,
 }
 /// Request message for GetBucket.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBucketRequest {
     /// Required. Name of a bucket.
@@ -33,20 +35,21 @@ pub struct GetBucketRequest {
     pub read_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Request message for CreateBucket.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateBucketRequest {
     /// Required. The project to which this bucket will belong.
     #[prost(string, tag = "1")]
     pub parent: ::prost::alloc::string::String,
-    /// Required. Properties of the new bucket being inserted.
+    /// Properties of the new bucket being inserted.
     /// The project and name of the bucket are specified in the parent and
     /// bucket_id fields, respectively. Populating those fields in `bucket` will
     /// result in an error.
     #[prost(message, optional, tag = "2")]
     pub bucket: ::core::option::Option<Bucket>,
-    /// Required. The ID to use for this bucket, which will become the final component of
-    /// the bucket's resource name. For example, the value `foo` might result in
-    /// a bucket with the name `projects/123456/buckets/foo`.
+    /// Required. The ID to use for this bucket, which will become the final
+    /// component of the bucket's resource name. For example, the value `foo` might
+    /// result in a bucket with the name `projects/123456/buckets/foo`.
     #[prost(string, tag = "3")]
     pub bucket_id: ::prost::alloc::string::String,
     /// Apply a predefined set of access controls to this bucket.
@@ -61,6 +64,7 @@ pub struct CreateBucketRequest {
     pub predefined_default_object_acl: ::prost::alloc::string::String,
 }
 /// Request message for ListBuckets.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListBucketsRequest {
     /// Required. The project whose buckets we are listing.
@@ -87,6 +91,7 @@ pub struct ListBucketsRequest {
     pub read_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// The result of a call to Buckets.ListBuckets
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListBucketsResponse {
     /// The list of items.
@@ -98,20 +103,22 @@ pub struct ListBucketsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request message for LockBucketRetentionPolicyRequest.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LockBucketRetentionPolicyRequest {
     /// Required. Name of a bucket.
     #[prost(string, tag = "1")]
     pub bucket: ::prost::alloc::string::String,
-    /// Makes the operation conditional on whether bucket's current metageneration
-    /// matches the given value. Must be positive.
+    /// Required. Makes the operation conditional on whether bucket's current
+    /// metageneration matches the given value. Must be positive.
     #[prost(int64, tag = "2")]
     pub if_metageneration_match: i64,
 }
 /// Request for UpdateBucket method.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateBucketRequest {
-    /// The bucket to update.
+    /// Required. The bucket to update.
     /// The bucket's `name` field will be used to identify the bucket.
     #[prost(message, optional, tag = "1")]
     pub bucket: ::core::option::Option<Bucket>,
@@ -133,7 +140,7 @@ pub struct UpdateBucketRequest {
     /// "bucketOwnerRead", "private", "projectPrivate", or "publicRead".
     #[prost(string, tag = "9")]
     pub predefined_default_object_acl: ::prost::alloc::string::String,
-    /// List of fields to be updated.
+    /// Required. List of fields to be updated.
     ///
     /// To specify ALL fields, equivalent to the JSON API's "update" function,
     /// specify a single field with the value `*`. Note: not recommended. If a new
@@ -147,6 +154,7 @@ pub struct UpdateBucketRequest {
     pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Request message for DeleteNotification.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteNotificationRequest {
     /// Required. The parent bucket of the notification.
@@ -154,6 +162,7 @@ pub struct DeleteNotificationRequest {
     pub name: ::prost::alloc::string::String,
 }
 /// Request message for GetNotification.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNotificationRequest {
     /// Required. The parent bucket of the notification.
@@ -163,6 +172,7 @@ pub struct GetNotificationRequest {
     pub name: ::prost::alloc::string::String,
 }
 /// Request message for CreateNotification.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateNotificationRequest {
     /// Required. The bucket to which this notification belongs.
@@ -173,6 +183,7 @@ pub struct CreateNotificationRequest {
     pub notification: ::core::option::Option<Notification>,
 }
 /// Request message for ListNotifications.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListNotificationsRequest {
     /// Required. Name of a Google Cloud Storage bucket.
@@ -193,6 +204,7 @@ pub struct ListNotificationsRequest {
     pub page_token: ::prost::alloc::string::String,
 }
 /// The result of a call to Notifications.ListNotifications
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListNotificationsResponse {
     /// The list of items.
@@ -204,6 +216,7 @@ pub struct ListNotificationsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Request message for ComposeObject.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ComposeObjectRequest {
     /// Required. Properties of the resulting object.
@@ -235,14 +248,19 @@ pub struct ComposeObjectRequest {
     /// A set of parameters common to Storage API requests concerning an object.
     #[prost(message, optional, tag = "7")]
     pub common_object_request_params: ::core::option::Option<CommonObjectRequestParams>,
+    /// The checksums of the complete object. This will be validated against the
+    /// combined checksums of the component objects.
+    #[prost(message, optional, tag = "10")]
+    pub object_checksums: ::core::option::Option<ObjectChecksums>,
 }
 /// Nested message and enum types in `ComposeObjectRequest`.
 pub mod compose_object_request {
     /// Description of a source object for a composition request.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct SourceObject {
-        /// Required. The source object's name. All source objects must reside in the same
-        /// bucket.
+        /// Required. The source object's name. All source objects must reside in the
+        /// same bucket.
         #[prost(string, tag = "1")]
         pub name: ::prost::alloc::string::String,
         /// The generation of this object to use as the source.
@@ -250,11 +268,14 @@ pub mod compose_object_request {
         pub generation: i64,
         /// Conditions that must be met for this operation to execute.
         #[prost(message, optional, tag = "3")]
-        pub object_preconditions: ::core::option::Option<source_object::ObjectPreconditions>,
+        pub object_preconditions: ::core::option::Option<
+            source_object::ObjectPreconditions,
+        >,
     }
     /// Nested message and enum types in `SourceObject`.
     pub mod source_object {
         /// Preconditions for a source object of a composition request.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct ObjectPreconditions {
             /// Only perform the composition if the generation of the source object
@@ -267,12 +288,15 @@ pub mod compose_object_request {
 }
 /// Message for deleting an object.
 /// `bucket` and `object` **must** be set.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteObjectRequest {
     /// Required. Name of the bucket in which the object resides.
     #[prost(string, tag = "1")]
     pub bucket: ::prost::alloc::string::String,
-    /// Required. The name of the object to delete (when not using a resumable write).
+    /// Required. The name of the finalized object to delete.
+    /// Note: If you want to delete an unfinalized resumable upload please use
+    /// `CancelResumableWrite`.
     #[prost(string, tag = "2")]
     pub object: ::prost::alloc::string::String,
     /// If present, permanently deletes a specific revision of this object (as
@@ -304,24 +328,27 @@ pub struct DeleteObjectRequest {
 }
 /// Message for canceling an in-progress resumable upload.
 /// `upload_id` **must** be set.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelResumableWriteRequest {
-    /// Required. The upload_id of the resumable upload to cancel. This should be copied
-    /// from the `upload_id` field of `StartResumableWriteResponse`.
+    /// Required. The upload_id of the resumable upload to cancel. This should be
+    /// copied from the `upload_id` field of `StartResumableWriteResponse`.
     #[prost(string, tag = "1")]
     pub upload_id: ::prost::alloc::string::String,
 }
 /// Empty response message for canceling an in-progress resumable upload, will be
 /// extended as needed.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CancelResumableWriteResponse {}
 /// Request message for ReadObject.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReadObjectRequest {
-    /// The name of the bucket containing the object to read.
+    /// Required. The name of the bucket containing the object to read.
     #[prost(string, tag = "1")]
     pub bucket: ::prost::alloc::string::String,
-    /// The name of the object to read.
+    /// Required. The name of the object to read.
     #[prost(string, tag = "2")]
     pub object: ::prost::alloc::string::String,
     /// If present, selects a specific revision of this object (as opposed
@@ -379,6 +406,7 @@ pub struct ReadObjectRequest {
     pub read_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Request message for GetObject.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetObjectRequest {
     /// Required. Name of the bucket in which the object resides.
@@ -421,6 +449,7 @@ pub struct GetObjectRequest {
     pub read_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Response message for ReadObject.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReadObjectResponse {
     /// A portion of the data for the object. The service **may** leave `data`
@@ -445,9 +474,10 @@ pub struct ReadObjectResponse {
     pub metadata: ::core::option::Option<Object>,
 }
 /// Describes an attempt to insert an object, possibly over multiple requests.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WriteObjectSpec {
-    /// Destination object, including its name and its metadata.
+    /// Required. Destination object, including its name and its metadata.
     #[prost(message, optional, tag = "1")]
     pub resource: ::core::option::Option<Object>,
     /// Apply a predefined set of access controls to this object.
@@ -487,10 +517,11 @@ pub struct WriteObjectSpec {
     pub object_size: ::core::option::Option<i64>,
 }
 /// Request message for WriteObject.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WriteObjectRequest {
-    /// Required. The offset from the beginning of the object at which the data should be
-    /// written.
+    /// Required. The offset from the beginning of the object at which the data
+    /// should be written.
     ///
     /// In the first `WriteObjectRequest` of a `WriteObject()` action, it
     /// indicates the initial offset for the `Write()` call. The value **must** be
@@ -531,6 +562,7 @@ pub struct WriteObjectRequest {
 /// Nested message and enum types in `WriteObjectRequest`.
 pub mod write_object_request {
     /// The first message of each stream should set one of the following.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum FirstMessage {
         /// For resumable uploads. This should be the `upload_id` returned from a
@@ -543,6 +575,7 @@ pub mod write_object_request {
         WriteObjectSpec(super::WriteObjectSpec),
     }
     /// A portion of the data for the object.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Data {
         /// The data to insert. If a crc32c checksum is provided that doesn't match
@@ -552,6 +585,7 @@ pub mod write_object_request {
     }
 }
 /// Response message for WriteObject.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WriteObjectResponse {
     /// The response will set one of the following.
@@ -561,6 +595,7 @@ pub struct WriteObjectResponse {
 /// Nested message and enum types in `WriteObjectResponse`.
 pub mod write_object_response {
     /// The response will set one of the following.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum WriteStatus {
         /// The total number of bytes that have been processed for the given object
@@ -574,6 +609,7 @@ pub mod write_object_response {
     }
 }
 /// Request message for ListObjects.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListObjectsRequest {
     /// Required. Name of the bucket in which to look for objects.
@@ -617,24 +653,25 @@ pub struct ListObjectsRequest {
     /// * may be used to mean "all fields".
     #[prost(message, optional, tag = "8")]
     pub read_mask: ::core::option::Option<::prost_types::FieldMask>,
-    /// Filter results to objects whose names are lexicographically equal to or
-    /// after lexicographic_start. If lexicographic_end is also set, the objects
-    /// listed have names between lexicographic_start (inclusive) and
+    /// Optional. Filter results to objects whose names are lexicographically equal
+    /// to or after lexicographic_start. If lexicographic_end is also set, the
+    /// objects listed have names between lexicographic_start (inclusive) and
     /// lexicographic_end (exclusive).
     #[prost(string, tag = "10")]
     pub lexicographic_start: ::prost::alloc::string::String,
-    /// Filter results to objects whose names are lexicographically before
-    /// lexicographic_end. If lexicographic_start is also set, the objects listed
-    /// have names between lexicographic_start (inclusive) and lexicographic_end
-    /// (exclusive).
+    /// Optional. Filter results to objects whose names are lexicographically
+    /// before lexicographic_end. If lexicographic_start is also set, the objects
+    /// listed have names between lexicographic_start (inclusive) and
+    /// lexicographic_end (exclusive).
     #[prost(string, tag = "11")]
     pub lexicographic_end: ::prost::alloc::string::String,
 }
 /// Request object for `QueryWriteStatus`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryWriteStatusRequest {
-    /// Required. The name of the resume token for the object whose write status is being
-    /// requested.
+    /// Required. The name of the resume token for the object whose write status is
+    /// being requested.
     #[prost(string, tag = "1")]
     pub upload_id: ::prost::alloc::string::String,
     /// A set of parameters common to Storage API requests concerning an object.
@@ -642,6 +679,7 @@ pub struct QueryWriteStatusRequest {
     pub common_object_request_params: ::core::option::Option<CommonObjectRequestParams>,
 }
 /// Response object for `QueryWriteStatus`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryWriteStatusResponse {
     /// The response will set one of the following.
@@ -651,6 +689,7 @@ pub struct QueryWriteStatusResponse {
 /// Nested message and enum types in `QueryWriteStatusResponse`.
 pub mod query_write_status_response {
     /// The response will set one of the following.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum WriteStatus {
         /// The total number of bytes that have been processed for the given object
@@ -673,18 +712,20 @@ pub mod query_write_status_response {
 /// should be provided in the encryption_algorithm, encryption_key_bytes, and
 /// encryption_key_sha256_bytes fields of the
 /// common_object_request_params.customer_encryption field.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RewriteObjectRequest {
-    /// Immutable. The name of the destination object.
+    /// Required. Immutable. The name of the destination object.
     /// See the
-    /// [Naming Guidelines](<https://cloud.google.com/storage/docs/naming-objects>).
+    /// [Naming Guidelines](<https://cloud.google.com/storage/docs/objects#naming>).
     /// Example: `test.txt`
     /// The `name` field by itself does not uniquely identify a Cloud Storage
     /// object. A Cloud Storage object is uniquely identified by the tuple of
     /// (bucket, object, generation).
     #[prost(string, tag = "24")]
     pub destination_name: ::prost::alloc::string::String,
-    /// Immutable. The name of the bucket containing the destination object.
+    /// Required. Immutable. The name of the bucket containing the destination
+    /// object.
     #[prost(string, tag = "25")]
     pub destination_bucket: ::prost::alloc::string::String,
     /// The name of the Cloud KMS key that will be used to encrypt the destination
@@ -787,8 +828,13 @@ pub struct RewriteObjectRequest {
     /// A set of parameters common to Storage API requests concerning an object.
     #[prost(message, optional, tag = "19")]
     pub common_object_request_params: ::core::option::Option<CommonObjectRequestParams>,
+    /// The checksums of the complete object. This will be used to validate the
+    /// destination object after rewriting.
+    #[prost(message, optional, tag = "29")]
+    pub object_checksums: ::core::option::Option<ObjectChecksums>,
 }
 /// A rewrite response.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RewriteResponse {
     /// The total bytes written so far, which can be used to provide a waiting user
@@ -813,16 +859,25 @@ pub struct RewriteResponse {
     pub resource: ::core::option::Option<Object>,
 }
 /// Request message StartResumableWrite.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StartResumableWriteRequest {
-    /// The destination bucket, object, and metadata, as well as any preconditions.
+    /// Required. The destination bucket, object, and metadata, as well as any
+    /// preconditions.
     #[prost(message, optional, tag = "1")]
     pub write_object_spec: ::core::option::Option<WriteObjectSpec>,
     /// A set of parameters common to Storage API requests concerning an object.
     #[prost(message, optional, tag = "3")]
     pub common_object_request_params: ::core::option::Option<CommonObjectRequestParams>,
+    /// The checksums of the complete object. This will be used to validate the
+    /// uploaded object. For each upload, object_checksums can be provided with
+    /// either StartResumableWriteRequest or the WriteObjectRequest with
+    /// finish_write set to `true`.
+    #[prost(message, optional, tag = "5")]
+    pub object_checksums: ::core::option::Option<ObjectChecksums>,
 }
 /// Response object for `StartResumableWrite`.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StartResumableWriteResponse {
     /// The upload_id of the newly started resumable write operation. This
@@ -831,9 +886,10 @@ pub struct StartResumableWriteResponse {
     pub upload_id: ::prost::alloc::string::String,
 }
 /// Request message for UpdateObject.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateObjectRequest {
-    /// The object to update.
+    /// Required. The object to update.
     /// The object's bucket and name fields are used to identify the object to
     /// update. If present, the object's generation field selects a specific
     /// revision of this object whose metadata should be updated. Otherwise,
@@ -864,7 +920,7 @@ pub struct UpdateObjectRequest {
     /// "bucketOwnerRead", "private", "projectPrivate", or "publicRead".
     #[prost(string, tag = "10")]
     pub predefined_acl: ::prost::alloc::string::String,
-    /// List of fields to be updated.
+    /// Required. List of fields to be updated.
     ///
     /// To specify ALL fields, equivalent to the JSON API's "update" function,
     /// specify a single field with the value `*`. Note: not recommended. If a new
@@ -881,6 +937,7 @@ pub struct UpdateObjectRequest {
     pub common_object_request_params: ::core::option::Option<CommonObjectRequestParams>,
 }
 /// Request message for GetServiceAccount.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetServiceAccountRequest {
     /// Required. Project ID, in the format of "projects/<projectIdentifier>".
@@ -889,11 +946,12 @@ pub struct GetServiceAccountRequest {
     pub project: ::prost::alloc::string::String,
 }
 /// Request message for CreateHmacKey.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateHmacKeyRequest {
-    /// Required. The project that the HMAC-owning service account lives in, in the format of
-    /// "projects/<projectIdentifier>".
-    /// <projectIdentifier> can be the project ID or project number.
+    /// Required. The project that the HMAC-owning service account lives in, in the
+    /// format of "projects/<projectIdentifier>". <projectIdentifier> can be the
+    /// project ID or project number.
     #[prost(string, tag = "1")]
     pub project: ::prost::alloc::string::String,
     /// Required. The service account to create the HMAC for.
@@ -901,6 +959,7 @@ pub struct CreateHmacKeyRequest {
     pub service_account_email: ::prost::alloc::string::String,
 }
 /// Create hmac response.  The only time the secret for an HMAC will be returned.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateHmacKeyResponse {
     /// Key metadata.
@@ -912,6 +971,7 @@ pub struct CreateHmacKeyResponse {
     pub secret_key_bytes: ::prost::alloc::vec::Vec<u8>,
 }
 /// Request object to delete a given HMAC key.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteHmacKeyRequest {
     /// Required. The identifying key for the HMAC to delete.
@@ -924,6 +984,7 @@ pub struct DeleteHmacKeyRequest {
     pub project: ::prost::alloc::string::String,
 }
 /// Request object to get metadata on a given HMAC key.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetHmacKeyRequest {
     /// Required. The identifying key for the HMAC to delete.
@@ -936,6 +997,7 @@ pub struct GetHmacKeyRequest {
     pub project: ::prost::alloc::string::String,
 }
 /// Request to fetch a list of HMAC keys under a given project.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListHmacKeysRequest {
     /// Required. The project to list HMAC keys for, in the format of
@@ -943,20 +1005,21 @@ pub struct ListHmacKeysRequest {
     /// <projectIdentifier> can be the project ID or project number.
     #[prost(string, tag = "1")]
     pub project: ::prost::alloc::string::String,
-    /// Optional. The maximum number of keys to return.
+    /// The maximum number of keys to return.
     #[prost(int32, tag = "2")]
     pub page_size: i32,
-    /// Optional. A previously returned token from ListHmacKeysResponse to get the next page.
+    /// A previously returned token from ListHmacKeysResponse to get the next page.
     #[prost(string, tag = "3")]
     pub page_token: ::prost::alloc::string::String,
-    /// Optional. If set, filters to only return HMAC keys for specified service account.
+    /// If set, filters to only return HMAC keys for specified service account.
     #[prost(string, tag = "4")]
     pub service_account_email: ::prost::alloc::string::String,
-    /// Optional. If set, return deleted keys that have not yet been wiped out.
+    /// If set, return deleted keys that have not yet been wiped out.
     #[prost(bool, tag = "5")]
     pub show_deleted_keys: bool,
 }
 /// Hmac key list response with next page information.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListHmacKeysResponse {
     /// The list of items.
@@ -971,6 +1034,7 @@ pub struct ListHmacKeysResponse {
 /// HmacKeyMetadata.state is required and the only writable field in
 /// UpdateHmacKey operation. Specifying fields other than state will result in an
 /// error.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateHmacKeyRequest {
     /// Required. The HMAC key to update.
@@ -986,6 +1050,7 @@ pub struct UpdateHmacKeyRequest {
     pub update_mask: ::core::option::Option<::prost_types::FieldMask>,
 }
 /// Parameters that can be passed to any object request.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommonObjectRequestParams {
     /// Encryption algorithm used with the Customer-Supplied Encryption Keys
@@ -1002,12 +1067,23 @@ pub struct CommonObjectRequestParams {
     pub encryption_key_sha256_bytes: ::prost::alloc::vec::Vec<u8>,
 }
 /// Shared constants.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceConstants {}
 /// Nested message and enum types in `ServiceConstants`.
 pub mod service_constants {
     /// A collection of constant values meaningful to the Storage API.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Values {
         /// Unused. Proto3 requires first enum to be 0.
@@ -1059,16 +1135,58 @@ pub mod service_constants {
         /// GetListObjectsSplitPoints RPC is valid.
         SplitTokenMaxValidDays = 14,
     }
+    impl Values {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Values::Unspecified => "VALUES_UNSPECIFIED",
+                Values::MaxReadChunkBytes => "MAX_READ_CHUNK_BYTES",
+                Values::MaxObjectSizeMb => "MAX_OBJECT_SIZE_MB",
+                Values::MaxCustomMetadataFieldNameBytes => {
+                    "MAX_CUSTOM_METADATA_FIELD_NAME_BYTES"
+                }
+                Values::MaxCustomMetadataFieldValueBytes => {
+                    "MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES"
+                }
+                Values::MaxCustomMetadataTotalSizeBytes => {
+                    "MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES"
+                }
+                Values::MaxBucketMetadataTotalSizeBytes => {
+                    "MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES"
+                }
+                Values::MaxNotificationConfigsPerBucket => {
+                    "MAX_NOTIFICATION_CONFIGS_PER_BUCKET"
+                }
+                Values::MaxNotificationCustomAttributes => {
+                    "MAX_NOTIFICATION_CUSTOM_ATTRIBUTES"
+                }
+                Values::MaxNotificationCustomAttributeKeyLength => {
+                    "MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH"
+                }
+                Values::MaxLabelsEntriesCount => "MAX_LABELS_ENTRIES_COUNT",
+                Values::MaxLabelsKeyValueLength => "MAX_LABELS_KEY_VALUE_LENGTH",
+                Values::MaxLabelsKeyValueBytes => "MAX_LABELS_KEY_VALUE_BYTES",
+                Values::MaxObjectIdsPerDeleteObjectsRequest => {
+                    "MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST"
+                }
+                Values::SplitTokenMaxValidDays => "SPLIT_TOKEN_MAX_VALID_DAYS",
+            }
+        }
+    }
 }
 /// A bucket.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bucket {
     /// Immutable. The name of the bucket.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    /// Output only. The user-chosen part of the bucket name. The `{bucket}` portion of the
-    /// `name` field. For globally unique buckets, this is equal to the "bucket
-    /// name" of other Cloud Storage APIs. Example: "pub".
+    /// Output only. The user-chosen part of the bucket name. The `{bucket}`
+    /// portion of the `name` field. For globally unique buckets, this is equal to
+    /// the "bucket name" of other Cloud Storage APIs. Example: "pub".
     #[prost(string, tag = "2")]
     pub bucket_id: ::prost::alloc::string::String,
     /// The etag of the bucket.
@@ -1086,14 +1204,16 @@ pub struct Bucket {
     /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(int64, tag = "4")]
     pub metageneration: i64,
-    /// Immutable. The location of the bucket. Object data for objects in the bucket resides
-    /// in physical storage within this region.  Defaults to `US`. See the
+    /// Immutable. The location of the bucket. Object data for objects in the
+    /// bucket resides in physical storage within this region.  Defaults to `US`.
+    /// See the
     /// \[<https://developers.google.com/storage/docs/concepts-techniques#specifyinglocations"\][developer's>
     /// guide] for the authoritative list. Attempting to update this field after
     /// the bucket is created will result in an error.
     #[prost(string, tag = "5")]
     pub location: ::prost::alloc::string::String,
-    /// Output only. The location type of the bucket (region, dual-region, multi-region, etc).
+    /// Output only. The location type of the bucket (region, dual-region,
+    /// multi-region, etc).
     #[prost(string, tag = "6")]
     pub location_type: ::prost::alloc::string::String,
     /// The bucket's default storage class, used whenever no storageClass is
@@ -1113,12 +1233,12 @@ pub struct Bucket {
     #[prost(string, tag = "27")]
     pub rpo: ::prost::alloc::string::String,
     /// Access controls on the bucket.
-    /// If iamConfig.uniformBucketLevelAccess is enabled on this bucket,
+    /// If iam_config.uniform_bucket_level_access is enabled on this bucket,
     /// requests to set, read, or modify acl is an error.
     #[prost(message, repeated, tag = "8")]
     pub acl: ::prost::alloc::vec::Vec<BucketAccessControl>,
     /// Default access controls to apply to new objects when no ACL is provided.
-    /// If iamConfig.uniformBucketLevelAccess is enabled on this bucket,
+    /// If iam_config.uniform_bucket_level_access is enabled on this bucket,
     /// requests to set, read, or modify acl is an error.
     #[prost(message, repeated, tag = "9")]
     pub default_object_acl: ::prost::alloc::vec::Vec<ObjectAccessControl>,
@@ -1158,7 +1278,10 @@ pub struct Bucket {
     pub default_event_based_hold: bool,
     /// User-provided labels, in key/value pairs.
     #[prost(map = "string, string", tag = "15")]
-    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub labels: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// The bucket's website config, controlling how the service behaves
     /// when accessing bucket contents as a web site. See the
     /// \[<https://cloud.google.com/storage/docs/static-website\][Static> Website
@@ -1172,7 +1295,8 @@ pub struct Bucket {
     /// and name prefix (if any) for the current bucket's logs.
     #[prost(message, optional, tag = "18")]
     pub logging: ::core::option::Option<bucket::Logging>,
-    /// Output only. The owner of the bucket. This is always the project team's owner group.
+    /// Output only. The owner of the bucket. This is always the project team's
+    /// owner group.
     #[prost(message, optional, tag = "19")]
     pub owner: ::core::option::Option<Owner>,
     /// Encryption config for a bucket.
@@ -1198,8 +1322,8 @@ pub struct Bucket {
     /// Reserved for future use.
     #[prost(bool, tag = "25")]
     pub satisfies_pzs: bool,
-    /// Configuration that, if present, specifies the data placement for a Custom
-    /// Dual Region.
+    /// Configuration that, if present, specifies the data placement for a
+    /// \[<https://cloud.google.com/storage/docs/use-dual-regions\][Dual> Region].
     #[prost(message, optional, tag = "26")]
     pub custom_placement_config: ::core::option::Option<bucket::CustomPlacementConfig>,
     /// The bucket's Autoclass configuration. If there is no configuration, the
@@ -1210,6 +1334,7 @@ pub struct Bucket {
 /// Nested message and enum types in `Bucket`.
 pub mod bucket {
     /// Billing properties of a bucket.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Billing {
         /// When set to true, Requester Pays is enabled for this bucket.
@@ -1220,6 +1345,7 @@ pub mod bucket {
     /// For more on Cloud Storage and CORS, see
     /// <https://cloud.google.com/storage/docs/cross-origin.>
     /// For more on CORS in general, see <https://tools.ietf.org/html/rfc6454.>
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Cors {
         /// The list of Origins eligible to receive CORS response headers. See
@@ -1244,6 +1370,7 @@ pub mod bucket {
         pub max_age_seconds: i32,
     }
     /// Encryption properties of a bucket.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Encryption {
         /// The name of the Cloud KMS key that will be used to encrypt objects
@@ -1252,11 +1379,14 @@ pub mod bucket {
         pub default_kms_key: ::prost::alloc::string::String,
     }
     /// Bucket restriction options.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct IamConfig {
         /// Bucket restriction options currently enforced on the bucket.
         #[prost(message, optional, tag = "1")]
-        pub uniform_bucket_level_access: ::core::option::Option<iam_config::UniformBucketLevelAccess>,
+        pub uniform_bucket_level_access: ::core::option::Option<
+            iam_config::UniformBucketLevelAccess,
+        >,
         /// Whether IAM will enforce public access prevention. Valid values are
         /// "enforced" or "inherited".
         #[prost(string, tag = "3")]
@@ -1266,20 +1396,23 @@ pub mod bucket {
     pub mod iam_config {
         /// Settings for Uniform Bucket level access.
         /// See <https://cloud.google.com/storage/docs/uniform-bucket-level-access.>
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct UniformBucketLevelAccess {
             /// If set, access checks only use bucket-level IAM policies or above.
             #[prost(bool, tag = "1")]
             pub enabled: bool,
             /// The deadline time for changing
-            /// `iamConfig.uniformBucketLevelAccess.enabled` from `true` to `false`.
-            /// Mutable until the specified deadline is reached, but not afterward.
+            /// `iam_config.uniform_bucket_level_access.enabled` from `true` to
+            /// `false`. Mutable until the specified deadline is reached, but not
+            /// afterward.
             #[prost(message, optional, tag = "2")]
             pub lock_time: ::core::option::Option<::prost_types::Timestamp>,
         }
     }
     /// Lifecycle properties of a bucket.
     /// For more information, see <https://cloud.google.com/storage/docs/lifecycle.>
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Lifecycle {
         /// A lifecycle management rule, which is made of an action to take and the
@@ -1291,6 +1424,7 @@ pub mod bucket {
     pub mod lifecycle {
         /// A lifecycle Rule, combining an action to take on an object and a
         /// condition which will trigger that action.
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Rule {
             /// The action to take.
@@ -1303,6 +1437,7 @@ pub mod bucket {
         /// Nested message and enum types in `Rule`.
         pub mod rule {
             /// An action to take on an object.
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct Action {
                 /// Type of the action. Currently, only `Delete`, `SetStorageClass`, and
@@ -1315,6 +1450,7 @@ pub mod bucket {
                 pub storage_class: ::prost::alloc::string::String,
             }
             /// A condition of an object which triggers some action.
+            #[allow(clippy::derive_partial_eq_without_eq)]
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct Condition {
                 /// Age of an object (in days). This condition is satisfied when an
@@ -1326,7 +1462,9 @@ pub mod bucket {
                 /// This condition is satisfied when an object is created before midnight
                 /// of the specified date in UTC.
                 #[prost(message, optional, tag = "2")]
-                pub created_before: ::core::option::Option<super::super::super::super::super::r#type::Date>,
+                pub created_before: ::core::option::Option<
+                    super::super::super::super::super::r#type::Date,
+                >,
                 /// Relevant only for versioned objects. If the value is
                 /// `true`, this condition matches live objects; if the value
                 /// is `false`, it matches archived objects.
@@ -1342,7 +1480,9 @@ pub mod bucket {
                 /// `NEARLINE`, `COLDLINE`, `STANDARD`, and
                 /// `DURABLE_REDUCED_AVAILABILITY`.
                 #[prost(string, repeated, tag = "5")]
-                pub matches_storage_class: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+                pub matches_storage_class: ::prost::alloc::vec::Vec<
+                    ::prost::alloc::string::String,
+                >,
                 /// Number of days that have elapsed since the custom timestamp set on an
                 /// object.
                 /// The value of the field must be a nonnegative integer.
@@ -1351,7 +1491,9 @@ pub mod bucket {
                 /// An object matches this condition if the custom timestamp set on the
                 /// object is before the specified date in UTC.
                 #[prost(message, optional, tag = "8")]
-                pub custom_time_before: ::core::option::Option<super::super::super::super::super::r#type::Date>,
+                pub custom_time_before: ::core::option::Option<
+                    super::super::super::super::super::r#type::Date,
+                >,
                 /// This condition is relevant only for versioned objects. An object
                 /// version satisfies this condition only if these many days have been
                 /// passed since it became noncurrent. The value of the field must be a
@@ -1363,19 +1505,26 @@ pub mod bucket {
                 /// version satisfies this condition only if it became noncurrent before
                 /// the specified date in UTC.
                 #[prost(message, optional, tag = "10")]
-                pub noncurrent_time_before: ::core::option::Option<super::super::super::super::super::r#type::Date>,
+                pub noncurrent_time_before: ::core::option::Option<
+                    super::super::super::super::super::r#type::Date,
+                >,
                 /// List of object name prefixes. If any prefix exactly matches the
                 /// beginning of the object name, the condition evaluates to true.
                 #[prost(string, repeated, tag = "11")]
-                pub matches_prefix: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+                pub matches_prefix: ::prost::alloc::vec::Vec<
+                    ::prost::alloc::string::String,
+                >,
                 /// List of object name suffixes. If any suffix exactly matches the
                 /// end of the object name, the condition evaluates to true.
                 #[prost(string, repeated, tag = "12")]
-                pub matches_suffix: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+                pub matches_suffix: ::prost::alloc::vec::Vec<
+                    ::prost::alloc::string::String,
+                >,
             }
         }
     }
     /// Logging-related properties of a bucket.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Logging {
         /// The destination bucket where the current bucket's logs should be placed,
@@ -1387,6 +1536,7 @@ pub mod bucket {
         pub log_object_prefix: ::prost::alloc::string::String,
     }
     /// Retention policy properties of a bucket.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RetentionPolicy {
         /// Server-determined value that indicates the time from which policy was
@@ -1400,12 +1550,20 @@ pub mod bucket {
         /// duration must be greater than zero and less than 100 years. Note that
         /// enforcement of retention periods less than a day is not guaranteed. Such
         /// periods should only be used for testing purposes.
-        #[prost(int64, tag = "3")]
-        pub retention_period: i64,
+        #[prost(int64, optional, tag = "3")]
+        pub retention_period: ::core::option::Option<i64>,
+        /// The duration that objects need to be retained. Retention duration must be
+        /// greater than zero and less than 100 years. Note that enforcement of
+        /// retention periods less than a day is not guaranteed. Such periods should
+        /// only be used for testing purposes. Any `nanos` value specified will be
+        /// rounded down to the nearest second.
+        #[prost(message, optional, tag = "4")]
+        pub retention_duration: ::core::option::Option<::prost_types::Duration>,
     }
     /// Properties of a bucket related to versioning.
     /// For more on Cloud Storage versioning, see
     /// <https://cloud.google.com/storage/docs/object-versioning.>
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Versioning {
         /// While set to true, versioning is fully enabled for this bucket.
@@ -1415,6 +1573,7 @@ pub mod bucket {
     /// Properties of a bucket related to accessing the contents as a static
     /// website. For more on hosting a static website via Cloud Storage, see
     /// <https://cloud.google.com/storage/docs/hosting-static-website.>
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Website {
         /// If the requested object path is missing, the service will ensure the path
@@ -1434,6 +1593,7 @@ pub mod bucket {
     /// Configuration for Custom Dual Regions.  It should specify precisely two
     /// eligible regions within the same Multiregion. More information on regions
     /// may be found \[<https://cloud.google.com/storage/docs/locations][here\].>
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CustomPlacementConfig {
         /// List of locations to use for data placement.
@@ -1441,20 +1601,22 @@ pub mod bucket {
         pub data_locations: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     }
     /// Configuration for a bucket's Autoclass feature.
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Autoclass {
         /// Enables Autoclass.
         #[prost(bool, tag = "1")]
         pub enabled: bool,
-        /// Output only. Latest instant at which the `enabled` field was set to true after being
-        /// disabled/unconfigured or set to false after being enabled. If Autoclass
-        /// is enabled when the bucket is created, the toggle_time is set to the
-        /// bucket creation time.
+        /// Output only. Latest instant at which the `enabled` field was set to true
+        /// after being disabled/unconfigured or set to false after being enabled. If
+        /// Autoclass is enabled when the bucket is created, the toggle_time is set
+        /// to the bucket creation time.
         #[prost(message, optional, tag = "2")]
         pub toggle_time: ::core::option::Option<::prost_types::Timestamp>,
     }
 }
 /// An access-control entry.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BucketAccessControl {
     /// The access permission for the entity.
@@ -1469,7 +1631,8 @@ pub struct BucketAccessControl {
     /// * `group-{groupid}`
     /// * `group-{email}`
     /// * `domain-{domain}`
-    /// * `project-{team-projectid}`
+    /// * `project-{team}-{projectnumber}`
+    /// * `project-{team}-{projectid}`
     /// * `allUsers`
     /// * `allAuthenticatedUsers`
     /// Examples:
@@ -1478,8 +1641,14 @@ pub struct BucketAccessControl {
     /// `group-example@googlegroups.com`
     /// * All members of the Google Apps for Business domain `example.com` would be
     /// `domain-example.com`
+    /// For project entities, `project-{team}-{projectnumber}` format will be
+    /// returned on response.
     #[prost(string, tag = "3")]
     pub entity: ::prost::alloc::string::String,
+    /// Output only. The alternative entity format, if exists. For project
+    /// entities, `project-{team}-{projectid}` format will be returned on response.
+    #[prost(string, tag = "9")]
+    pub entity_alt: ::prost::alloc::string::String,
     /// The ID for the entity, if any.
     #[prost(string, tag = "4")]
     pub entity_id: ::prost::alloc::string::String,
@@ -1501,6 +1670,7 @@ pub struct BucketAccessControl {
 }
 /// Message used to convey content being read or written, along with an optional
 /// checksum.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChecksummedData {
     /// The data.
@@ -1511,6 +1681,7 @@ pub struct ChecksummedData {
     pub crc32c: ::core::option::Option<u32>,
 }
 /// Message used for storing full (not subrange) object checksums.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectChecksums {
     /// CRC32C digest of the object data. Computed by the Cloud Storage service for
@@ -1530,6 +1701,7 @@ pub struct ObjectChecksums {
     pub md5_hash: ::prost::alloc::vec::Vec<u8>,
 }
 /// Hmac Key Metadata, which includes all information other than the secret.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HmacKeyMetadata {
     /// Immutable. Resource name ID of the key in the format
@@ -1540,9 +1712,9 @@ pub struct HmacKeyMetadata {
     /// Immutable. Globally unique id for keys.
     #[prost(string, tag = "2")]
     pub access_id: ::prost::alloc::string::String,
-    /// Immutable. Identifies the project that owns the service account of the specified HMAC
-    /// key, in the format "projects/<projectIdentifier>". <projectIdentifier> can
-    /// be the project ID or project number.
+    /// Immutable. Identifies the project that owns the service account of the
+    /// specified HMAC key, in the format "projects/<projectIdentifier>".
+    /// <projectIdentifier> can be the project ID or project number.
     #[prost(string, tag = "3")]
     pub project: ::prost::alloc::string::String,
     /// Output only. Email of the service account the key authenticates as.
@@ -1563,6 +1735,7 @@ pub struct HmacKeyMetadata {
     pub etag: ::prost::alloc::string::String,
 }
 /// A directive to publish Pub/Sub notifications upon changes to a bucket.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Notification {
     /// Required. The resource name of this notification.
@@ -1571,7 +1744,8 @@ pub struct Notification {
     /// The `{project}` portion may be `_` for globally unique buckets.
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
-    /// Required. The Pub/Sub topic to which this subscription publishes. Formatted as:
+    /// Required. The Pub/Sub topic to which this subscription publishes. Formatted
+    /// as:
     /// '//pubsub.googleapis.com/projects/{project-identifier}/topics/{my-topic}'
     #[prost(string, tag = "2")]
     pub topic: ::prost::alloc::string::String,
@@ -1580,15 +1754,18 @@ pub struct Notification {
     /// only be performed if the etag matches that of the Notification.
     #[prost(string, tag = "7")]
     pub etag: ::prost::alloc::string::String,
-    /// Optional. If present, only send notifications about listed event types. If empty,
+    /// If present, only send notifications about listed event types. If empty,
     /// sent notifications for all event types.
     #[prost(string, repeated, tag = "3")]
     pub event_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Optional. An optional list of additional attributes to attach to each Pub/Sub
+    /// A list of additional attributes to attach to each Pub/Sub
     /// message published for this notification subscription.
     #[prost(map = "string, string", tag = "4")]
-    pub custom_attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
-    /// Optional. If present, only apply this notification config to object names that
+    pub custom_attributes: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
+    /// If present, only apply this notification config to object names that
     /// begin with this prefix.
     #[prost(string, tag = "5")]
     pub object_name_prefix: ::prost::alloc::string::String,
@@ -1598,6 +1775,7 @@ pub struct Notification {
 }
 /// Describes the Customer-Supplied Encryption Key mechanism used to store an
 /// Object's data at rest.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CustomerEncryption {
     /// The encryption algorithm.
@@ -1609,11 +1787,12 @@ pub struct CustomerEncryption {
     pub key_sha256_bytes: ::prost::alloc::vec::Vec<u8>,
 }
 /// An object.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Object {
-    /// Immutable. The name of this object. Nearly any sequence of unicode characters is
-    /// valid. See
-    /// \[Guidelines\](<https://cloud.google.com/storage/docs/naming-objects>).
+    /// Immutable. The name of this object. Nearly any sequence of unicode
+    /// characters is valid. See
+    /// \[Guidelines\](<https://cloud.google.com/storage/docs/objects#naming>).
     /// Example: `test.txt`
     /// The `name` field by itself does not uniquely identify a Cloud Storage
     /// object. A Cloud Storage object is uniquely identified by the tuple of
@@ -1629,17 +1808,16 @@ pub struct Object {
     /// object.
     #[prost(string, tag = "27")]
     pub etag: ::prost::alloc::string::String,
-    /// Immutable. The content generation of this object. Used for object versioning.
-    /// Attempting to set or update this field will result in a
+    /// Immutable. The content generation of this object. Used for object
+    /// versioning. Attempting to set or update this field will result in a
     /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(int64, tag = "3")]
     pub generation: i64,
-    /// Output only. The version of the metadata for this generation of this object. Used for
-    /// preconditions and for detecting changes in metadata. A metageneration
-    /// number is only meaningful in the context of a particular generation of a
-    /// particular object.
-    /// Attempting to set or update this field will result in a
-    /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
+    /// Output only. The version of the metadata for this generation of this
+    /// object. Used for preconditions and for detecting changes in metadata. A
+    /// metageneration number is only meaningful in the context of a particular
+    /// generation of a particular object. Attempting to set or update this field
+    /// will result in a \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(int64, tag = "4")]
     pub metageneration: i64,
     /// Storage class of the object.
@@ -1666,7 +1844,7 @@ pub struct Object {
     #[prost(string, tag = "9")]
     pub cache_control: ::prost::alloc::string::String,
     /// Access controls on the object.
-    /// If iamConfig.uniformBucketLevelAccess is enabled on the parent
+    /// If iam_config.uniform_bucket_level_access is enabled on the parent
     /// bucket, requests to set, read, or modify acl is an error.
     #[prost(message, repeated, tag = "10")]
     pub acl: ::prost::alloc::vec::Vec<ObjectAccessControl>,
@@ -1674,9 +1852,9 @@ pub struct Object {
     /// \[<https://tools.ietf.org/html/rfc7231#section-3.1.3.2\][RFC> 7231 §3.1.3.2].
     #[prost(string, tag = "11")]
     pub content_language: ::prost::alloc::string::String,
-    /// Output only. The deletion time of the object. Will be returned if and only if this
-    /// version of the object has been deleted.
-    /// Attempting to set or update this field will result in a
+    /// Output only. The deletion time of the object. Will be returned if and only
+    /// if this version of the object has been deleted. Attempting to set or update
+    /// this field will result in a
     /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(message, optional, tag = "12")]
     pub delete_time: ::core::option::Option<::prost_types::Timestamp>,
@@ -1691,13 +1869,14 @@ pub struct Object {
     /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(message, optional, tag = "14")]
     pub create_time: ::core::option::Option<::prost_types::Timestamp>,
-    /// Output only. Number of underlying components that make up this object. Components are
-    /// accumulated by compose operations.
-    /// Attempting to set or update this field will result in a
+    /// Output only. Number of underlying components that make up this object.
+    /// Components are accumulated by compose operations. Attempting to set or
+    /// update this field will result in a
     /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(int32, tag = "15")]
     pub component_count: i32,
-    /// Output only. Hashes for the data part of this object.
+    /// Output only. Hashes for the data part of this object. This field is used
+    /// for output only and will be silently ignored if provided in requests.
     #[prost(message, optional, tag = "16")]
     pub checksums: ::core::option::Option<ObjectChecksums>,
     /// Output only. The modification time of the object metadata.
@@ -1714,8 +1893,8 @@ pub struct Object {
     /// such a key.
     #[prost(string, tag = "18")]
     pub kms_key: ::prost::alloc::string::String,
-    /// Output only. The time at which the object's storage class was last changed. When the
-    /// object is initially created, it will be set to time_created.
+    /// Output only. The time at which the object's storage class was last changed.
+    /// When the object is initially created, it will be set to time_created.
     /// Attempting to set or update this field will result in a
     /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(message, optional, tag = "19")]
@@ -1738,7 +1917,10 @@ pub struct Object {
     pub retention_expire_time: ::core::option::Option<::prost_types::Timestamp>,
     /// User-provided metadata, in key/value pairs.
     #[prost(map = "string, string", tag = "22")]
-    pub metadata: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    pub metadata: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// Whether an object is under event-based hold.
     /// An event-based hold is a way to force the retention of an object until
     /// after some event occurs. Once the hold is released by explicitly setting
@@ -1752,8 +1934,8 @@ pub struct Object {
     /// In a response, this field will always be set to true or false.
     #[prost(bool, optional, tag = "23")]
     pub event_based_hold: ::core::option::Option<bool>,
-    /// Output only. The owner of the object. This will always be the uploader of the object.
-    /// Attempting to set or update this field will result in a
+    /// Output only. The owner of the object. This will always be the uploader of
+    /// the object. Attempting to set or update this field will result in a
     /// \[FieldViolation][google.rpc.BadRequest.FieldViolation\].
     #[prost(message, optional, tag = "24")]
     pub owner: ::core::option::Option<Owner>,
@@ -1766,6 +1948,7 @@ pub struct Object {
     pub custom_time: ::core::option::Option<::prost_types::Timestamp>,
 }
 /// An access-control entry.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectAccessControl {
     /// The access permission for the entity.
@@ -1780,7 +1963,8 @@ pub struct ObjectAccessControl {
     /// * `group-{groupid}`
     /// * `group-{email}`
     /// * `domain-{domain}`
-    /// * `project-{team-projectid}`
+    /// * `project-{team}-{projectnumber}`
+    /// * `project-{team}-{projectid}`
     /// * `allUsers`
     /// * `allAuthenticatedUsers`
     /// Examples:
@@ -1789,8 +1973,14 @@ pub struct ObjectAccessControl {
     /// `group-example@googlegroups.com`.
     /// * All members of the Google Apps for Business domain `example.com` would be
     /// `domain-example.com`.
+    /// For project entities, `project-{team}-{projectnumber}` format will be
+    /// returned on response.
     #[prost(string, tag = "3")]
     pub entity: ::prost::alloc::string::String,
+    /// Output only. The alternative entity format, if exists. For project
+    /// entities, `project-{team}-{projectid}` format will be returned on response.
+    #[prost(string, tag = "9")]
+    pub entity_alt: ::prost::alloc::string::String,
     /// The ID for the entity, if any.
     #[prost(string, tag = "4")]
     pub entity_id: ::prost::alloc::string::String,
@@ -1811,6 +2001,7 @@ pub struct ObjectAccessControl {
     pub project_team: ::core::option::Option<ProjectTeam>,
 }
 /// The result of a call to Objects.ListObjects
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListObjectsResponse {
     /// The list of items.
@@ -1826,6 +2017,7 @@ pub struct ListObjectsResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Represents the Viewers, Editors, or Owners of a given project.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProjectTeam {
     /// The project number.
@@ -1838,6 +2030,7 @@ pub struct ProjectTeam {
 /// A service account, owned by Cloud Storage, which may be used when taking
 /// action on behalf of a given project, for example to publish Pub/Sub
 /// notifications or to retrieve security keys.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceAccount {
     /// The ID of the notification.
@@ -1845,6 +2038,7 @@ pub struct ServiceAccount {
     pub email_address: ::prost::alloc::string::String,
 }
 /// The owner of a specific resource.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Owner {
     /// The entity, in the form `user-`*userId*.
@@ -1855,6 +2049,7 @@ pub struct Owner {
     pub entity_id: ::prost::alloc::string::String,
 }
 /// Specifies a requested range of bytes to download.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContentRange {
     /// The starting offset of the object data.
@@ -1871,6 +2066,7 @@ pub struct ContentRange {
 pub mod storage_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     /// ## API Overview and Naming Syntax
     ///
     /// The Cloud Storage gRPC API allows applications to read and write data through
@@ -1918,31 +2114,42 @@ pub mod storage_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> StorageClient<InterceptedService<T, F>>
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> StorageClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             StorageClient::new(InterceptedService::new(inner, interceptor))
         }
-        /// Compress requests with `gzip`.
+        /// Compress requests with the given encoding.
         ///
         /// This requires the server to support it otherwise it might respond with an
         /// error.
         #[must_use]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_compressed(CompressionEncoding::Gzip);
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        /// Enable decompressing responses with `gzip`.
+        /// Enable decompressing responses.
         #[must_use]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_compressed(CompressionEncoding::Gzip);
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         /// Permanently deletes an empty bucket.
@@ -1950,11 +2157,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBucketRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteBucket");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/DeleteBucket",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns metadata for the specified bucket.
@@ -1962,11 +2177,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetBucketRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetBucket");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/GetBucket",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a new bucket.
@@ -1974,11 +2197,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBucketRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateBucket");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/CreateBucket",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves a list of buckets for a given project.
@@ -1986,11 +2217,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListBucketsRequest>,
         ) -> Result<tonic::Response<super::ListBucketsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListBuckets");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/ListBuckets",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Locks retention policy on a bucket.
@@ -1998,48 +2237,104 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::LockBucketRetentionPolicyRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/LockBucketRetentionPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/LockBucketRetentionPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the IAM policy for a specified bucket or object.
+        /// The `resource` field in the request should be
+        /// projects/_/buckets/<bucket_name> for a bucket or
+        /// projects/_/buckets/<bucket_name>/objects/<object_name> for an object.
         pub async fn get_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::iam::v1::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::iam::v1::GetIamPolicyRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::iam::v1::Policy>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/GetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an IAM policy for the specified bucket or object.
+        /// The `resource` field in the request should be
+        /// projects/_/buckets/<bucket_name> for a bucket or
+        /// projects/_/buckets/<bucket_name>/objects/<object_name> for an object.
         pub async fn set_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::iam::v1::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::iam::v1::SetIamPolicyRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::iam::v1::Policy>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/SetIamPolicy");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/SetIamPolicy",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Tests a set of permissions on the given bucket or object to see which, if
         /// any, are held by the caller.
+        /// The `resource` field in the request should be
+        /// projects/_/buckets/<bucket_name> for a bucket or
+        /// projects/_/buckets/<bucket_name>/objects/<object_name> for an object.
         pub async fn test_iam_permissions(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::iam::v1::TestIamPermissionsRequest>,
-        ) -> Result<tonic::Response<super::super::super::iam::v1::TestIamPermissionsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            request: impl tonic::IntoRequest<
+                super::super::super::iam::v1::TestIamPermissionsRequest,
+            >,
+        ) -> Result<
+            tonic::Response<super::super::super::iam::v1::TestIamPermissionsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/TestIamPermissions");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/TestIamPermissions",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates a bucket. Equivalent to JSON API's storage.buckets.patch method.
@@ -2047,11 +2342,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBucketRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateBucket");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/UpdateBucket",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Permanently deletes a notification subscription.
@@ -2059,11 +2362,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteNotificationRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteNotification");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/DeleteNotification",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// View a notification config.
@@ -2071,11 +2382,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetNotificationRequest>,
         ) -> Result<tonic::Response<super::Notification>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetNotification");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/GetNotification",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a notification subscription for a given bucket.
@@ -2086,11 +2405,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateNotificationRequest>,
         ) -> Result<tonic::Response<super::Notification>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateNotification");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/CreateNotification",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves a list of notification subscriptions for a given bucket.
@@ -2098,11 +2425,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListNotificationsRequest>,
         ) -> Result<tonic::Response<super::ListNotificationsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListNotifications");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/ListNotifications",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Concatenates a list of existing objects into a new object in the same
@@ -2111,11 +2446,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ComposeObjectRequest>,
         ) -> Result<tonic::Response<super::Object>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ComposeObject");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/ComposeObject",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes an object and its metadata. Deletions are permanent if versioning
@@ -2124,23 +2467,42 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteObjectRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteObject");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/DeleteObject",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Cancels an in-progress resumable upload.
         pub async fn cancel_resumable_write(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelResumableWriteRequest>,
-        ) -> Result<tonic::Response<super::CancelResumableWriteResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<super::CancelResumableWriteResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CancelResumableWrite");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/CancelResumableWrite",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves an object's metadata.
@@ -2148,23 +2510,42 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetObjectRequest>,
         ) -> Result<tonic::Response<super::Object>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetObject");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/GetObject",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Reads an object's data.
         pub async fn read_object(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadObjectRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::ReadObjectResponse>>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::ReadObjectResponse>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ReadObject");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/ReadObject",
+            );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
         /// Updates an object's metadata.
@@ -2173,11 +2554,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateObjectRequest>,
         ) -> Result<tonic::Response<super::Object>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateObject");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/UpdateObject",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Stores a new object and metadata.
@@ -2234,13 +2623,23 @@ pub mod storage_client {
         /// metadata.
         pub async fn write_object(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = super::WriteObjectRequest>,
+            request: impl tonic::IntoStreamingRequest<
+                Message = super::WriteObjectRequest,
+            >,
         ) -> Result<tonic::Response<super::WriteObjectResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/WriteObject");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/WriteObject",
+            );
             self.inner
                 .client_streaming(request.into_streaming_request(), path, codec)
                 .await
@@ -2250,11 +2649,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListObjectsRequest>,
         ) -> Result<tonic::Response<super::ListObjectsResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListObjects");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/ListObjects",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Rewrites a source object to a destination object. Optionally overrides
@@ -2263,11 +2670,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RewriteObjectRequest>,
         ) -> Result<tonic::Response<super::RewriteResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/RewriteObject");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/RewriteObject",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Starts a resumable write. How long the write operation remains valid, and
@@ -2277,11 +2692,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::StartResumableWriteRequest>,
         ) -> Result<tonic::Response<super::StartResumableWriteResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/StartResumableWrite");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/StartResumableWrite",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Determines the `persisted_size` for an object that is being written, which
@@ -2301,11 +2724,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryWriteStatusRequest>,
         ) -> Result<tonic::Response<super::QueryWriteStatusResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/QueryWriteStatus");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/QueryWriteStatus",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves the name of a project's Google Cloud Storage service account.
@@ -2313,11 +2744,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetServiceAccountRequest>,
         ) -> Result<tonic::Response<super::ServiceAccount>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetServiceAccount");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/GetServiceAccount",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a new HMAC key for the given service account.
@@ -2325,11 +2764,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateHmacKeyRequest>,
         ) -> Result<tonic::Response<super::CreateHmacKeyResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateHmacKey");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/CreateHmacKey",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a given HMAC key.  Key must be in an INACTIVE state.
@@ -2337,11 +2784,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteHmacKeyRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteHmacKey");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/DeleteHmacKey",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets an existing HMAC key metadata for the given id.
@@ -2349,11 +2804,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetHmacKeyRequest>,
         ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetHmacKey");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/GetHmacKey",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists HMAC keys under a given project with the additional filters provided.
@@ -2361,11 +2824,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListHmacKeysRequest>,
         ) -> Result<tonic::Response<super::ListHmacKeysResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListHmacKeys");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/ListHmacKeys",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates a given HMAC key state between ACTIVE and INACTIVE.
@@ -2373,11 +2844,19 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateHmacKeyRequest>,
         ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateHmacKey");
+            let path = http::uri::PathAndQuery::from_static(
+                "/google.storage.v2.Storage/UpdateHmacKey",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/googleapis/src/google.storage.v2.rs
+++ b/googleapis/src/google.storage.v2.rs
@@ -268,9 +268,7 @@ pub mod compose_object_request {
         pub generation: i64,
         /// Conditions that must be met for this operation to execute.
         #[prost(message, optional, tag = "3")]
-        pub object_preconditions: ::core::option::Option<
-            source_object::ObjectPreconditions,
-        >,
+        pub object_preconditions: ::core::option::Option<source_object::ObjectPreconditions>,
     }
     /// Nested message and enum types in `SourceObject`.
     pub mod source_object {
@@ -1073,17 +1071,7 @@ pub struct ServiceConstants {}
 /// Nested message and enum types in `ServiceConstants`.
 pub mod service_constants {
     /// A collection of constant values meaningful to the Storage API.
-    #[derive(
-        Clone,
-        Copy,
-        Debug,
-        PartialEq,
-        Eq,
-        Hash,
-        PartialOrd,
-        Ord,
-        ::prost::Enumeration
-    )]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Values {
         /// Unused. Proto3 requires first enum to be 0.
@@ -1145,33 +1133,17 @@ pub mod service_constants {
                 Values::Unspecified => "VALUES_UNSPECIFIED",
                 Values::MaxReadChunkBytes => "MAX_READ_CHUNK_BYTES",
                 Values::MaxObjectSizeMb => "MAX_OBJECT_SIZE_MB",
-                Values::MaxCustomMetadataFieldNameBytes => {
-                    "MAX_CUSTOM_METADATA_FIELD_NAME_BYTES"
-                }
-                Values::MaxCustomMetadataFieldValueBytes => {
-                    "MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES"
-                }
-                Values::MaxCustomMetadataTotalSizeBytes => {
-                    "MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES"
-                }
-                Values::MaxBucketMetadataTotalSizeBytes => {
-                    "MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES"
-                }
-                Values::MaxNotificationConfigsPerBucket => {
-                    "MAX_NOTIFICATION_CONFIGS_PER_BUCKET"
-                }
-                Values::MaxNotificationCustomAttributes => {
-                    "MAX_NOTIFICATION_CUSTOM_ATTRIBUTES"
-                }
-                Values::MaxNotificationCustomAttributeKeyLength => {
-                    "MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH"
-                }
+                Values::MaxCustomMetadataFieldNameBytes => "MAX_CUSTOM_METADATA_FIELD_NAME_BYTES",
+                Values::MaxCustomMetadataFieldValueBytes => "MAX_CUSTOM_METADATA_FIELD_VALUE_BYTES",
+                Values::MaxCustomMetadataTotalSizeBytes => "MAX_CUSTOM_METADATA_TOTAL_SIZE_BYTES",
+                Values::MaxBucketMetadataTotalSizeBytes => "MAX_BUCKET_METADATA_TOTAL_SIZE_BYTES",
+                Values::MaxNotificationConfigsPerBucket => "MAX_NOTIFICATION_CONFIGS_PER_BUCKET",
+                Values::MaxNotificationCustomAttributes => "MAX_NOTIFICATION_CUSTOM_ATTRIBUTES",
+                Values::MaxNotificationCustomAttributeKeyLength => "MAX_NOTIFICATION_CUSTOM_ATTRIBUTE_KEY_LENGTH",
                 Values::MaxLabelsEntriesCount => "MAX_LABELS_ENTRIES_COUNT",
                 Values::MaxLabelsKeyValueLength => "MAX_LABELS_KEY_VALUE_LENGTH",
                 Values::MaxLabelsKeyValueBytes => "MAX_LABELS_KEY_VALUE_BYTES",
-                Values::MaxObjectIdsPerDeleteObjectsRequest => {
-                    "MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST"
-                }
+                Values::MaxObjectIdsPerDeleteObjectsRequest => "MAX_OBJECT_IDS_PER_DELETE_OBJECTS_REQUEST",
                 Values::SplitTokenMaxValidDays => "SPLIT_TOKEN_MAX_VALID_DAYS",
             }
         }
@@ -1278,10 +1250,7 @@ pub struct Bucket {
     pub default_event_based_hold: bool,
     /// User-provided labels, in key/value pairs.
     #[prost(map = "string, string", tag = "15")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// The bucket's website config, controlling how the service behaves
     /// when accessing bucket contents as a web site. See the
     /// \[<https://cloud.google.com/storage/docs/static-website\][Static> Website
@@ -1384,9 +1353,7 @@ pub mod bucket {
     pub struct IamConfig {
         /// Bucket restriction options currently enforced on the bucket.
         #[prost(message, optional, tag = "1")]
-        pub uniform_bucket_level_access: ::core::option::Option<
-            iam_config::UniformBucketLevelAccess,
-        >,
+        pub uniform_bucket_level_access: ::core::option::Option<iam_config::UniformBucketLevelAccess>,
         /// Whether IAM will enforce public access prevention. Valid values are
         /// "enforced" or "inherited".
         #[prost(string, tag = "3")]
@@ -1462,9 +1429,7 @@ pub mod bucket {
                 /// This condition is satisfied when an object is created before midnight
                 /// of the specified date in UTC.
                 #[prost(message, optional, tag = "2")]
-                pub created_before: ::core::option::Option<
-                    super::super::super::super::super::r#type::Date,
-                >,
+                pub created_before: ::core::option::Option<super::super::super::super::super::r#type::Date>,
                 /// Relevant only for versioned objects. If the value is
                 /// `true`, this condition matches live objects; if the value
                 /// is `false`, it matches archived objects.
@@ -1480,9 +1445,7 @@ pub mod bucket {
                 /// `NEARLINE`, `COLDLINE`, `STANDARD`, and
                 /// `DURABLE_REDUCED_AVAILABILITY`.
                 #[prost(string, repeated, tag = "5")]
-                pub matches_storage_class: ::prost::alloc::vec::Vec<
-                    ::prost::alloc::string::String,
-                >,
+                pub matches_storage_class: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
                 /// Number of days that have elapsed since the custom timestamp set on an
                 /// object.
                 /// The value of the field must be a nonnegative integer.
@@ -1491,9 +1454,7 @@ pub mod bucket {
                 /// An object matches this condition if the custom timestamp set on the
                 /// object is before the specified date in UTC.
                 #[prost(message, optional, tag = "8")]
-                pub custom_time_before: ::core::option::Option<
-                    super::super::super::super::super::r#type::Date,
-                >,
+                pub custom_time_before: ::core::option::Option<super::super::super::super::super::r#type::Date>,
                 /// This condition is relevant only for versioned objects. An object
                 /// version satisfies this condition only if these many days have been
                 /// passed since it became noncurrent. The value of the field must be a
@@ -1505,21 +1466,15 @@ pub mod bucket {
                 /// version satisfies this condition only if it became noncurrent before
                 /// the specified date in UTC.
                 #[prost(message, optional, tag = "10")]
-                pub noncurrent_time_before: ::core::option::Option<
-                    super::super::super::super::super::r#type::Date,
-                >,
+                pub noncurrent_time_before: ::core::option::Option<super::super::super::super::super::r#type::Date>,
                 /// List of object name prefixes. If any prefix exactly matches the
                 /// beginning of the object name, the condition evaluates to true.
                 #[prost(string, repeated, tag = "11")]
-                pub matches_prefix: ::prost::alloc::vec::Vec<
-                    ::prost::alloc::string::String,
-                >,
+                pub matches_prefix: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
                 /// List of object name suffixes. If any suffix exactly matches the
                 /// end of the object name, the condition evaluates to true.
                 #[prost(string, repeated, tag = "12")]
-                pub matches_suffix: ::prost::alloc::vec::Vec<
-                    ::prost::alloc::string::String,
-                >,
+                pub matches_suffix: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
             }
         }
     }
@@ -1761,10 +1716,7 @@ pub struct Notification {
     /// A list of additional attributes to attach to each Pub/Sub
     /// message published for this notification subscription.
     #[prost(map = "string, string", tag = "4")]
-    pub custom_attributes: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub custom_attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// If present, only apply this notification config to object names that
     /// begin with this prefix.
     #[prost(string, tag = "5")]
@@ -1917,10 +1869,7 @@ pub struct Object {
     pub retention_expire_time: ::core::option::Option<::prost_types::Timestamp>,
     /// User-provided metadata, in key/value pairs.
     #[prost(map = "string, string", tag = "22")]
-    pub metadata: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub metadata: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Whether an object is under event-based hold.
     /// An event-based hold is a way to force the retention of an object until
     /// after some event occurs. Once the hold is released by explicitly setting
@@ -2065,8 +2014,8 @@ pub struct ContentRange {
 /// Generated client implementations.
 pub mod storage_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     /// ## API Overview and Naming Syntax
     ///
     /// The Cloud Storage gRPC API allows applications to read and write data through
@@ -2118,22 +2067,15 @@ pub mod storage_client {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> StorageClient<InterceptedService<T, F>>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> StorageClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
+                Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
         {
             StorageClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -2157,19 +2099,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBucketRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/DeleteBucket",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteBucket");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Returns metadata for the specified bucket.
@@ -2177,19 +2111,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetBucketRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/GetBucket",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetBucket");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a new bucket.
@@ -2197,19 +2123,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBucketRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/CreateBucket",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateBucket");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves a list of buckets for a given project.
@@ -2217,19 +2135,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListBucketsRequest>,
         ) -> Result<tonic::Response<super::ListBucketsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/ListBuckets",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListBuckets");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Locks retention policy on a bucket.
@@ -2237,19 +2147,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::LockBucketRetentionPolicyRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/LockBucketRetentionPolicy",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/LockBucketRetentionPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets the IAM policy for a specified bucket or object.
@@ -2258,26 +2160,13 @@ pub mod storage_client {
         /// projects/_/buckets/<bucket_name>/objects/<object_name> for an object.
         pub async fn get_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::iam::v1::GetIamPolicyRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::iam::v1::Policy>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::super::super::iam::v1::GetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/GetIamPolicy",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates an IAM policy for the specified bucket or object.
@@ -2286,26 +2175,13 @@ pub mod storage_client {
         /// projects/_/buckets/<bucket_name>/objects/<object_name> for an object.
         pub async fn set_iam_policy(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::iam::v1::SetIamPolicyRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::iam::v1::Policy>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::super::super::iam::v1::SetIamPolicyRequest>,
+        ) -> Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/SetIamPolicy",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/SetIamPolicy");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Tests a set of permissions on the given bucket or object to see which, if
@@ -2315,26 +2191,13 @@ pub mod storage_client {
         /// projects/_/buckets/<bucket_name>/objects/<object_name> for an object.
         pub async fn test_iam_permissions(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::iam::v1::TestIamPermissionsRequest,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::iam::v1::TestIamPermissionsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            request: impl tonic::IntoRequest<super::super::super::iam::v1::TestIamPermissionsRequest>,
+        ) -> Result<tonic::Response<super::super::super::iam::v1::TestIamPermissionsResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/TestIamPermissions",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/TestIamPermissions");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates a bucket. Equivalent to JSON API's storage.buckets.patch method.
@@ -2342,19 +2205,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBucketRequest>,
         ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/UpdateBucket",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateBucket");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Permanently deletes a notification subscription.
@@ -2362,19 +2217,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteNotificationRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/DeleteNotification",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteNotification");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// View a notification config.
@@ -2382,19 +2229,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetNotificationRequest>,
         ) -> Result<tonic::Response<super::Notification>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/GetNotification",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetNotification");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a notification subscription for a given bucket.
@@ -2405,19 +2244,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateNotificationRequest>,
         ) -> Result<tonic::Response<super::Notification>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/CreateNotification",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateNotification");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves a list of notification subscriptions for a given bucket.
@@ -2425,19 +2256,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListNotificationsRequest>,
         ) -> Result<tonic::Response<super::ListNotificationsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/ListNotifications",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListNotifications");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Concatenates a list of existing objects into a new object in the same
@@ -2446,19 +2269,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ComposeObjectRequest>,
         ) -> Result<tonic::Response<super::Object>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/ComposeObject",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ComposeObject");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes an object and its metadata. Deletions are permanent if versioning
@@ -2467,42 +2282,23 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteObjectRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/DeleteObject",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteObject");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Cancels an in-progress resumable upload.
         pub async fn cancel_resumable_write(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelResumableWriteRequest>,
-        ) -> Result<
-            tonic::Response<super::CancelResumableWriteResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<super::CancelResumableWriteResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/CancelResumableWrite",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CancelResumableWrite");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves an object's metadata.
@@ -2510,42 +2306,23 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetObjectRequest>,
         ) -> Result<tonic::Response<super::Object>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/GetObject",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetObject");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Reads an object's data.
         pub async fn read_object(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadObjectRequest>,
-        ) -> Result<
-            tonic::Response<tonic::codec::Streaming<super::ReadObjectResponse>>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> Result<tonic::Response<tonic::codec::Streaming<super::ReadObjectResponse>>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/ReadObject",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ReadObject");
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
         /// Updates an object's metadata.
@@ -2554,19 +2331,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateObjectRequest>,
         ) -> Result<tonic::Response<super::Object>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/UpdateObject",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateObject");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Stores a new object and metadata.
@@ -2623,23 +2392,13 @@ pub mod storage_client {
         /// metadata.
         pub async fn write_object(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<
-                Message = super::WriteObjectRequest,
-            >,
+            request: impl tonic::IntoStreamingRequest<Message = super::WriteObjectRequest>,
         ) -> Result<tonic::Response<super::WriteObjectResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/WriteObject",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/WriteObject");
             self.inner
                 .client_streaming(request.into_streaming_request(), path, codec)
                 .await
@@ -2649,19 +2408,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListObjectsRequest>,
         ) -> Result<tonic::Response<super::ListObjectsResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/ListObjects",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListObjects");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Rewrites a source object to a destination object. Optionally overrides
@@ -2670,19 +2421,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RewriteObjectRequest>,
         ) -> Result<tonic::Response<super::RewriteResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/RewriteObject",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/RewriteObject");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Starts a resumable write. How long the write operation remains valid, and
@@ -2692,19 +2435,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::StartResumableWriteRequest>,
         ) -> Result<tonic::Response<super::StartResumableWriteResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/StartResumableWrite",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/StartResumableWrite");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Determines the `persisted_size` for an object that is being written, which
@@ -2724,19 +2459,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QueryWriteStatusRequest>,
         ) -> Result<tonic::Response<super::QueryWriteStatusResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/QueryWriteStatus",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/QueryWriteStatus");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Retrieves the name of a project's Google Cloud Storage service account.
@@ -2744,19 +2471,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetServiceAccountRequest>,
         ) -> Result<tonic::Response<super::ServiceAccount>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/GetServiceAccount",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetServiceAccount");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Creates a new HMAC key for the given service account.
@@ -2764,19 +2483,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreateHmacKeyRequest>,
         ) -> Result<tonic::Response<super::CreateHmacKeyResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/CreateHmacKey",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateHmacKey");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Deletes a given HMAC key.  Key must be in an INACTIVE state.
@@ -2784,19 +2495,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteHmacKeyRequest>,
         ) -> Result<tonic::Response<()>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/DeleteHmacKey",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteHmacKey");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Gets an existing HMAC key metadata for the given id.
@@ -2804,19 +2507,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetHmacKeyRequest>,
         ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/GetHmacKey",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetHmacKey");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Lists HMAC keys under a given project with the additional filters provided.
@@ -2824,19 +2519,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ListHmacKeysRequest>,
         ) -> Result<tonic::Response<super::ListHmacKeysResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/ListHmacKeys",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListHmacKeys");
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Updates a given HMAC key state between ACTIVE and INACTIVE.
@@ -2844,19 +2531,11 @@ pub mod storage_client {
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateHmacKeyRequest>,
         ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.storage.v2.Storage/UpdateHmacKey",
-            );
+            let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateHmacKey");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/spanner/src/apiv1/mod.rs
+++ b/spanner/src/apiv1/mod.rs
@@ -58,8 +58,8 @@ mod tests {
     async fn begin_read_write_transaction(client: &mut Client, session: &Session) -> Transaction {
         let request = BeginTransactionRequest {
             session: session.name.to_string(),
-            options: Option::from(TransactionOptions {
-                mode: Option::from(transaction_options::Mode::ReadWrite(transaction_options::ReadWrite {})),
+            options: Some(TransactionOptions {
+                mode: Some(transaction_options::Mode::ReadWrite(transaction_options::ReadWrite::default())),
             }),
             request_options: None,
         };

--- a/spanner/src/client.rs
+++ b/spanner/src/client.rs
@@ -398,7 +398,7 @@ impl Client {
             Some(ro),
             |session| async {
                 let tx = commit_request::Transaction::SingleUseTransaction(TransactionOptions {
-                    mode: Some(transaction_options::Mode::ReadWrite(transaction_options::ReadWrite {})),
+                    mode: Some(transaction_options::Mode::ReadWrite(transaction_options::ReadWrite::default())),
                 });
                 match commit(session, ms.clone(), tx, options.clone()).await {
                     Ok(s) => Ok(s.commit_timestamp.map(|s| s.into())),

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -475,6 +475,7 @@ mod tests {
                 fields: vec![field("column1")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value("value1"), value("value2"), value("value3")];
         assert!(rs.add(metadata, values, false).unwrap());
@@ -496,6 +497,7 @@ mod tests {
                 fields: vec![field("column1"), field("column2")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value("value1"), value("value2"), value("value3")];
         assert!(rs.add(metadata, values, false).unwrap());
@@ -515,6 +517,7 @@ mod tests {
                 fields: vec![field("column1"), field("column2")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value("value1"), value("value2"), value("value3"), value("value4")];
         assert!(rs.add(metadata, values, false).unwrap());
@@ -535,6 +538,7 @@ mod tests {
                 fields: vec![field("column1")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value("value1"), value("value2"), value("val")];
         assert!(rs.add(metadata.clone(), values, true).unwrap());
@@ -562,6 +566,7 @@ mod tests {
                 fields: vec![field("column1"), field("column2")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value("value1"), value("value2"), value("val")];
         assert!(rs.add(metadata.clone(), values, true).unwrap());
@@ -593,6 +598,7 @@ mod tests {
                 fields: vec![field("column1"), field("column2")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value(vec!["value1-1", "value1-2"])];
         assert!(rs.add(metadata.clone(), values, false).unwrap());
@@ -619,6 +625,7 @@ mod tests {
                 fields: vec![field("column1"), field("column2")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value(vec!["value1-1", "value1-2"]), value(vec!["value2-"])];
         assert!(rs.add(metadata.clone(), values, true).unwrap());
@@ -653,6 +660,7 @@ mod tests {
                 fields: vec![field("column1"), field("column2")],
             }),
             transaction: None,
+            undeclared_parameters: None,
         });
         let values = vec![value(vec!["value1-1", "value1-2"]), value("va")];
         assert!(rs.add(metadata.clone(), values, true).unwrap());

--- a/spanner/src/transaction_rw.rs
+++ b/spanner/src/transaction_rw.rs
@@ -105,7 +105,7 @@ impl ReadWriteTransaction {
     pub async fn begin(session: ManagedSession, options: CallOptions) -> Result<ReadWriteTransaction, BeginError> {
         ReadWriteTransaction::begin_internal(
             session,
-            transaction_options::Mode::ReadWrite(transaction_options::ReadWrite {}),
+            transaction_options::Mode::ReadWrite(transaction_options::ReadWrite::default()),
             options,
         )
         .await

--- a/spanner/tests/common.rs
+++ b/spanner/tests/common.rs
@@ -109,7 +109,7 @@ pub async fn replace_test_data(
                 return_commit_stats: false,
                 request_options: None,
                 transaction: Some(SingleUseTransaction(TransactionOptions {
-                    mode: Some(Mode::ReadWrite(ReadWrite {})),
+                    mode: Some(Mode::ReadWrite(ReadWrite::default())),
                 })),
             },
             None,


### PR DESCRIPTION
This puts tonic-build behind a feature, so it only needs to be included when generating the protos.

I also re-generated all protos with the latest googleapis