### PR TITLE
Add get_resumable_upload to create Instance from URL

### DIFF
--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1972,6 +1972,13 @@ impl StorageClient {
         }
     }
 
+    /// Creates resumable upload from known URL.
+    ///
+    /// Assumes URL is correct, if not, `ResumableUploadClient` is not guaranteed to perform correctly.
+    pub fn get_resumable_upload(&self, url: String) -> ResumableUploadClient {
+        ResumableUploadClient::new(url, self.http.clone())
+    }
+
     /// Perform resumable uploads
     /// https://cloud.google.com/storage/docs/performing-resumable-uploads
     ///


### PR DESCRIPTION
It might be useful to provide user with shortcut to create resumable instance.

In my case I would need it if I want to initiate upload from graphql API and finish it via regular REST API