### PR TITLE
impl Clone for google_cloud_storage::Client

### DIFF
--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -35,6 +35,7 @@ impl Default for ClientConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct Client {
     default_google_access_id: Option<String>,
     default_sign_by: Option<SignBy>,

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -4,6 +4,7 @@ use google_cloud_token::TokenSource;
 
 use crate::http::{check_response_status, Error};
 
+#[derive(Clone)]
 pub struct ServiceAccountClient {
     ts: Arc<dyn TokenSource>,
     v1_endpoint: String,


### PR DESCRIPTION
This is useful, and falls out of the client being a wrapper around reqwest's client, which is cheaply cloneable.