### PR TITLE
GCS: simplify error type

### DIFF
--- a/storage/src/http/error.rs
+++ b/storage/src/http/error.rs
@@ -24,7 +24,6 @@ pub struct ErrorResponse {
 impl ErrorResponse {
     /// Returns `true` if the error is retriable according to the [GCS documentation][1].
     ///
-    ///
     /// [1]: https://cloud.google.com/storage/docs/retry-strategy#retryable
     pub fn is_retriable(&self) -> bool {
         matches!(self.code, 408 | 429 | 500..=599)

--- a/storage/src/http/error.rs
+++ b/storage/src/http/error.rs
@@ -1,0 +1,82 @@
+use std::error::Error;
+use std::fmt;
+
+/// An error response returned from Google Cloud Storage.
+///
+/// See the [`HTTP status and error codes for JSON`][1] documentation for more details.
+///
+/// [1]: https://cloud.google.com/storage/docs/json_api/v1/status-codes
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorResponse {
+    /// An HTTP status value, without the textual description.
+    ///
+    /// Example values include: `400` (Bad Request), `401` (Unauthorized), and `404` (Not Found).
+    pub code: u16,
+
+    /// A container for the error details.
+    pub errors: Vec<ErrorResponseItem>,
+
+    /// Description of the error. Same as `errors.message`.
+    pub message: String,
+}
+
+impl ErrorResponse {
+    /// Returns `true` if the error is retriable according to the [GCS documentation][1].
+    ///
+    ///
+    /// [1]: https://cloud.google.com/storage/docs/retry-strategy#retryable
+    pub fn is_retriable(&self) -> bool {
+        matches!(self.code, 408 | 429 | 500..=599)
+    }
+}
+
+impl fmt::Display for ErrorResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+impl Error for ErrorResponse {}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorResponseItem {
+    /// The scope of the error. Example values include: `global` and `push`.
+    pub domain: String,
+
+    /// The specific item within the `locationType` that caused the error. For example, if you
+    /// specify an invalid value for a parameter, the `location` will be the name of the parameter.
+    ///
+    /// Example values include: `Authorization`, `project`, and `projection`.
+    pub location: Option<String>,
+
+    /// The location or part of the request that caused the error. Use with `location` to pinpoint
+    /// the error. For example, if you specify an invalid value for a parameter, the `locationType`
+    /// will be `parameter` and the `location` will be the name of the parameter.
+    ///
+    /// Example values include `header` and `parameter`.
+    pub location_type: Option<String>,
+
+    /// Description of the error.
+    ///
+    /// Example values include `Invalid argument`, `Login required`, and
+    /// `Required parameter: project`.
+    pub message: String,
+
+    /// Example values include `invalid`, `invalidParameter`, and `required`.
+    pub reason: String,
+}
+
+impl fmt::Display for ErrorResponseItem {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+/// The GCS error response JSON format contains an extra object level that is inconvenient to include in our
+/// error.
+#[derive(serde::Deserialize)]
+pub(crate) struct ErrorWrapper {
+    pub(crate) error: ErrorResponse,
+}

--- a/storage/src/http/objects/download.rs
+++ b/storage/src/http/objects/download.rs
@@ -3,7 +3,7 @@ use reqwest::{Client, RequestBuilder};
 use crate::http::objects::get::GetObjectRequest;
 use crate::http::Escape;
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Range(pub Option<u64>, pub Option<u64>);
 
 impl Range {

--- a/storage/src/http/objects/download.rs
+++ b/storage/src/http/objects/download.rs
@@ -3,7 +3,7 @@ use reqwest::{Client, RequestBuilder};
 use crate::http::objects::get::GetObjectRequest;
 use crate::http::Escape;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Range(pub Option<u64>, pub Option<u64>);
 
 impl Range {

--- a/storage/src/http/objects/upload.rs
+++ b/storage/src/http/objects/upload.rs
@@ -113,7 +113,8 @@ pub(crate) fn build_multipart<T: Into<reqwest::Body>>(
 ) -> Result<RequestBuilder, Error> {
     let url = format!("{}/b/{}/o?uploadType=multipart", base_url, req.bucket.escape(),);
     let form = Form::new();
-    let metadata_part = Part::text(serde_json::to_string(metadata)?).mime_str("application/json; charset=UTF-8")?;
+    let metadata_part = Part::text(serde_json::to_string(metadata).expect("object serialize failed"))
+        .mime_str("application/json; charset=UTF-8")?;
     let data_part = Part::stream(body);
     let form = form.part("metadata", metadata_part).part("data", data_part);
 

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -32,7 +32,7 @@ impl ServiceAccountClient {
             .header(reqwest::header::AUTHORIZATION, token);
         let response = request.send().await?;
         let response = check_response_status(response).await?;
-        Ok(response.json::<SignBlobResponse>().await?.signed_block)
+        Ok(response.json::<SignBlobResponse>().await?.signed_blob)
     }
 }
 
@@ -46,7 +46,7 @@ struct SignBlobRequest<'a> {
 #[serde(rename_all = "camelCase")]
 struct SignBlobResponse {
     #[serde(with = "super::base64")]
-    signed_block: Vec<u8>,
+    signed_blob: Vec<u8>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
While using `google-cloud-storage` to develop an application with strict retry & error handling requirements, I found it difficult to work with the `google_cloud_storage::http::Error` type. It exposes many error variants, and it's not clear how they should be handled, and many of the variants have a lot of overlap.

This PR simplifies the error type by reducing it to three variants:

1. GCS errors, returned by the GCS server
2. HTTP errors (wrapping `reqwest::Error`)
3. Token provider errors

Everything else, like the various decoding variants, has been removed. As an application author, I find this much easier to work with, since I don't have to consider how to handle as many types of errors. Reqwest's error type already has variants for failure to decode response bodies, so such errors only need to be handled in one way now.

To implement this, I had to tweak a few areas of the implementation to return a reqwest 'body' or 'decode' error instead of serde or base64 error. Primarily this is done via more uses of `Response::json`, which in effect pushes error creation into reqwest, who then wraps it appropriately.

Finally, I simplified and fixed some bugs in the resumable upload API. Previously the `ChunkSize::new` constructor did validation. This validation is unnecessary, since the GCS server will do the validation, and they are ultimately the authority. Indeed, the validation was overly strict and didn't allow empty chunks to be uploaded (which is useful for finishing a streaming upload if you don't know you are done till you have no more bytes to write).