### PR TITLE
Change AtomicI64 to AtomicUsize

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -236,7 +236,8 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite.
 skip-tree = [
-    { name = "windows-sys", version = "=0.36" },
+    # https://github.com/hyperium/tonic/pull/1223/files
+    { name = "rustls-pemfile" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/foundation/gax/src/conn.rs
+++ b/foundation/gax/src/conn.rs
@@ -92,7 +92,7 @@ where
     T: Clone + Debug,
 {
     fn next(&self) -> T {
-        let current = self.index.fetch_add(1, Ordering::SeqCst) as usize;
+        let current = self.index.fetch_add(1, Ordering::SeqCst);
         //clone() reuses http/2 connection
         self.values[current % self.values.len()].clone()
     }


### PR DESCRIPTION
* Use `AtomicUsize` for connection index instead of `AtomicI64` 
* Added `rustls-pemfile` into skip-tree according to [tonic](https://github.com/hyperium/tonic/pull/1223/files)
