### PR TITLE
include object metadata in conclusion of multi-part upload

### DIFF
--- a/storage/src/http/resumable_upload_client.rs
+++ b/storage/src/http/resumable_upload_client.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE};
 use reqwest::{Body, Client, Response};
 
-use crate::http::{check_response_status, Error};
+use crate::http::{check_response_status, objects::Object, Error};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ChunkError {
@@ -17,7 +17,7 @@ pub enum ChunkError {
 
 #[derive(PartialEq, Debug)]
 pub enum UploadStatus {
-    Ok,
+    Ok(Object),
     ResumeIncomplete,
 }
 
@@ -128,8 +128,8 @@ impl ResumableUploadClient {
         if response.status() == 308 {
             Ok(UploadStatus::ResumeIncomplete)
         } else {
-            check_response_status(response).await?;
-            Ok(UploadStatus::Ok)
+            let response = check_response_status(response).await?;
+            Ok(UploadStatus::Ok(response.json::<Object>().await?))
         }
     }
 }

--- a/storage/src/http/resumable_upload_client.rs
+++ b/storage/src/http/resumable_upload_client.rs
@@ -16,6 +16,7 @@ pub enum ChunkError {
 }
 
 #[derive(PartialEq, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum UploadStatus {
     Ok(Object),
     ResumeIncomplete,

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -2032,11 +2032,11 @@ mod test {
             .upload_multiple_chunk(chunk2_data.clone(), &chunk2)
             .await
             .unwrap();
-        assert_eq!(status2, UploadStatus::Ok);
+        assert!(matches!(status2, UploadStatus::Ok(_)));
 
         tracing::info!("check status chunk2");
         let status_check2 = uploader.status(total_size).await.unwrap();
-        assert_eq!(status_check2, UploadStatus::Ok);
+        assert!(matches!(status_check2, UploadStatus::Ok(_)));
 
         let get_request = &GetObjectRequest {
             bucket: bucket_name.to_string(),
@@ -2136,7 +2136,7 @@ mod test {
             .upload_multiple_chunk(chunk2_data.clone(), &chunk2)
             .await
             .unwrap();
-        assert_eq!(status2, UploadStatus::Ok);
+        assert!(matches!(status2, UploadStatus::Ok(_)));
 
         let get_request = &GetObjectRequest {
             bucket: bucket_name.to_string(),

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1070,7 +1070,7 @@ impl StorageClient {
     ///
     ///     let chunk2 = ChunkSize::new(chunk1_size, chunk1_size + chunk2_size - 1, total_size.clone());
     ///     let status2 = uploader.upload_multiple_chunk(chunk2_data.clone(), &chunk2).await.unwrap();
-    ///     assert_eq!(status2, UploadStatus::Ok);
+    ///     assert!(matches!(status2, UploadStatus::Ok(_)));
     /// }
     /// ```
     #[cfg_attr(feature = "trace", tracing::instrument(skip_all))]


### PR DESCRIPTION
Adds the inserted object metadata to the `Ok` side of the multi-part object upload return type. This allows for client-side validation that the written checksum is correct.