### PR TITLE
Refactoring to re-use HTTP client in storage client

### DIFF
--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -40,6 +40,7 @@ impl Deref for Client {
 
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
+    pub http: Option<reqwest::Client>,
     pub project: Option<Project>,
     pub storage_endpoint: String,
     pub service_account_endpoint: String,
@@ -48,6 +49,7 @@ pub struct ClientConfig {
 impl Default for ClientConfig {
     fn default() -> Self {
         Self {
+            http: None,
             project: None,
             storage_endpoint: "https://storage.googleapis.com".to_string(),
             service_account_endpoint: "https://iamcredentials.googleapis.com".to_string(),
@@ -80,6 +82,7 @@ impl Client {
         let service_account_client =
             ServiceAccountClient::new(Arc::clone(&ts), config.service_account_endpoint.as_str());
 
+        let http = config.http.unwrap_or_default();
         match project {
             Project::FromFile(cred) => Ok(Client {
                 private_key: cred.private_key.clone(),
@@ -93,7 +96,7 @@ impl Client {
                     .as_ref()
                     .ok_or(Error::Other("no project_id was found"))?
                     .to_string(),
-                storage_client: StorageClient::new(ts, config.storage_endpoint.as_str()),
+                storage_client: StorageClient::new(ts, config.storage_endpoint.as_str(), http),
                 service_account_client,
             }),
             Project::FromMetadataServer(info) => Ok(Client {
@@ -104,7 +107,7 @@ impl Client {
                     .as_ref()
                     .ok_or(Error::Other("no project_id was found"))?
                     .to_string(),
-                storage_client: StorageClient::new(ts, config.storage_endpoint.as_str()),
+                storage_client: StorageClient::new(ts, config.storage_endpoint.as_str(), http),
                 service_account_client,
             }),
         }

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -513,8 +513,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ListDefaultObjectAccessControlsResponse, Error> {
         let action = async {
-            let builder =
-                default_object_access_controls::list::build(self.v1_endpoint.as_str(), &self.http, req);
+            let builder = default_object_access_controls::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -562,8 +561,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
-            let builder =
-                default_object_access_controls::get::build(self.v1_endpoint.as_str(), &self.http, req);
+            let builder = default_object_access_controls::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -616,8 +614,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
-            let builder =
-                default_object_access_controls::insert::build(self.v1_endpoint.as_str(), &self.http, req);
+            let builder = default_object_access_controls::insert::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -672,8 +669,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
-            let builder =
-                default_object_access_controls::patch::build(self.v1_endpoint.as_str(), &self.http, req);
+            let builder = default_object_access_controls::patch::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -721,8 +717,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<(), Error> {
         let action = async {
-            let builder =
-                default_object_access_controls::delete::build(self.v1_endpoint.as_str(), &self.http, req);
+            let builder = default_object_access_controls::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -72,14 +72,16 @@ pub struct StorageClient {
     ts: Arc<dyn TokenSource>,
     v1_endpoint: String,
     v1_upload_endpoint: String,
+    http: Client,
 }
 
 impl StorageClient {
-    pub(crate) fn new(ts: Arc<dyn TokenSource>, endpoint: &str) -> Self {
+    pub(crate) fn new(ts: Arc<dyn TokenSource>, endpoint: &str, http: Client) -> Self {
         Self {
             ts,
             v1_endpoint: format!("{endpoint}/storage/v1"),
             v1_upload_endpoint: format!("{endpoint}/upload/storage/v1"),
+            http,
         }
     }
 
@@ -121,7 +123,7 @@ impl StorageClient {
     #[inline(always)]
     async fn _delete_bucket(&self, req: &DeleteBucketRequest, cancel: Option<CancellationToken>) -> Result<(), Error> {
         let action = async {
-            let builder = buckets::delete::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await
@@ -173,7 +175,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Bucket, Error> {
         let action = async {
-            let builder = buckets::insert::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::insert::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -209,7 +211,7 @@ impl StorageClient {
     #[inline(always)]
     async fn _get_bucket(&self, req: &GetBucketRequest, cancel: Option<CancellationToken>) -> Result<Bucket, Error> {
         let action = async {
-            let builder = buckets::get::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -260,7 +262,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Bucket, Error> {
         let action = async {
-            let builder = buckets::patch::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::patch::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -308,7 +310,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ListBucketsResponse, Error> {
         let action = async {
-            let builder = buckets::list::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -365,7 +367,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Policy, Error> {
         let action = async {
-            let builder = buckets::set_iam_policy::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::set_iam_policy::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -414,7 +416,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Policy, Error> {
         let action = async {
-            let builder = buckets::get_iam_policy::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::get_iam_policy::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -462,7 +464,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<TestIamPermissionsResponse, Error> {
         let action = async {
-            let builder = buckets::test_iam_permissions::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = buckets::test_iam_permissions::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -512,7 +514,7 @@ impl StorageClient {
     ) -> Result<ListDefaultObjectAccessControlsResponse, Error> {
         let action = async {
             let builder =
-                default_object_access_controls::list::build(self.v1_endpoint.as_str(), &Client::default(), req);
+                default_object_access_controls::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -561,7 +563,7 @@ impl StorageClient {
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
             let builder =
-                default_object_access_controls::get::build(self.v1_endpoint.as_str(), &Client::default(), req);
+                default_object_access_controls::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -615,7 +617,7 @@ impl StorageClient {
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
             let builder =
-                default_object_access_controls::insert::build(self.v1_endpoint.as_str(), &Client::default(), req);
+                default_object_access_controls::insert::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -671,7 +673,7 @@ impl StorageClient {
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
             let builder =
-                default_object_access_controls::patch::build(self.v1_endpoint.as_str(), &Client::default(), req);
+                default_object_access_controls::patch::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -720,7 +722,7 @@ impl StorageClient {
     ) -> Result<(), Error> {
         let action = async {
             let builder =
-                default_object_access_controls::delete::build(self.v1_endpoint.as_str(), &Client::default(), req);
+                default_object_access_controls::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await
@@ -767,7 +769,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ListBucketAccessControlsResponse, Error> {
         let action = async {
-            let builder = bucket_access_controls::list::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = bucket_access_controls::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -815,7 +817,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<BucketAccessControl, Error> {
         let action = async {
-            let builder = bucket_access_controls::get::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = bucket_access_controls::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -867,7 +869,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<BucketAccessControl, Error> {
         let action = async {
-            let builder = bucket_access_controls::insert::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = bucket_access_controls::insert::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -921,7 +923,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<BucketAccessControl, Error> {
         let action = async {
-            let builder = bucket_access_controls::patch::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = bucket_access_controls::patch::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -968,7 +970,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<(), Error> {
         let action = async {
-            let builder = bucket_access_controls::delete::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = bucket_access_controls::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await
@@ -1017,7 +1019,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ListBucketAccessControlsResponse, Error> {
         let action = async {
-            let builder = object_access_controls::list::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = object_access_controls::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1067,7 +1069,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
-            let builder = object_access_controls::get::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = object_access_controls::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1121,7 +1123,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
-            let builder = object_access_controls::insert::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = object_access_controls::insert::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1176,7 +1178,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ObjectAccessControl, Error> {
         let action = async {
-            let builder = object_access_controls::patch::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = object_access_controls::patch::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1227,7 +1229,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<(), Error> {
         let action = async {
-            let builder = object_access_controls::delete::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = object_access_controls::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await
@@ -1275,7 +1277,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ListNotificationsResponse, Error> {
         let action = async {
-            let builder = notifications::list::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = notifications::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1323,7 +1325,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Notification, Error> {
         let action = async {
-            let builder = notifications::get::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = notifications::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1376,7 +1378,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Notification, Error> {
         let action = async {
-            let builder = notifications::insert::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = notifications::insert::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1424,7 +1426,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<(), Error> {
         let action = async {
-            let builder = notifications::delete::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = notifications::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await
@@ -1472,7 +1474,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ListHmacKeysResponse, Error> {
         let action = async {
-            let builder = hmac_keys::list::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = hmac_keys::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1520,7 +1522,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<HmacKeyMetadata, Error> {
         let action = async {
-            let builder = hmac_keys::get::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = hmac_keys::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1568,7 +1570,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<CreateHmacKeyResponse, Error> {
         let action = async {
-            let builder = hmac_keys::create::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = hmac_keys::create::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1621,7 +1623,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<HmacKeyMetadata, Error> {
         let action = async {
-            let builder = hmac_keys::update::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = hmac_keys::update::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1669,7 +1671,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<(), Error> {
         let action = async {
-            let builder = hmac_keys::delete::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = hmac_keys::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await
@@ -1717,7 +1719,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<ListObjectsResponse, Error> {
         let action = async {
-            let builder = objects::list::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = objects::list::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1754,7 +1756,7 @@ impl StorageClient {
     #[inline(always)]
     async fn _get_object(&self, req: &GetObjectRequest, cancel: Option<CancellationToken>) -> Result<Object, Error> {
         let action = async {
-            let builder = objects::get::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = objects::get::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -1808,7 +1810,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Vec<u8>, Error> {
         let action = async {
-            let builder = objects::download::build(self.v1_endpoint.as_str(), &Client::default(), req, range);
+            let builder = objects::download::build(self.v1_endpoint.as_str(), &self.http, req, range);
             let request = self.with_headers(builder).await?;
             let response = request.send().await?;
             if response.status().is_success() {
@@ -1872,7 +1874,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<impl Stream<Item = reqwest::Result<bytes::Bytes>>, Error> {
         let action = async {
-            let builder = objects::download::build(self.v1_endpoint.as_str(), &Client::default(), req, range);
+            let builder = objects::download::build(self.v1_endpoint.as_str(), &self.http, req, range);
             let request = self.with_headers(builder).await?;
             let response = request.send().await?;
             if response.status().is_success() {
@@ -1936,7 +1938,7 @@ impl StorageClient {
         let action = async {
             let builder = objects::upload::build(
                 self.v1_upload_endpoint.as_str(),
-                &Client::default(),
+                &self.http,
                 req,
                 Some(data.len()),
                 content_type,
@@ -2022,7 +2024,7 @@ impl StorageClient {
         let action = async {
             let builder = objects::upload::build(
                 self.v1_upload_endpoint.as_str(),
-                &Client::default(),
+                &self.http,
                 req,
                 content_length,
                 content_type,
@@ -2076,7 +2078,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Object, Error> {
         let action = async {
-            let builder = objects::patch::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = objects::patch::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -2121,7 +2123,7 @@ impl StorageClient {
     #[inline(always)]
     async fn _delete_object(&self, req: &DeleteObjectRequest, cancel: Option<CancellationToken>) -> Result<(), Error> {
         let action = async {
-            let builder = objects::delete::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = objects::delete::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send_get_empty(builder).await
         };
         invoke(cancel, action).await
@@ -2172,7 +2174,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<RewriteObjectResponse, Error> {
         let action = async {
-            let builder = objects::rewrite::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = objects::rewrite::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -2230,7 +2232,7 @@ impl StorageClient {
         cancel: Option<CancellationToken>,
     ) -> Result<Object, Error> {
         let action = async {
-            let builder = objects::compose::build(self.v1_endpoint.as_str(), &Client::default(), req);
+            let builder = objects::compose::build(self.v1_endpoint.as_str(), &self.http, req);
             self.send(builder).await
         };
         invoke(cancel, action).await
@@ -2361,7 +2363,7 @@ mod test {
         })
         .await
         .unwrap();
-        StorageClient::new(Arc::from(ts), "https://storage.googleapis.com")
+        StorageClient::new(Arc::from(ts), "https://storage.googleapis.com", reqwest::Client::new())
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR changes the way HTTP client is used.
Instead of creating HTTP client every request, it initializes it once or allows user to pass it to allow API calls to benefit from connection pooling in `hyper`