### PR TITLE
pubsub: derive Debug and Clone where appropriate

### DIFF
--- a/pubsub/src/publisher.rs
+++ b/pubsub/src/publisher.rs
@@ -25,7 +25,7 @@ pub(crate) enum Reserved {
     Multi(Vec<ReservedMessage>),
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PublisherConfig {
     /// worker count. each workers have gRPC channel
     pub workers: usize,

--- a/pubsub/src/subscriber.rs
+++ b/pubsub/src/subscriber.rs
@@ -55,7 +55,7 @@ impl ReceivedMessage {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SubscriberConfig {
     /// ping interval for Bi Directional Streaming
     pub ping_interval: Duration,

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -20,7 +20,7 @@ use google_cloud_googleapis::pubsub::v1::{
 use crate::apiv1::subscriber_client::SubscriberClient;
 use crate::subscriber::{ack, ReceivedMessage, Subscriber, SubscriberConfig};
 
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SubscriptionConfig {
     pub push_config: Option<PushConfig>,
     pub ack_deadline_seconds: i32,
@@ -64,7 +64,7 @@ impl From<InternalSubscription> for SubscriptionConfig {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SubscriptionConfigToUpdate {
     pub push_config: Option<PushConfig>,
     pub bigquery_config: Option<BigQueryConfig>,
@@ -77,6 +77,7 @@ pub struct SubscriptionConfigToUpdate {
     pub retry_policy: Option<RetryPolicy>,
 }
 
+#[derive(Debug, Clone)]
 pub struct ReceiveConfig {
     pub worker_count: usize,
     pub subscriber_config: SubscriberConfig,
@@ -91,6 +92,7 @@ impl Default for ReceiveConfig {
     }
 }
 
+#[derive(Debug, Clone)]
 pub enum SeekTo {
     Timestamp(SystemTime),
     Snapshot(String),

--- a/pubsub/src/topic.rs
+++ b/pubsub/src/topic.rs
@@ -15,6 +15,7 @@ use crate::apiv1::subscriber_client::SubscriberClient;
 use crate::publisher::{Publisher, PublisherConfig};
 use crate::subscription::Subscription;
 
+#[derive(Debug, Clone)]
 pub struct TopicConfig {
     pub labels: HashMap<String, String>,
     pub message_storage_policy: Option<MessageStoragePolicy>,


### PR DESCRIPTION
Add derive Debug and Clone on configs and other structs and enums.
