### PR TITLE
Support impersonate credentials

### DIFF
--- a/default/src/lib.rs
+++ b/default/src/lib.rs
@@ -34,6 +34,7 @@ impl WithAuthExt for google_cloud_pubsub::client::ClientConfig {
             let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(google_cloud_auth::project::Config {
                 audience: Some(google_cloud_pubsub::apiv1::conn_pool::AUDIENCE),
                 scopes: Some(&google_cloud_pubsub::apiv1::conn_pool::SCOPES),
+                sub: None,
             })
             .await?;
             self.project_id = ts.project_id.clone();
@@ -51,6 +52,7 @@ impl WithAuthExt for google_cloud_pubsub::client::ClientConfig {
                 google_cloud_auth::project::Config {
                     audience: Some(google_cloud_pubsub::apiv1::conn_pool::AUDIENCE),
                     scopes: Some(&google_cloud_pubsub::apiv1::conn_pool::SCOPES),
+                    sub: None,
                 },
                 Box::new(credentials),
             )
@@ -71,6 +73,7 @@ impl WithAuthExt for google_cloud_spanner::client::ClientConfig {
             let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(google_cloud_auth::project::Config {
                 audience: Some(google_cloud_spanner::apiv1::conn_pool::AUDIENCE),
                 scopes: Some(&google_cloud_spanner::apiv1::conn_pool::SCOPES),
+                sub: None,
             })
             .await?;
             self.environment = google_cloud_gax::conn::Environment::GoogleCloud(Box::new(ts))
@@ -87,6 +90,7 @@ impl WithAuthExt for google_cloud_spanner::client::ClientConfig {
                 google_cloud_auth::project::Config {
                     audience: Some(google_cloud_spanner::apiv1::conn_pool::AUDIENCE),
                     scopes: Some(&google_cloud_spanner::apiv1::conn_pool::SCOPES),
+                    sub: None,
                 },
                 Box::new(credentials),
             )
@@ -104,6 +108,7 @@ impl WithAuthExt for google_cloud_storage::client::ClientConfig {
         let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(google_cloud_auth::project::Config {
             audience: None,
             scopes: Some(&google_cloud_storage::http::storage_client::SCOPES),
+            sub: None,
         })
         .await?;
 
@@ -137,6 +142,7 @@ impl WithAuthExt for google_cloud_storage::client::ClientConfig {
             google_cloud_auth::project::Config {
                 audience: None,
                 scopes: Some(&google_cloud_storage::http::storage_client::SCOPES),
+                sub: None,
             },
             Box::new(credentials),
         )

--- a/foundation/auth/README.md
+++ b/foundation/auth/README.md
@@ -27,11 +27,12 @@ async fn main() -> Result<(), error::Error> {
         // audience is required only for service account jwt-auth
         // https://developers.google.com/identity/protocols/oauth2/service-account#jwt-auth
         audience: Some(audience),
-        // scopes is required only for service account Oauth2 
+        // scopes is required only for service account Oauth2
         // https://developers.google.com/identity/protocols/oauth2/service-account
-        scopes: Some(&scopes) 
+        scopes: Some(&scopes),
+        sub: None
     };
-    let ts = create_token_source(config).await?;  
+    let ts = create_token_source(config).await?;
     let token = ts.token().await?;
     println!("token is {}",token.access_token);
     Ok(())

--- a/foundation/auth/src/project.rs
+++ b/foundation/auth/src/project.rs
@@ -121,8 +121,11 @@ fn credentials_from_json_with_params(
                     }
 
                     // use Standard OAuth 2.0 Flow
-                    let source =
-                        OAuth2ServiceAccountTokenSource::new(credentials, config.scopes_to_string(" ").as_str(), config.sub)?;
+                    let source = OAuth2ServiceAccountTokenSource::new(
+                        credentials,
+                        config.scopes_to_string(" ").as_str(),
+                        config.sub,
+                    )?;
                     Ok(Box::new(source))
                 }
                 Some(audience) => {

--- a/foundation/auth/src/project.rs
+++ b/foundation/auth/src/project.rs
@@ -16,6 +16,7 @@ const USER_CREDENTIALS_KEY: &str = "authorized_user";
 pub struct Config<'a> {
     pub audience: Option<&'a str>,
     pub scopes: Option<&'a [&'a str]>,
+    pub sub: Option<&'a str>,
 }
 
 impl Config<'_> {
@@ -121,7 +122,7 @@ fn credentials_from_json_with_params(
 
                     // use Standard OAuth 2.0 Flow
                     let source =
-                        OAuth2ServiceAccountTokenSource::new(credentials, config.scopes_to_string(" ").as_str())?;
+                        OAuth2ServiceAccountTokenSource::new(credentials, config.scopes_to_string(" ").as_str(), config.sub)?;
                     Ok(Box::new(source))
                 }
                 Some(audience) => {

--- a/foundation/auth/src/token_source/mod.rs
+++ b/foundation/auth/src/token_source/mod.rs
@@ -68,7 +68,8 @@ mod tests {
     async fn test_oauth2_token_source() -> Result<(), Error> {
         let credentials = CredentialsFile::new().await?;
         let scope = "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/spanner.data";
-        let ts = OAuth2ServiceAccountTokenSource::new(&credentials, scope)?;
+        let sub = None;
+        let ts = OAuth2ServiceAccountTokenSource::new(&credentials, scope, sub)?;
         let token = ts.token().await?;
         assert_eq!("Bearer", token.token_type);
         assert!(token.expiry.unwrap().unix_timestamp() > 0);

--- a/foundation/auth/src/token_source/service_account_token_source.rs
+++ b/foundation/auth/src/token_source/service_account_token_source.rs
@@ -140,10 +140,7 @@ impl OAuth2ServiceAccountTokenSource {
                 Some(s) => s.to_string(),
             },
             client: default_http_client(),
-            sub: match sub {
-                None => None,
-                Some(s) => Some(s.to_string()),
-            },
+            sub: sub.map(|s| s.to_string()),
         })
     }
 }

--- a/foundation/auth/src/token_source/service_account_token_source.rs
+++ b/foundation/auth/src/token_source/service_account_token_source.rs
@@ -105,6 +105,7 @@ pub struct OAuth2ServiceAccountTokenSource {
     pub pk_id: String,
     pub scopes: String,
     pub token_url: String,
+    pub sub: Option<String>,
 
     pub client: reqwest::Client,
 }
@@ -117,6 +118,7 @@ impl Debug for OAuth2ServiceAccountTokenSource {
             .field("pk_id", &self.pk_id)
             .field("scopes", &self.scopes)
             .field("token_url", &self.token_url)
+            .field("sub", &self.sub)
             .field("client", &self.client)
             .finish()
     }
@@ -126,6 +128,7 @@ impl OAuth2ServiceAccountTokenSource {
     pub(crate) fn new(
         cred: &credentials::CredentialsFile,
         scopes: &str,
+        sub: Option<&str>,
     ) -> Result<OAuth2ServiceAccountTokenSource, Error> {
         Ok(OAuth2ServiceAccountTokenSource {
             email: cred.client_email.unwrap_or_empty(),
@@ -137,6 +140,10 @@ impl OAuth2ServiceAccountTokenSource {
                 Some(s) => s.to_string(),
             },
             client: default_http_client(),
+            sub: match sub {
+                None => None,
+                Some(s) => Some(s.to_string()),
+            },
         })
     }
 }
@@ -149,7 +156,7 @@ impl TokenSource for OAuth2ServiceAccountTokenSource {
 
         let request_token = Claims {
             iss: self.email.as_ref(),
-            sub: None, // TODO support impersonate credentials
+            sub: self.sub.as_ref().map(|s| s.as_ref()),
             scope: Some(self.scopes.as_ref()),
             aud: self.token_url.as_ref(),
             exp: exp.unix_timestamp(),

--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -222,6 +222,7 @@ mod test {
         let ts = DefaultTokenSourceProvider::new(Config {
             audience: None,
             scopes: Some(&SCOPES),
+            sub: None
         })
         .await
         .unwrap();

--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -222,7 +222,7 @@ mod test {
         let ts = DefaultTokenSourceProvider::new(Config {
             audience: None,
             scopes: Some(&SCOPES),
-            sub: None
+            sub: None,
         })
         .await
         .unwrap();

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -71,7 +71,7 @@ mod test {
         let ts = DefaultTokenSourceProvider::new(Config {
             audience: None,
             scopes: Some(&["https://www.googleapis.com/auth/cloud-platform"]),
-            sub: None
+            sub: None,
         })
         .await
         .unwrap()

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -71,6 +71,7 @@ mod test {
         let ts = DefaultTokenSourceProvider::new(Config {
             audience: None,
             scopes: Some(&["https://www.googleapis.com/auth/cloud-platform"]),
+            sub: None
         })
         .await
         .unwrap()

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1373,6 +1373,7 @@ mod test {
         let tsp = DefaultTokenSourceProvider::new(Config {
             audience: None,
             scopes: Some(&SCOPES),
+            sub: None
         })
         .await
         .unwrap();

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1373,7 +1373,7 @@ mod test {
         let tsp = DefaultTokenSourceProvider::new(Config {
             audience: None,
             scopes: Some(&SCOPES),
-            sub: None
+            sub: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
Hi there! 👋

I've implemented the support for impersonating users, but since I'm new to Rust, I'm facing some difficulties in making the `sub` parameter optional. Could anyone provide me with some suggestions on how to achieve this? I already looked at implementing a `set_subject` mutator, but that didn't work out, as the `create_token_source` calls the `token()` function directly.. 

What is best practice? Thank you in advance!