### PR TITLE
use quota project ID as default when available

### DIFF
--- a/foundation/auth/src/token.rs
+++ b/foundation/auth/src/token.rs
@@ -62,7 +62,9 @@ impl DefaultTokenSourceProvider {
 
         let (project_id, source_credentials) = match project {
             Project::FromMetadataServer(info) => (info.project_id, None),
-            Project::FromFile(cred) => (cred.project_id.clone(), Some(cred)),
+            Project::FromFile(cred) => {
+                (cred.project_id.as_ref().or(cred.quota_project_id.as_ref()).cloned(), Some(cred))
+            }
         };
         Ok(Self {
             ts: Arc::new(DefaultTokenSource {


### PR DESCRIPTION
This PR allows the quota project ID to be used as the default project ID when it is present in credentials.  I believe this matches the behavior of the `gcloud` CLI tool.