### PR TITLE
Deny multiple versions of dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -172,7 +172,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
+multiple-versions = "deny"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates
@@ -236,7 +236,7 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+    { name = "windows-sys", version = "=0.36" },
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
This will cause CI to fail if multiple versions of a dependency is being used. This will prevent that someone accidentally adds several versions of a dependency.

In some cases there is no solution to having multiple versions, and in those cases an exception can be added in deny.yaml,
I've added an exception for `windows-sys` where there is currently two versions in the dependency graph.
