### PR TITLE
Add resumable upload

### DIFF
--- a/storage/src/http/mod.rs
+++ b/storage/src/http/mod.rs
@@ -17,6 +17,7 @@ use serde::{de, Deserialize, Deserializer};
 use serde_json::Value;
 use std::fmt::Display;
 use std::str::FromStr;
+use std::string::FromUtf8Error;
 pub use tokio_util::sync::CancellationToken;
 
 #[derive(thiserror::Error, Debug)]
@@ -33,6 +34,8 @@ pub enum Error {
     Base64DecodeError(#[from] base64::DecodeError),
     #[error(transparent)]
     Std(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error(transparent)]
+    FromUtf8Error(#[from] FromUtf8Error),
 }
 
 impl Error {

--- a/storage/src/http/objects/upload.rs
+++ b/storage/src/http/objects/upload.rs
@@ -125,3 +125,39 @@ pub(crate) fn build_multipart<T: Into<reqwest::Body>>(
         builder
     })
 }
+
+pub(crate) fn build_resumable_session_simple(
+    base_url: &str,
+    client: &Client,
+    req: &UploadObjectRequest,
+    media: &Media,
+) -> RequestBuilder {
+    let url = format!("{}/b/{}/o?uploadType=resumable", base_url, req.bucket.escape(),);
+    let mut builder = client.post(url).query(&req).query(&[("name", &media.name)]);
+    if let Some(content_type) = media.content_type {
+        builder = builder.header("X-Upload-Content-Type", content_type.to_string())
+    }
+    if let Some(len) = media.content_length {
+        builder = builder.header("X-Upload-Content-Length", len)
+    }
+    if let Some(e) = &req.encryption {
+        e.with_headers(builder)
+    } else {
+        builder
+    }
+}
+
+pub(crate) fn build_resumable_session_simple_metadata<T: Into<reqwest::Body>>(
+    base_url: &str,
+    client: &Client,
+    req: &UploadObjectRequest,
+    metadata: &Object,
+) -> RequestBuilder {
+    let url = format!("{}/b/{}/o?uploadType=resumable", base_url, req.bucket.escape(),);
+    let mut builder = client.post(url).query(&req).json(&metadata);
+    if let Some(e) = &req.encryption {
+        e.with_headers(builder)
+    } else {
+        builder
+    }
+}

--- a/storage/src/http/objects/upload.rs
+++ b/storage/src/http/objects/upload.rs
@@ -133,10 +133,12 @@ pub(crate) fn build_resumable_session_simple(
     media: &Media,
 ) -> RequestBuilder {
     let url = format!("{}/b/{}/o?uploadType=resumable", base_url, req.bucket.escape(),);
-    let mut builder = client.post(url).query(&req).query(&[("name", &media.name)]);
-    if let Some(content_type) = media.content_type {
-        builder = builder.header("X-Upload-Content-Type", content_type.to_string())
-    }
+    let mut builder = client
+        .post(url)
+        .query(&req)
+        .query(&[("name", &media.name)])
+        .header(CONTENT_LENGTH, 0)
+        .header("X-Upload-Content-Type", media.content_type.to_string());
     if let Some(len) = media.content_length {
         builder = builder.header("X-Upload-Content-Length", len)
     }
@@ -147,14 +149,14 @@ pub(crate) fn build_resumable_session_simple(
     }
 }
 
-pub(crate) fn build_resumable_session_simple_metadata<T: Into<reqwest::Body>>(
+pub(crate) fn build_resumable_session_metadata(
     base_url: &str,
     client: &Client,
     req: &UploadObjectRequest,
     metadata: &Object,
 ) -> RequestBuilder {
     let url = format!("{}/b/{}/o?uploadType=resumable", base_url, req.bucket.escape(),);
-    let mut builder = client.post(url).query(&req).json(&metadata);
+    let builder = client.post(url).query(&req).json(&metadata);
     if let Some(e) = &req.encryption {
         e.with_headers(builder)
     } else {

--- a/storage/src/http/resumable_upload_client.rs
+++ b/storage/src/http/resumable_upload_client.rs
@@ -139,7 +139,7 @@ impl ResumableUploadClient {
     }
 
     /// https://cloud.google.com/storage/docs/performing-resumable-uploads#cancel-upload
-    pub async fn cancel(&self) -> Result<(), Error> {
+    pub async fn cancel(self) -> Result<(), Error> {
         let response = self
             .http
             .delete(&self.session_url)

--- a/storage/src/http/resumable_upload_client.rs
+++ b/storage/src/http/resumable_upload_client.rs
@@ -1,0 +1,148 @@
+use crate::http::objects::download::Range;
+use crate::http::Error;
+use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE};
+use reqwest::Client;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ChunkError {
+    InvalidRange(usize, usize),
+    ZeroTotalObjectSize,
+}
+
+pub enum UploadStatus {
+    Ok,
+    ResumeIncomplete,
+}
+
+pub enum TotalSize {
+    Unknown,
+    Known(usize),
+}
+
+impl ToString for TotalSize {
+    fn to_string(&self) -> String {
+        match self {
+            TotalSize::Unknown => "*".to_string(),
+            TotalSize::Known(size) => size.to_string(),
+        }
+    }
+}
+
+pub struct ChunkSize {
+    first_byte: usize,
+    last_byte: usize,
+    total_object_size: TotalSize,
+}
+
+impl ToString for ChunkSize {
+    fn to_string(&self) -> String {
+        format!(
+            "bytes {}-{}/{}",
+            self.first_byte,
+            self.last_byte,
+            self.total_object_size.to_string()
+        )
+    }
+}
+
+impl ChunkSize {
+    pub fn new(first_byte: usize, last_byte: usize, total_object_size: TotalSize) -> Result<Self, ChunkError> {
+        if let TotalSize(size) = total_object_size {
+            if size == 0 {
+                return Err(ChunkError::ZeroTotalObjectSize);
+            }
+        }
+        if first_byte >= last_byte {
+            return Err(ChunkError::InvalidRange(first_byte, last_byte));
+        }
+        let size = last_byte - first_byte + 1;
+        if size % (256 * 1024) != 0 {
+            tracing::warn!("The chunk size should be multiple of 256KiB. size = {}", size);
+        }
+
+        Ok(Self {
+            first_byte,
+            last_byte,
+            total_object_size,
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        self.last_byte - self.first_byte + 1
+    }
+}
+
+#[derive(Clone)]
+pub struct ResumableUploadClient {
+    session_url: String,
+    http: Client,
+}
+
+impl ResumableUploadClient {
+    pub fn new(session_url: String, http: Client) -> Self {
+        Self { session_url, http }
+    }
+
+    /// https://cloud.google.com/storage/docs/performing-resumable-uploads#single-chunk-upload
+    pub fn upload_single_chunk<T>(&self, data: T, size: usize) -> Result<(), Error> {
+        let response = self
+            .http
+            .put(&self.session_url)
+            .header(CONTENT_LENGTH, size)
+            .body(data)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::from_response(response).await)
+        }
+    }
+
+    /// https://cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload
+    /// https://cloud.google.com/storage/docs/performing-resumable-uploads#resume-upload
+    pub fn upload_multiple_chunk<T>(&self, data: T, size: &ChunkSize) -> Result<UploadStatus, Error> {
+        let response = self
+            .http
+            .put(&self.session_url)
+            .header(CONTENT_RANGE, size.to_string())
+            .header(CONTENT_LENGTH, size.size())
+            .body(data)
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(UploadStatus::Ok)
+        } else if response.status() == 308 {
+            Ok(UploadStatus::ResumeIncomplete)
+        } else {
+            Err(Error::from_response(response).await)
+        }
+    }
+
+    /// https://cloud.google.com/storage/docs/performing-resumable-uploads#status-check
+    pub fn status(&self, object_size: &TotalSize) -> Result<UploadStatus, Error> {
+        let response = self
+            .http
+            .put(&self.session_url)
+            .header(CONTENT_RANGE, format! {"bytes */{}", object_size.to_string()})
+            .send()
+            .await?;
+        if response.status().is_success() {
+            Ok(UploadStatus::Ok)
+        } else if response.status() == 308 {
+            Ok(UploadStatus::ResumeIncomplete)
+        } else {
+            Err(Error::from_response(response).await)
+        }
+    }
+
+    /// https://cloud.google.com/storage/docs/performing-resumable-uploads#cancel-upload
+    pub fn cancel(&self) -> Result<(), Error> {
+        let response = self.http.delete(&self.session_url).send().await?;
+        if response.status() == 499 {
+            Ok(())
+        } else {
+            Err(Error::from_response(response).await)
+        }
+    }
+}

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -2286,12 +2286,7 @@ impl StorageClient {
 }
 
 async fn map_error(r: Response) -> Error {
-    let status = r.status().as_u16();
-    let text = match r.text().await {
-        Ok(text) => text,
-        Err(e) => format!("{e}"),
-    };
-    Error::Response(status, text)
+    Error::from_response(r)
 }
 
 async fn invoke<S>(
@@ -2838,7 +2833,7 @@ mod test {
 
     #[tokio::test]
     #[serial]
-    pub async fn upload_metadata() {
+    pub async fn metadata() {
         let bucket_name = "rust-object-test";
         let (client, _project) = client().await;
         let mut metadata = HashMap::<String, String>::new();

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -2084,7 +2084,6 @@ impl StorageClient {
 
     /// Uploads the streamed object.
     /// https://cloud.google.com/storage/docs/json_api/v1/objects/insert
-    /// TODO resumable upload
     ///
     /// ```
     /// use google_cloud_storage::client::Client;


### PR DESCRIPTION
https://cloud.google.com/storage/docs/performing-resumable-uploads

ref #107 

```rust
     async fn run_with_metadata(client:Client) {
         let mut metadata = HashMap::<String, String>::new();
         metadata.insert("key1".to_string(), "value1".to_string());
         let upload_type = UploadType::Multipart(Box::new(Object {
             name: "test1_meta".to_string(),
             content_type: Some("text/plain".to_string()),
             metadata: Some(metadata),
             ..Default::default()
         }));
         let uploader = client.prepare_resumable_upload(&UploadObjectRequest{
             bucket: "bucket".to_string(),
             ..Default::default()
         }, &upload_type, None).await.unwrap();
    
         let chunk1_data : Vec<u8>= (0..256 * 1024).map(|i| (i % 256) as u8).collect();
         let chunk2_data : Vec<u8>= (1..256 * 1024 + 50).map(|i| (i % 256) as u8).collect();
         let total_size = TotalSize::Known(chunk1_data.len() + chunk2_data.len());
    
         // The chunk size should be multiple of 256KiB, unless it's the last chunk that completes the upload.
         let chunk1 = ChunkSize::new(0, chunk1_data.len() - 1, total_size.clone()).unwrap();
         let status1 = uploader.upload_multiple_chunk(chunk1_data.clone(), &chunk1).await.unwrap();
         assert_eq!(status1, UploadStatus::ResumeIncomplete);
    
         let chunk2 = ChunkSize::new(chunk1_data.len(), chunk1_data.len() + chunk2_data.len() - 1, total_size.clone()).unwrap();
         let status2 = uploader.upload_multiple_chunk(chunk2_data.clone(), &chunk2).await.unwrap();
         assert_eq!(status2, UploadStatus::Ok);
```