### PR TITLE
[Storage] remove default implementation for SignedUrlOptions

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -61,6 +61,7 @@ async fn run(cred: CredentialsFile) {
 use google_cloud_storage::client::Client;
 use google_cloud_storage::client::ClientConfig;
 use google_cloud_storage::sign::SignedURLOptions;
+use google_cloud_storage::sign::SignBy;
 use google_cloud_storage::sign::SignedURLMethod;
 use google_cloud_storage::http::Error;
 use google_cloud_storage::http::objects::download::Range;
@@ -90,12 +91,13 @@ async fn run(config: ClientConfig) -> Result<(), Error> {
         ..Default::default()
    }, &Range::default()).await;
 
-    // Create signed url.
-    let url_for_download = client.signed_url("bucket", "foo.txt", SignedURLOptions::default());
-    let url_for_upload = client.signed_url("bucket", "foo.txt", SignedURLOptions {
+    // Create signed url with the default key and google-access-id of the client
+    let url_for_download = client.signed_url("bucket", "foo.txt", None, None, SignedURLOptions::default());
+    let url_for_upload = client.signed_url("bucket", "foo.txt", None, None, SignedURLOptions {
         method: SignedURLMethod::PUT,
         ..Default::default()
     });
+
     Ok(())
 }
 ```

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -81,12 +81,13 @@
 //!         ..Default::default()
 //!    }, &Range::default()).await;
 //!
-//!     // Create signed url.
-//!     let url_for_download = client.signed_url("bucket", "foo.txt", SignedURLOptions::default());
-//!     let url_for_upload = client.signed_url("bucket", "foo.txt", SignedURLOptions {
+//!     // Create signed url with the default key and google-access-id of the client
+//!     let url_for_download = client.signed_url("bucket", "foo.txt", None, None, SignedURLOptions::default());
+//!     let url_for_upload = client.signed_url("bucket", "foo.txt", None, None, SignedURLOptions {
 //!         method: SignedURLMethod::PUT,
 //!         ..Default::default()
 //!     });
+//!
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
Hi :)

# My Problem
When trying to create a signed url for cloud-storage I realized that using the `Default` implementation of the `SignedUrlOptions` does not work.
Looking at the code that is quite obvious as there cannot be a sensible default for things like credentials.
Imo its not really user-friendly to provide defaults that do not work.
I get it, that it is convenient to use `default` in Tests but as a user of the crate its not cool.

# My proposed solution
I renamed `SignedUrlOptions` -> `SignedUrlConfig` and added `SignedUrlConfigOptions` to represent some config options that are not required and thus can implement default.

I am open for discussion and feedback is greatly appreciated :) 
