### PR TITLE
set larger encode/decode message size limits to be consistent with pubsub

### DIFF
--- a/googleapis/README.md
+++ b/googleapis/README.md
@@ -3,6 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/google-cloud-googleapis.svg)](https://crates.io/crates/google-cloud-googleapis)
 
 ```bash
-git submodule update --init --recursive
+git submodule update --init --recursive --progress --depth=1
 cargo build --features generate,bytes
+cargo fmt
 ```

--- a/googleapis/src/bytes/google.iam.v1.rs
+++ b/googleapis/src/bytes/google.iam.v1.rs
@@ -617,7 +617,7 @@ pub mod iam_policy_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -673,6 +673,22 @@ pub mod iam_policy_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Sets the access control policy on the specified resource. Replaces any
         /// existing policy.
         ///
@@ -680,7 +696,7 @@ pub mod iam_policy_client {
         pub async fn set_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Policy>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -694,7 +710,10 @@ pub mod iam_policy_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.iam.v1.IAMPolicy/SetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.iam.v1.IAMPolicy", "SetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the access control policy for a resource.
         /// Returns an empty policy if the resource exists and does not have a policy
@@ -702,7 +721,7 @@ pub mod iam_policy_client {
         pub async fn get_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Policy>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -716,7 +735,10 @@ pub mod iam_policy_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.iam.v1.IAMPolicy/GetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.iam.v1.IAMPolicy", "GetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Returns permissions that a caller has on the specified resource.
         /// If the resource does not exist, this will return an empty set of
@@ -728,7 +750,10 @@ pub mod iam_policy_client {
         pub async fn test_iam_permissions(
             &mut self,
             request: impl tonic::IntoRequest<super::TestIamPermissionsRequest>,
-        ) -> Result<tonic::Response<super::TestIamPermissionsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::TestIamPermissionsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -742,7 +767,12 @@ pub mod iam_policy_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.iam.v1.IAMPolicy/TestIamPermissions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.iam.v1.IAMPolicy", "TestIamPermissions"),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/bytes/google.longrunning.rs
+++ b/googleapis/src/bytes/google.longrunning.rs
@@ -169,7 +169,7 @@ pub mod operations_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -225,6 +225,22 @@ pub mod operations_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Lists operations that match the specified filter in the request. If the
         /// server doesn't support this method, it returns `UNIMPLEMENTED`.
         ///
@@ -238,7 +254,10 @@ pub mod operations_client {
         pub async fn list_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListOperationsRequest>,
-        ) -> Result<tonic::Response<super::ListOperationsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListOperationsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -252,7 +271,12 @@ pub mod operations_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.longrunning.Operations/ListOperations",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.longrunning.Operations", "ListOperations"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the latest state of a long-running operation.  Clients can use this
         /// method to poll the operation result at intervals as recommended by the API
@@ -260,7 +284,7 @@ pub mod operations_client {
         pub async fn get_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::GetOperationRequest>,
-        ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -274,7 +298,12 @@ pub mod operations_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.longrunning.Operations/GetOperation",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.longrunning.Operations", "GetOperation"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a long-running operation. This method indicates that the client is
         /// no longer interested in the operation result. It does not cancel the
@@ -283,7 +312,7 @@ pub mod operations_client {
         pub async fn delete_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteOperationRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -297,7 +326,12 @@ pub mod operations_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.longrunning.Operations/DeleteOperation",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.longrunning.Operations", "DeleteOperation"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Starts asynchronous cancellation on a long-running operation.  The server
         /// makes a best effort to cancel the operation, but success is not
@@ -312,7 +346,7 @@ pub mod operations_client {
         pub async fn cancel_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelOperationRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -326,7 +360,12 @@ pub mod operations_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.longrunning.Operations/CancelOperation",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.longrunning.Operations", "CancelOperation"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Waits until the specified long-running operation is done or reaches at most
         /// a specified timeout, returning the latest state.  If the operation is
@@ -340,7 +379,7 @@ pub mod operations_client {
         pub async fn wait_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::WaitOperationRequest>,
-        ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -354,7 +393,12 @@ pub mod operations_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.longrunning.Operations/WaitOperation",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.longrunning.Operations", "WaitOperation"),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/bytes/google.pubsub.v1.rs
+++ b/googleapis/src/bytes/google.pubsub.v1.rs
@@ -347,7 +347,7 @@ pub mod schema_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -396,125 +396,171 @@ pub mod schema_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates a schema.
         pub async fn create_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/CreateSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "CreateSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets a schema.
         pub async fn get_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/GetSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "GetSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists schemas in a project.
         pub async fn list_schemas(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSchemasRequest>,
-        ) -> Result<tonic::Response<super::ListSchemasResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSchemasResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ListSchemas");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ListSchemas"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists all schema revisions for the named schema.
         pub async fn list_schema_revisions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSchemaRevisionsRequest>,
-        ) -> Result<tonic::Response<super::ListSchemaRevisionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSchemaRevisionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ListSchemaRevisions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ListSchemaRevisions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Commits a new schema revision to an existing schema.
         pub async fn commit_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::CommitSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/CommitSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "CommitSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new schema revision that is a copy of the provided revision_id.
         pub async fn rollback_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::RollbackSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/RollbackSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "RollbackSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a specific schema revision.
         pub async fn delete_schema_revision(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSchemaRevisionRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/DeleteSchemaRevision");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "DeleteSchemaRevision"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a schema.
         pub async fn delete_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSchemaRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/DeleteSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "DeleteSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Validates a schema.
         pub async fn validate_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateSchemaRequest>,
-        ) -> Result<tonic::Response<super::ValidateSchemaResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ValidateSchemaResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ValidateSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Validates a message against a schema.
         pub async fn validate_message(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateMessageRequest>,
-        ) -> Result<tonic::Response<super::ValidateMessageResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ValidateMessageResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateMessage");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ValidateMessage"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1705,7 +1751,7 @@ pub mod publisher_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1754,80 +1800,114 @@ pub mod publisher_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates the given topic with the given name. See the [resource name rules]
         /// (https://cloud.google.com/pubsub/docs/admin#resource_names).
         pub async fn create_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::Topic>,
-        ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Topic>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/CreateTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "CreateTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an existing topic. Note that certain properties of a
         /// topic are not modifiable.
         pub async fn update_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateTopicRequest>,
-        ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Topic>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/UpdateTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "UpdateTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
         /// does not exist.
         pub async fn publish(
             &mut self,
             request: impl tonic::IntoRequest<super::PublishRequest>,
-        ) -> Result<tonic::Response<super::PublishResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::PublishResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/Publish");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "Publish"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the configuration of a topic.
         pub async fn get_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTopicRequest>,
-        ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Topic>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/GetTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "GetTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists matching topics.
         pub async fn list_topics(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicsRequest>,
-        ) -> Result<tonic::Response<super::ListTopicsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListTopicsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopics");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "ListTopics"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the names of the attached subscriptions on this topic.
         pub async fn list_topic_subscriptions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSubscriptionsRequest>,
-        ) -> Result<tonic::Response<super::ListTopicSubscriptionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListTopicSubscriptionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSubscriptions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "ListTopicSubscriptions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the names of the snapshots on this topic. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -1837,13 +1917,16 @@ pub mod publisher_client {
         pub async fn list_topic_snapshots(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::ListTopicSnapshotsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListTopicSnapshotsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSnapshots");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "ListTopicSnapshots"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
         /// does not exist. After a topic is deleted, a new topic may be created with
@@ -1853,13 +1936,16 @@ pub mod publisher_client {
         pub async fn delete_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteTopicRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DeleteTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "DeleteTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Detaches a subscription from this topic. All messages retained in the
         /// subscription are dropped. Subsequent `Pull` and `StreamingPull` requests
@@ -1868,13 +1954,16 @@ pub mod publisher_client {
         pub async fn detach_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::DetachSubscriptionRequest>,
-        ) -> Result<tonic::Response<super::DetachSubscriptionResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::DetachSubscriptionResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DetachSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "DetachSubscription"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1894,7 +1983,7 @@ pub mod subscriber_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1943,6 +2032,22 @@ pub mod subscriber_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates a subscription to a given topic. See the [resource name rules]
         /// (https://cloud.google.com/pubsub/docs/admin#resource_names).
         /// If the subscription already exists, returns `ALREADY_EXISTS`.
@@ -1957,50 +2062,62 @@ pub mod subscriber_client {
         pub async fn create_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::Subscription>,
-        ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Subscription>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "CreateSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the configuration details of a subscription.
         pub async fn get_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSubscriptionRequest>,
-        ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Subscription>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "GetSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an existing subscription. Note that certain properties of a
         /// subscription, such as its topic, are not modifiable.
         pub async fn update_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSubscriptionRequest>,
-        ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Subscription>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "UpdateSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists matching subscriptions.
         pub async fn list_subscriptions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSubscriptionsRequest>,
-        ) -> Result<tonic::Response<super::ListSubscriptionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSubscriptionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSubscriptions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ListSubscriptions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes an existing subscription. All messages retained in the subscription
         /// are immediately dropped. Calls to `Pull` after deletion will return
@@ -2010,13 +2127,16 @@ pub mod subscriber_client {
         pub async fn delete_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSubscriptionRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "DeleteSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Modifies the ack deadline for a specific message. This method is useful
         /// to indicate that more time is needed to process a message by the
@@ -2026,13 +2146,16 @@ pub mod subscriber_client {
         pub async fn modify_ack_deadline(
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyAckDeadlineRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyAckDeadline");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ModifyAckDeadline"));
+            self.inner.unary(req, path, codec).await
         }
         /// Acknowledges the messages associated with the `ack_ids` in the
         /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
@@ -2044,25 +2167,31 @@ pub mod subscriber_client {
         pub async fn acknowledge(
             &mut self,
             request: impl tonic::IntoRequest<super::AcknowledgeRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Acknowledge");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "Acknowledge"));
+            self.inner.unary(req, path, codec).await
         }
         /// Pulls messages from the server.
         pub async fn pull(
             &mut self,
             request: impl tonic::IntoRequest<super::PullRequest>,
-        ) -> Result<tonic::Response<super::PullResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::PullResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Pull");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "Pull"));
+            self.inner.unary(req, path, codec).await
         }
         /// Establishes a stream with the server, which sends messages down to the
         /// client. The client streams acknowledgements and ack deadline modifications
@@ -2074,15 +2203,17 @@ pub mod subscriber_client {
         pub async fn streaming_pull(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::StreamingPullRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/StreamingPull");
-            self.inner
-                .streaming(request.into_streaming_request(), path, codec)
-                .await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "StreamingPull"));
+            self.inner.streaming(req, path, codec).await
         }
         /// Modifies the `PushConfig` for a specified subscription.
         ///
@@ -2093,13 +2224,16 @@ pub mod subscriber_client {
         pub async fn modify_push_config(
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyPushConfigRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyPushConfig");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ModifyPushConfig"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the configuration details of a snapshot. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -2109,13 +2243,16 @@ pub mod subscriber_client {
         pub async fn get_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSnapshotRequest>,
-        ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Snapshot>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "GetSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the existing snapshots. Snapshots are used in [Seek](
         /// https://cloud.google.com/pubsub/docs/replay-overview) operations, which
@@ -2125,13 +2262,16 @@ pub mod subscriber_client {
         pub async fn list_snapshots(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSnapshots");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ListSnapshots"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a snapshot from the requested subscription. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -2152,13 +2292,16 @@ pub mod subscriber_client {
         pub async fn create_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
-        ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Snapshot>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "CreateSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an existing snapshot. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -2168,13 +2311,16 @@ pub mod subscriber_client {
         pub async fn update_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSnapshotRequest>,
-        ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Snapshot>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "UpdateSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Removes an existing snapshot. Snapshots are used in [Seek]
         /// (https://cloud.google.com/pubsub/docs/replay-overview) operations, which
@@ -2188,13 +2334,16 @@ pub mod subscriber_client {
         pub async fn delete_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "DeleteSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Seeks an existing subscription to a point in time or to a given snapshot,
         /// whichever is provided in the request. Snapshots are used in [Seek]
@@ -2206,13 +2355,16 @@ pub mod subscriber_client {
         pub async fn seek(
             &mut self,
             request: impl tonic::IntoRequest<super::SeekRequest>,
-        ) -> Result<tonic::Response<super::SeekResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::SeekResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Seek");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "Seek"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/bytes/google.spanner.admin.database.v1.rs
+++ b/googleapis/src/bytes/google.spanner.admin.database.v1.rs
@@ -1474,7 +1474,7 @@ pub mod database_admin_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1530,11 +1530,30 @@ pub mod database_admin_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Lists Cloud Spanner databases.
         pub async fn list_databases(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabasesRequest>,
-        ) -> Result<tonic::Response<super::ListDatabasesResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListDatabasesResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1548,7 +1567,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabases",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "ListDatabases",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new Cloud Spanner database and starts to prepare it for serving.
         /// The returned [long-running operation][google.longrunning.Operation] will
@@ -1561,7 +1588,7 @@ pub mod database_admin_client {
         pub async fn create_database(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateDatabaseRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1578,13 +1605,21 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/CreateDatabase",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "CreateDatabase",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the state of a Cloud Spanner database.
         pub async fn get_database(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseRequest>,
-        ) -> Result<tonic::Response<super::Database>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Database>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1598,7 +1633,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabase",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "GetDatabase",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Updates the schema of a Cloud Spanner database by
         /// creating/altering/dropping tables, columns, indexes, etc. The returned
@@ -1610,7 +1653,7 @@ pub mod database_admin_client {
         pub async fn update_database_ddl(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateDatabaseDdlRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1627,7 +1670,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/UpdateDatabaseDdl",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "UpdateDatabaseDdl",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Drops (aka deletes) a Cloud Spanner database.
         /// Completed backups for the database will be retained according to their
@@ -1637,7 +1688,7 @@ pub mod database_admin_client {
         pub async fn drop_database(
             &mut self,
             request: impl tonic::IntoRequest<super::DropDatabaseRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1651,7 +1702,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/DropDatabase",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "DropDatabase",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Returns the schema of a Cloud Spanner database as a list of formatted
         /// DDL statements. This method does not show pending schema updates, those may
@@ -1659,7 +1718,10 @@ pub mod database_admin_client {
         pub async fn get_database_ddl(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseDdlRequest>,
-        ) -> Result<tonic::Response<super::GetDatabaseDdlResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::GetDatabaseDdlResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1673,7 +1735,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabaseDdl",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "GetDatabaseDdl",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Sets the access control policy on a database or backup resource.
         /// Replaces any existing policy.
@@ -1687,7 +1757,7 @@ pub mod database_admin_client {
             request: impl tonic::IntoRequest<
                 super::super::super::super::super::iam::v1::SetIamPolicyRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::iam::v1::Policy>,
             tonic::Status,
         > {
@@ -1704,7 +1774,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/SetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "SetIamPolicy",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the access control policy for a database or backup resource.
         /// Returns an empty policy if a database or backup exists but does not have a
@@ -1719,7 +1797,7 @@ pub mod database_admin_client {
             request: impl tonic::IntoRequest<
                 super::super::super::super::super::iam::v1::GetIamPolicyRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::iam::v1::Policy>,
             tonic::Status,
         > {
@@ -1736,7 +1814,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/GetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "GetIamPolicy",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Returns permissions that the caller has on the specified database or backup
         /// resource.
@@ -1753,7 +1839,7 @@ pub mod database_admin_client {
             request: impl tonic::IntoRequest<
                 super::super::super::super::super::iam::v1::TestIamPermissionsRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<
                 super::super::super::super::super::iam::v1::TestIamPermissionsResponse,
             >,
@@ -1772,7 +1858,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/TestIamPermissions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "TestIamPermissions",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Starts creating a new Cloud Spanner Backup.
         /// The returned backup [long-running operation][google.longrunning.Operation]
@@ -1789,7 +1883,7 @@ pub mod database_admin_client {
         pub async fn create_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBackupRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1806,7 +1900,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/CreateBackup",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "CreateBackup",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Starts copying a Cloud Spanner Backup.
         /// The returned backup [long-running operation][google.longrunning.Operation]
@@ -1823,7 +1925,7 @@ pub mod database_admin_client {
         pub async fn copy_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CopyBackupRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1840,13 +1942,21 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/CopyBackup",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "CopyBackup",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets metadata on a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
         pub async fn get_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::GetBackupRequest>,
-        ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Backup>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1860,13 +1970,21 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/GetBackup",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "GetBackup",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Updates a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
         pub async fn update_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBackupRequest>,
-        ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Backup>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1880,13 +1998,21 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/UpdateBackup",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "UpdateBackup",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
         pub async fn delete_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBackupRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1900,7 +2026,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/DeleteBackup",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "DeleteBackup",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Lists completed and pending backups.
         /// Backups returned are ordered by `create_time` in descending order,
@@ -1908,7 +2042,10 @@ pub mod database_admin_client {
         pub async fn list_backups(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupsRequest>,
-        ) -> Result<tonic::Response<super::ListBackupsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListBackupsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1922,7 +2059,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListBackups",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "ListBackups",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Create a new database by restoring from a completed backup. The new
         /// database must be in the same project and in an instance with the same
@@ -1944,7 +2089,7 @@ pub mod database_admin_client {
         pub async fn restore_database(
             &mut self,
             request: impl tonic::IntoRequest<super::RestoreDatabaseRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1961,7 +2106,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/RestoreDatabase",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "RestoreDatabase",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Lists database [longrunning-operations][google.longrunning.Operation].
         /// A database operation has a name of the form
@@ -1974,7 +2127,7 @@ pub mod database_admin_client {
         pub async fn list_database_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseOperationsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::ListDatabaseOperationsResponse>,
             tonic::Status,
         > {
@@ -1991,7 +2144,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseOperations",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "ListDatabaseOperations",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the backup [long-running operations][google.longrunning.Operation] in
         /// the given instance. A backup operation has a name of the form
@@ -2006,7 +2167,7 @@ pub mod database_admin_client {
         pub async fn list_backup_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupOperationsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::ListBackupOperationsResponse>,
             tonic::Status,
         > {
@@ -2023,13 +2184,24 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListBackupOperations",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "ListBackupOperations",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Lists Cloud Spanner database roles.
         pub async fn list_database_roles(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseRolesRequest>,
-        ) -> Result<tonic::Response<super::ListDatabaseRolesResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListDatabaseRolesResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2043,7 +2215,15 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseRoles",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.database.v1.DatabaseAdmin",
+                        "ListDatabaseRoles",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/bytes/google.spanner.admin.instance.v1.rs
+++ b/googleapis/src/bytes/google.spanner.admin.instance.v1.rs
@@ -841,7 +841,7 @@ pub mod instance_admin_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -897,11 +897,30 @@ pub mod instance_admin_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Lists the supported instance configurations for a given project.
         pub async fn list_instance_configs(
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstanceConfigsRequest>,
-        ) -> Result<tonic::Response<super::ListInstanceConfigsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListInstanceConfigsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -915,13 +934,21 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigs",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "ListInstanceConfigs",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets information about a particular instance configuration.
         pub async fn get_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceConfigRequest>,
-        ) -> Result<tonic::Response<super::InstanceConfig>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::InstanceConfig>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -935,7 +962,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/GetInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "GetInstanceConfig",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Creates an instance config and begins preparing it to be used. The
         /// returned [long-running operation][google.longrunning.Operation]
@@ -981,7 +1016,7 @@ pub mod instance_admin_client {
         pub async fn create_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateInstanceConfigRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -998,7 +1033,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "CreateInstanceConfig",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an instance config. The returned
         /// [long-running operation][google.longrunning.Operation] can be used to track
@@ -1047,7 +1090,7 @@ pub mod instance_admin_client {
         pub async fn update_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateInstanceConfigRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1064,7 +1107,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "UpdateInstanceConfig",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes the instance config. Deletion is only allowed when no
         /// instances are using the configuration. If any instances are using
@@ -1077,7 +1128,7 @@ pub mod instance_admin_client {
         pub async fn delete_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteInstanceConfigRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1091,7 +1142,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "DeleteInstanceConfig",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the user-managed instance config [long-running
         /// operations][google.longrunning.Operation] in the given project. An instance
@@ -1107,7 +1166,7 @@ pub mod instance_admin_client {
         pub async fn list_instance_config_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstanceConfigOperationsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::ListInstanceConfigOperationsResponse>,
             tonic::Status,
         > {
@@ -1124,13 +1183,24 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigOperations",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "ListInstanceConfigOperations",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Lists all instances in the given project.
         pub async fn list_instances(
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstancesRequest>,
-        ) -> Result<tonic::Response<super::ListInstancesResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListInstancesResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1144,13 +1214,21 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstances",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "ListInstances",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets information about a particular instance.
         pub async fn get_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceRequest>,
-        ) -> Result<tonic::Response<super::Instance>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Instance>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1164,7 +1242,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/GetInstance",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "GetInstance",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Creates an instance and begins preparing it to begin serving. The
         /// returned [long-running operation][google.longrunning.Operation]
@@ -1203,7 +1289,7 @@ pub mod instance_admin_client {
         pub async fn create_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateInstanceRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1220,7 +1306,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstance",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "CreateInstance",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an instance, and begins allocating or releasing resources
         /// as requested. The returned [long-running
@@ -1265,7 +1359,7 @@ pub mod instance_admin_client {
         pub async fn update_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateInstanceRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::longrunning::Operation>,
             tonic::Status,
         > {
@@ -1282,7 +1376,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstance",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "UpdateInstance",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes an instance.
         ///
@@ -1298,7 +1400,7 @@ pub mod instance_admin_client {
         pub async fn delete_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteInstanceRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1312,7 +1414,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstance",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "DeleteInstance",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Sets the access control policy on an instance resource. Replaces any
         /// existing policy.
@@ -1324,7 +1434,7 @@ pub mod instance_admin_client {
             request: impl tonic::IntoRequest<
                 super::super::super::super::super::iam::v1::SetIamPolicyRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::iam::v1::Policy>,
             tonic::Status,
         > {
@@ -1341,7 +1451,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/SetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "SetIamPolicy",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the access control policy for an instance resource. Returns an empty
         /// policy if an instance exists but does not have a policy set.
@@ -1353,7 +1471,7 @@ pub mod instance_admin_client {
             request: impl tonic::IntoRequest<
                 super::super::super::super::super::iam::v1::GetIamPolicyRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::iam::v1::Policy>,
             tonic::Status,
         > {
@@ -1370,7 +1488,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/GetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "GetIamPolicy",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Returns permissions that the caller has on the specified instance resource.
         ///
@@ -1383,7 +1509,7 @@ pub mod instance_admin_client {
             request: impl tonic::IntoRequest<
                 super::super::super::super::super::iam::v1::TestIamPermissionsRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<
                 super::super::super::super::super::iam::v1::TestIamPermissionsResponse,
             >,
@@ -1402,7 +1528,15 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/TestIamPermissions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.spanner.admin.instance.v1.InstanceAdmin",
+                        "TestIamPermissions",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/bytes/google.spanner.v1.rs
+++ b/googleapis/src/bytes/google.spanner.v1.rs
@@ -2221,7 +2221,7 @@ pub mod spanner_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -2277,6 +2277,22 @@ pub mod spanner_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates a new session. A session can be used to perform
         /// transactions that read and/or modify data in a Cloud Spanner database.
         /// Sessions are meant to be reused for many consecutive
@@ -2299,7 +2315,7 @@ pub mod spanner_client {
         pub async fn create_session(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSessionRequest>,
-        ) -> Result<tonic::Response<super::Session>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Session>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2313,7 +2329,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/CreateSession",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "CreateSession"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates multiple new sessions.
         ///
@@ -2322,7 +2341,10 @@ pub mod spanner_client {
         pub async fn batch_create_sessions(
             &mut self,
             request: impl tonic::IntoRequest<super::BatchCreateSessionsRequest>,
-        ) -> Result<tonic::Response<super::BatchCreateSessionsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::BatchCreateSessionsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2336,7 +2358,12 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/BatchCreateSessions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.spanner.v1.Spanner", "BatchCreateSessions"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets a session. Returns `NOT_FOUND` if the session does not exist.
         /// This is mainly useful for determining whether a session is still
@@ -2344,7 +2371,7 @@ pub mod spanner_client {
         pub async fn get_session(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSessionRequest>,
-        ) -> Result<tonic::Response<super::Session>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Session>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2358,13 +2385,19 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/GetSession",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "GetSession"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists all sessions in a given database.
         pub async fn list_sessions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSessionsRequest>,
-        ) -> Result<tonic::Response<super::ListSessionsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListSessionsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2378,7 +2411,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/ListSessions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "ListSessions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Ends a session, releasing server resources associated with it. This will
         /// asynchronously trigger cancellation of any operations that are running with
@@ -2386,7 +2422,7 @@ pub mod spanner_client {
         pub async fn delete_session(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSessionRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2400,7 +2436,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/DeleteSession",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "DeleteSession"));
+            self.inner.unary(req, path, codec).await
         }
         /// Executes an SQL statement, returning all results in a single reply. This
         /// method cannot be used to return a result set larger than 10 MiB;
@@ -2416,7 +2455,7 @@ pub mod spanner_client {
         pub async fn execute_sql(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
-        ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ResultSet>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2430,7 +2469,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/ExecuteSql",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "ExecuteSql"));
+            self.inner.unary(req, path, codec).await
         }
         /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the result
         /// set as a stream. Unlike [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], there
@@ -2440,7 +2482,7 @@ pub mod spanner_client {
         pub async fn execute_streaming_sql(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>,
             tonic::Status,
         > {
@@ -2457,7 +2499,12 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/ExecuteStreamingSql",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.spanner.v1.Spanner", "ExecuteStreamingSql"),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Executes a batch of SQL DML statements. This method allows many statements
         /// to be run with lower latency than submitting them sequentially with
@@ -2473,7 +2520,10 @@ pub mod spanner_client {
         pub async fn execute_batch_dml(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteBatchDmlRequest>,
-        ) -> Result<tonic::Response<super::ExecuteBatchDmlResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ExecuteBatchDmlResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2487,7 +2537,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/ExecuteBatchDml",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "ExecuteBatchDml"));
+            self.inner.unary(req, path, codec).await
         }
         /// Reads rows from the database using key lookups and scans, as a
         /// simple key/value style alternative to
@@ -2505,7 +2558,7 @@ pub mod spanner_client {
         pub async fn read(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
-        ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ResultSet>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2519,7 +2572,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/Read",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "Read"));
+            self.inner.unary(req, path, codec).await
         }
         /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set as a
         /// stream. Unlike [Read][google.spanner.v1.Spanner.Read], there is no limit on the
@@ -2529,7 +2585,7 @@ pub mod spanner_client {
         pub async fn streaming_read(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>,
             tonic::Status,
         > {
@@ -2546,7 +2602,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/StreamingRead",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "StreamingRead"));
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Begins a new transaction. This step can often be skipped:
         /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
@@ -2555,7 +2614,7 @@ pub mod spanner_client {
         pub async fn begin_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::BeginTransactionRequest>,
-        ) -> Result<tonic::Response<super::Transaction>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Transaction>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2569,7 +2628,12 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/BeginTransaction",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.spanner.v1.Spanner", "BeginTransaction"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Commits a transaction. The request includes the mutations to be
         /// applied to rows in the database.
@@ -2588,7 +2652,7 @@ pub mod spanner_client {
         pub async fn commit(
             &mut self,
             request: impl tonic::IntoRequest<super::CommitRequest>,
-        ) -> Result<tonic::Response<super::CommitResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::CommitResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2602,7 +2666,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/Commit",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "Commit"));
+            self.inner.unary(req, path, codec).await
         }
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
@@ -2615,7 +2682,7 @@ pub mod spanner_client {
         pub async fn rollback(
             &mut self,
             request: impl tonic::IntoRequest<super::RollbackRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2629,7 +2696,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/Rollback",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "Rollback"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a query
         /// operation in parallel.  Each of the returned partition tokens can be used
@@ -2645,7 +2715,10 @@ pub mod spanner_client {
         pub async fn partition_query(
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionQueryRequest>,
-        ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::PartitionResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2659,7 +2732,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/PartitionQuery",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "PartitionQuery"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a read
         /// operation in parallel.  Each of the returned partition tokens can be used
@@ -2677,7 +2753,10 @@ pub mod spanner_client {
         pub async fn partition_read(
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionReadRequest>,
-        ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::PartitionResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2691,7 +2770,10 @@ pub mod spanner_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.v1.Spanner/PartitionRead",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "PartitionRead"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/bytes/google.storage.v2.rs
+++ b/googleapis/src/bytes/google.storage.v2.rs
@@ -2123,7 +2123,7 @@ pub mod storage_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -2179,11 +2179,27 @@ pub mod storage_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Permanently deletes an empty bucket.
         pub async fn delete_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBucketRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2197,13 +2213,16 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/DeleteBucket",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "DeleteBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Returns metadata for the specified bucket.
         pub async fn get_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::GetBucketRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2217,13 +2236,16 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/GetBucket",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new bucket.
         pub async fn create_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBucketRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2237,13 +2259,19 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/CreateBucket",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "CreateBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves a list of buckets for a given project.
         pub async fn list_buckets(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBucketsRequest>,
-        ) -> Result<tonic::Response<super::ListBucketsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListBucketsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2257,13 +2285,16 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/ListBuckets",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ListBuckets"));
+            self.inner.unary(req, path, codec).await
         }
         /// Locks retention policy on a bucket.
         pub async fn lock_bucket_retention_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::LockBucketRetentionPolicyRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2277,7 +2308,15 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/LockBucketRetentionPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.storage.v2.Storage",
+                        "LockBucketRetentionPolicy",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the IAM policy for a specified bucket or object.
         /// The `resource` field in the request should be
@@ -2288,7 +2327,7 @@ pub mod storage_client {
             request: impl tonic::IntoRequest<
                 super::super::super::iam::v1::GetIamPolicyRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::iam::v1::Policy>,
             tonic::Status,
         > {
@@ -2305,7 +2344,10 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/GetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an IAM policy for the specified bucket or object.
         /// The `resource` field in the request should be
@@ -2316,7 +2358,7 @@ pub mod storage_client {
             request: impl tonic::IntoRequest<
                 super::super::super::iam::v1::SetIamPolicyRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::iam::v1::Policy>,
             tonic::Status,
         > {
@@ -2333,7 +2375,10 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/SetIamPolicy",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "SetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Tests a set of permissions on the given bucket or object to see which, if
         /// any, are held by the caller.
@@ -2345,7 +2390,7 @@ pub mod storage_client {
             request: impl tonic::IntoRequest<
                 super::super::super::iam::v1::TestIamPermissionsRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::iam::v1::TestIamPermissionsResponse>,
             tonic::Status,
         > {
@@ -2362,13 +2407,18 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/TestIamPermissions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.storage.v2.Storage", "TestIamPermissions"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Updates a bucket. Equivalent to JSON API's storage.buckets.patch method.
         pub async fn update_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBucketRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2382,13 +2432,16 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/UpdateBucket",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "UpdateBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Permanently deletes a NotificationConfig.
         pub async fn delete_notification_config(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteNotificationConfigRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2402,13 +2455,24 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/DeleteNotificationConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.storage.v2.Storage",
+                        "DeleteNotificationConfig",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// View a NotificationConfig.
         pub async fn get_notification_config(
             &mut self,
             request: impl tonic::IntoRequest<super::GetNotificationConfigRequest>,
-        ) -> Result<tonic::Response<super::NotificationConfig>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::NotificationConfig>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2422,7 +2486,12 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/GetNotificationConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.storage.v2.Storage", "GetNotificationConfig"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a NotificationConfig for a given bucket.
         /// These NotificationConfigs, when triggered, publish messages to the
@@ -2431,7 +2500,10 @@ pub mod storage_client {
         pub async fn create_notification_config(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateNotificationConfigRequest>,
-        ) -> Result<tonic::Response<super::NotificationConfig>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::NotificationConfig>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2445,13 +2517,21 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/CreateNotificationConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.storage.v2.Storage",
+                        "CreateNotificationConfig",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves a list of NotificationConfigs for a given bucket.
         pub async fn list_notification_configs(
             &mut self,
             request: impl tonic::IntoRequest<super::ListNotificationConfigsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::ListNotificationConfigsResponse>,
             tonic::Status,
         > {
@@ -2468,14 +2548,22 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/ListNotificationConfigs",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "google.storage.v2.Storage",
+                        "ListNotificationConfigs",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Concatenates a list of existing objects into a new object in the same
         /// bucket.
         pub async fn compose_object(
             &mut self,
             request: impl tonic::IntoRequest<super::ComposeObjectRequest>,
-        ) -> Result<tonic::Response<super::Object>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Object>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2489,7 +2577,10 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/ComposeObject",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ComposeObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes an object and its metadata.
         ///
@@ -2500,7 +2591,7 @@ pub mod storage_client {
         pub async fn delete_object(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteObjectRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2514,7 +2605,10 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/DeleteObject",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "DeleteObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Cancels an in-progress resumable upload.
         ///
@@ -2527,7 +2621,7 @@ pub mod storage_client {
         pub async fn cancel_resumable_write(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelResumableWriteRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::CancelResumableWriteResponse>,
             tonic::Status,
         > {
@@ -2544,13 +2638,18 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/CancelResumableWrite",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.storage.v2.Storage", "CancelResumableWrite"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves an object's metadata.
         pub async fn get_object(
             &mut self,
             request: impl tonic::IntoRequest<super::GetObjectRequest>,
-        ) -> Result<tonic::Response<super::Object>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Object>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2564,13 +2663,16 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/GetObject",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Reads an object's data.
         pub async fn read_object(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadObjectRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ReadObjectResponse>>,
             tonic::Status,
         > {
@@ -2587,14 +2689,17 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/ReadObject",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ReadObject"));
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Updates an object's metadata.
         /// Equivalent to JSON API's storage.objects.patch.
         pub async fn update_object(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateObjectRequest>,
-        ) -> Result<tonic::Response<super::Object>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Object>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2608,7 +2713,10 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/UpdateObject",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "UpdateObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Stores a new object and metadata.
         ///
@@ -2668,7 +2776,10 @@ pub mod storage_client {
             request: impl tonic::IntoStreamingRequest<
                 Message = super::WriteObjectRequest,
             >,
-        ) -> Result<tonic::Response<super::WriteObjectResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::WriteObjectResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2682,15 +2793,19 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/WriteObject",
             );
-            self.inner
-                .client_streaming(request.into_streaming_request(), path, codec)
-                .await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "WriteObject"));
+            self.inner.client_streaming(req, path, codec).await
         }
         /// Retrieves a list of objects matching the criteria.
         pub async fn list_objects(
             &mut self,
             request: impl tonic::IntoRequest<super::ListObjectsRequest>,
-        ) -> Result<tonic::Response<super::ListObjectsResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListObjectsResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2704,14 +2819,20 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/ListObjects",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ListObjects"));
+            self.inner.unary(req, path, codec).await
         }
         /// Rewrites a source object to a destination object. Optionally overrides
         /// metadata.
         pub async fn rewrite_object(
             &mut self,
             request: impl tonic::IntoRequest<super::RewriteObjectRequest>,
-        ) -> Result<tonic::Response<super::RewriteResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::RewriteResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2725,7 +2846,10 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/RewriteObject",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "RewriteObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Starts a resumable write. How long the write operation remains valid, and
         /// what happens when the write operation becomes invalid, are
@@ -2733,7 +2857,10 @@ pub mod storage_client {
         pub async fn start_resumable_write(
             &mut self,
             request: impl tonic::IntoRequest<super::StartResumableWriteRequest>,
-        ) -> Result<tonic::Response<super::StartResumableWriteResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::StartResumableWriteResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2747,7 +2874,12 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/StartResumableWrite",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.storage.v2.Storage", "StartResumableWrite"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Determines the `persisted_size` for an object that is being written, which
         /// can then be used as the `write_offset` for the next `Write()` call.
@@ -2765,7 +2897,10 @@ pub mod storage_client {
         pub async fn query_write_status(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryWriteStatusRequest>,
-        ) -> Result<tonic::Response<super::QueryWriteStatusResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::QueryWriteStatusResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2779,13 +2914,18 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/QueryWriteStatus",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.storage.v2.Storage", "QueryWriteStatus"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves the name of a project's Google Cloud Storage service account.
         pub async fn get_service_account(
             &mut self,
             request: impl tonic::IntoRequest<super::GetServiceAccountRequest>,
-        ) -> Result<tonic::Response<super::ServiceAccount>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ServiceAccount>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2799,13 +2939,21 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/GetServiceAccount",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("google.storage.v2.Storage", "GetServiceAccount"),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new HMAC key for the given service account.
         pub async fn create_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateHmacKeyRequest>,
-        ) -> Result<tonic::Response<super::CreateHmacKeyResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::CreateHmacKeyResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2819,13 +2967,16 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/CreateHmacKey",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "CreateHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a given HMAC key.  Key must be in an INACTIVE state.
         pub async fn delete_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteHmacKeyRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -2839,13 +2990,19 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/DeleteHmacKey",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "DeleteHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets an existing HMAC key metadata for the given id.
         pub async fn get_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::GetHmacKeyRequest>,
-        ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::HmacKeyMetadata>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2859,13 +3016,19 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/GetHmacKey",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists HMAC keys under a given project with the additional filters provided.
         pub async fn list_hmac_keys(
             &mut self,
             request: impl tonic::IntoRequest<super::ListHmacKeysRequest>,
-        ) -> Result<tonic::Response<super::ListHmacKeysResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ListHmacKeysResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2879,13 +3042,19 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/ListHmacKeys",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ListHmacKeys"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates a given HMAC key state between ACTIVE and INACTIVE.
         pub async fn update_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateHmacKeyRequest>,
-        ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::HmacKeyMetadata>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2899,7 +3068,10 @@ pub mod storage_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.storage.v2.Storage/UpdateHmacKey",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "UpdateHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/google.iam.v1.rs
+++ b/googleapis/src/google.iam.v1.rs
@@ -587,7 +587,7 @@ pub mod iam_policy_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -636,6 +636,22 @@ pub mod iam_policy_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Sets the access control policy on the specified resource. Replaces any
         /// existing policy.
         ///
@@ -643,13 +659,16 @@ pub mod iam_policy_client {
         pub async fn set_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Policy>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/SetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.iam.v1.IAMPolicy", "SetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the access control policy for a resource.
         /// Returns an empty policy if the resource exists and does not have a policy
@@ -657,13 +676,16 @@ pub mod iam_policy_client {
         pub async fn get_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Policy>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/GetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.iam.v1.IAMPolicy", "GetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Returns permissions that a caller has on the specified resource.
         /// If the resource does not exist, this will return an empty set of
@@ -675,13 +697,16 @@ pub mod iam_policy_client {
         pub async fn test_iam_permissions(
             &mut self,
             request: impl tonic::IntoRequest<super::TestIamPermissionsRequest>,
-        ) -> Result<tonic::Response<super::TestIamPermissionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::TestIamPermissionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.iam.v1.IAMPolicy/TestIamPermissions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.iam.v1.IAMPolicy", "TestIamPermissions"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/google.longrunning.rs
+++ b/googleapis/src/google.longrunning.rs
@@ -169,7 +169,7 @@ pub mod operations_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -218,6 +218,22 @@ pub mod operations_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Lists operations that match the specified filter in the request. If the
         /// server doesn't support this method, it returns `UNIMPLEMENTED`.
         ///
@@ -231,13 +247,16 @@ pub mod operations_client {
         pub async fn list_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListOperationsRequest>,
-        ) -> Result<tonic::Response<super::ListOperationsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListOperationsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/ListOperations");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.longrunning.Operations", "ListOperations"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the latest state of a long-running operation.  Clients can use this
         /// method to poll the operation result at intervals as recommended by the API
@@ -245,13 +264,16 @@ pub mod operations_client {
         pub async fn get_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::GetOperationRequest>,
-        ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/GetOperation");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.longrunning.Operations", "GetOperation"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a long-running operation. This method indicates that the client is
         /// no longer interested in the operation result. It does not cancel the
@@ -260,13 +282,16 @@ pub mod operations_client {
         pub async fn delete_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteOperationRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/DeleteOperation");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.longrunning.Operations", "DeleteOperation"));
+            self.inner.unary(req, path, codec).await
         }
         /// Starts asynchronous cancellation on a long-running operation.  The server
         /// makes a best effort to cancel the operation, but success is not
@@ -281,13 +306,16 @@ pub mod operations_client {
         pub async fn cancel_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelOperationRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/CancelOperation");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.longrunning.Operations", "CancelOperation"));
+            self.inner.unary(req, path, codec).await
         }
         /// Waits until the specified long-running operation is done or reaches at most
         /// a specified timeout, returning the latest state.  If the operation is
@@ -301,13 +329,16 @@ pub mod operations_client {
         pub async fn wait_operation(
             &mut self,
             request: impl tonic::IntoRequest<super::WaitOperationRequest>,
-        ) -> Result<tonic::Response<super::Operation>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Operation>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.longrunning.Operations/WaitOperation");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.longrunning.Operations", "WaitOperation"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/google.pubsub.v1.rs
+++ b/googleapis/src/google.pubsub.v1.rs
@@ -347,7 +347,7 @@ pub mod schema_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -396,125 +396,171 @@ pub mod schema_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates a schema.
         pub async fn create_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/CreateSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "CreateSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets a schema.
         pub async fn get_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/GetSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "GetSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists schemas in a project.
         pub async fn list_schemas(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSchemasRequest>,
-        ) -> Result<tonic::Response<super::ListSchemasResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSchemasResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ListSchemas");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ListSchemas"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists all schema revisions for the named schema.
         pub async fn list_schema_revisions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSchemaRevisionsRequest>,
-        ) -> Result<tonic::Response<super::ListSchemaRevisionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSchemaRevisionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ListSchemaRevisions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ListSchemaRevisions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Commits a new schema revision to an existing schema.
         pub async fn commit_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::CommitSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/CommitSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "CommitSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new schema revision that is a copy of the provided revision_id.
         pub async fn rollback_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::RollbackSchemaRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/RollbackSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "RollbackSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a specific schema revision.
         pub async fn delete_schema_revision(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSchemaRevisionRequest>,
-        ) -> Result<tonic::Response<super::Schema>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Schema>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/DeleteSchemaRevision");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "DeleteSchemaRevision"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a schema.
         pub async fn delete_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSchemaRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/DeleteSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "DeleteSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Validates a schema.
         pub async fn validate_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateSchemaRequest>,
-        ) -> Result<tonic::Response<super::ValidateSchemaResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ValidateSchemaResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateSchema");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ValidateSchema"));
+            self.inner.unary(req, path, codec).await
         }
         /// Validates a message against a schema.
         pub async fn validate_message(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateMessageRequest>,
-        ) -> Result<tonic::Response<super::ValidateMessageResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ValidateMessageResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.SchemaService/ValidateMessage");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.SchemaService", "ValidateMessage"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1705,7 +1751,7 @@ pub mod publisher_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1754,80 +1800,114 @@ pub mod publisher_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates the given topic with the given name. See the [resource name rules]
         /// (https://cloud.google.com/pubsub/docs/admin#resource_names).
         pub async fn create_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::Topic>,
-        ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Topic>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/CreateTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "CreateTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an existing topic. Note that certain properties of a
         /// topic are not modifiable.
         pub async fn update_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateTopicRequest>,
-        ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Topic>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/UpdateTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "UpdateTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
         /// does not exist.
         pub async fn publish(
             &mut self,
             request: impl tonic::IntoRequest<super::PublishRequest>,
-        ) -> Result<tonic::Response<super::PublishResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::PublishResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/Publish");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "Publish"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the configuration of a topic.
         pub async fn get_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTopicRequest>,
-        ) -> Result<tonic::Response<super::Topic>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Topic>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/GetTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "GetTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists matching topics.
         pub async fn list_topics(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicsRequest>,
-        ) -> Result<tonic::Response<super::ListTopicsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListTopicsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopics");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "ListTopics"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the names of the attached subscriptions on this topic.
         pub async fn list_topic_subscriptions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSubscriptionsRequest>,
-        ) -> Result<tonic::Response<super::ListTopicSubscriptionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListTopicSubscriptionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSubscriptions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "ListTopicSubscriptions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the names of the snapshots on this topic. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -1837,13 +1917,16 @@ pub mod publisher_client {
         pub async fn list_topic_snapshots(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::ListTopicSnapshotsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListTopicSnapshotsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/ListTopicSnapshots");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "ListTopicSnapshots"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
         /// does not exist. After a topic is deleted, a new topic may be created with
@@ -1853,13 +1936,16 @@ pub mod publisher_client {
         pub async fn delete_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteTopicRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DeleteTopic");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "DeleteTopic"));
+            self.inner.unary(req, path, codec).await
         }
         /// Detaches a subscription from this topic. All messages retained in the
         /// subscription are dropped. Subsequent `Pull` and `StreamingPull` requests
@@ -1868,13 +1954,16 @@ pub mod publisher_client {
         pub async fn detach_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::DetachSubscriptionRequest>,
-        ) -> Result<tonic::Response<super::DetachSubscriptionResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::DetachSubscriptionResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Publisher/DetachSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Publisher", "DetachSubscription"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1894,7 +1983,7 @@ pub mod subscriber_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1943,6 +2032,22 @@ pub mod subscriber_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates a subscription to a given topic. See the [resource name rules]
         /// (https://cloud.google.com/pubsub/docs/admin#resource_names).
         /// If the subscription already exists, returns `ALREADY_EXISTS`.
@@ -1957,50 +2062,62 @@ pub mod subscriber_client {
         pub async fn create_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::Subscription>,
-        ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Subscription>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "CreateSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the configuration details of a subscription.
         pub async fn get_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSubscriptionRequest>,
-        ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Subscription>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "GetSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an existing subscription. Note that certain properties of a
         /// subscription, such as its topic, are not modifiable.
         pub async fn update_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSubscriptionRequest>,
-        ) -> Result<tonic::Response<super::Subscription>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Subscription>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "UpdateSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists matching subscriptions.
         pub async fn list_subscriptions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSubscriptionsRequest>,
-        ) -> Result<tonic::Response<super::ListSubscriptionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSubscriptionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSubscriptions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ListSubscriptions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes an existing subscription. All messages retained in the subscription
         /// are immediately dropped. Calls to `Pull` after deletion will return
@@ -2010,13 +2127,16 @@ pub mod subscriber_client {
         pub async fn delete_subscription(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSubscriptionRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSubscription");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "DeleteSubscription"));
+            self.inner.unary(req, path, codec).await
         }
         /// Modifies the ack deadline for a specific message. This method is useful
         /// to indicate that more time is needed to process a message by the
@@ -2026,13 +2146,16 @@ pub mod subscriber_client {
         pub async fn modify_ack_deadline(
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyAckDeadlineRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyAckDeadline");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ModifyAckDeadline"));
+            self.inner.unary(req, path, codec).await
         }
         /// Acknowledges the messages associated with the `ack_ids` in the
         /// `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
@@ -2044,25 +2167,31 @@ pub mod subscriber_client {
         pub async fn acknowledge(
             &mut self,
             request: impl tonic::IntoRequest<super::AcknowledgeRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Acknowledge");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "Acknowledge"));
+            self.inner.unary(req, path, codec).await
         }
         /// Pulls messages from the server.
         pub async fn pull(
             &mut self,
             request: impl tonic::IntoRequest<super::PullRequest>,
-        ) -> Result<tonic::Response<super::PullResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::PullResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Pull");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "Pull"));
+            self.inner.unary(req, path, codec).await
         }
         /// Establishes a stream with the server, which sends messages down to the
         /// client. The client streams acknowledgements and ack deadline modifications
@@ -2074,15 +2203,17 @@ pub mod subscriber_client {
         pub async fn streaming_pull(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::StreamingPullRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<super::StreamingPullResponse>>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/StreamingPull");
-            self.inner
-                .streaming(request.into_streaming_request(), path, codec)
-                .await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "StreamingPull"));
+            self.inner.streaming(req, path, codec).await
         }
         /// Modifies the `PushConfig` for a specified subscription.
         ///
@@ -2093,13 +2224,16 @@ pub mod subscriber_client {
         pub async fn modify_push_config(
             &mut self,
             request: impl tonic::IntoRequest<super::ModifyPushConfigRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ModifyPushConfig");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ModifyPushConfig"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the configuration details of a snapshot. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -2109,13 +2243,16 @@ pub mod subscriber_client {
         pub async fn get_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSnapshotRequest>,
-        ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Snapshot>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/GetSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "GetSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the existing snapshots. Snapshots are used in [Seek](
         /// https://cloud.google.com/pubsub/docs/replay-overview) operations, which
@@ -2125,13 +2262,16 @@ pub mod subscriber_client {
         pub async fn list_snapshots(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSnapshotsRequest>,
-        ) -> Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSnapshotsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/ListSnapshots");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "ListSnapshots"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a snapshot from the requested subscription. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -2152,13 +2292,16 @@ pub mod subscriber_client {
         pub async fn create_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSnapshotRequest>,
-        ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Snapshot>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/CreateSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "CreateSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an existing snapshot. Snapshots are used in
         /// [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -2168,13 +2311,16 @@ pub mod subscriber_client {
         pub async fn update_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateSnapshotRequest>,
-        ) -> Result<tonic::Response<super::Snapshot>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Snapshot>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/UpdateSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "UpdateSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Removes an existing snapshot. Snapshots are used in [Seek]
         /// (https://cloud.google.com/pubsub/docs/replay-overview) operations, which
@@ -2188,13 +2334,16 @@ pub mod subscriber_client {
         pub async fn delete_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSnapshotRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/DeleteSnapshot");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "DeleteSnapshot"));
+            self.inner.unary(req, path, codec).await
         }
         /// Seeks an existing subscription to a point in time or to a given snapshot,
         /// whichever is provided in the request. Snapshots are used in [Seek]
@@ -2206,13 +2355,16 @@ pub mod subscriber_client {
         pub async fn seek(
             &mut self,
             request: impl tonic::IntoRequest<super::SeekRequest>,
-        ) -> Result<tonic::Response<super::SeekResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::SeekResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.pubsub.v1.Subscriber/Seek");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.pubsub.v1.Subscriber", "Seek"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/google.spanner.admin.database.v1.rs
+++ b/googleapis/src/google.spanner.admin.database.v1.rs
@@ -1391,7 +1391,7 @@ pub mod database_admin_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1440,18 +1440,39 @@ pub mod database_admin_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Lists Cloud Spanner databases.
         pub async fn list_databases(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabasesRequest>,
-        ) -> Result<tonic::Response<super::ListDatabasesResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListDatabasesResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabases");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "ListDatabases",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new Cloud Spanner database and starts to prepare it for serving.
         /// The returned [long-running operation][google.longrunning.Operation] will
@@ -1464,27 +1485,38 @@ pub mod database_admin_client {
         pub async fn create_database(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateDatabaseRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CreateDatabase");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "CreateDatabase",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the state of a Cloud Spanner database.
         pub async fn get_database(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseRequest>,
-        ) -> Result<tonic::Response<super::Database>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Database>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabase");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.admin.database.v1.DatabaseAdmin", "GetDatabase"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates the schema of a Cloud Spanner database by
         /// creating/altering/dropping tables, columns, indexes, etc. The returned
@@ -1496,7 +1528,10 @@ pub mod database_admin_client {
         pub async fn update_database_ddl(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateDatabaseDdlRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -1504,7 +1539,12 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/UpdateDatabaseDdl",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "UpdateDatabaseDdl",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Drops (aka deletes) a Cloud Spanner database.
         /// Completed backups for the database will be retained according to their
@@ -1514,14 +1554,19 @@ pub mod database_admin_client {
         pub async fn drop_database(
             &mut self,
             request: impl tonic::IntoRequest<super::DropDatabaseRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/DropDatabase");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "DropDatabase",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Returns the schema of a Cloud Spanner database as a list of formatted
         /// DDL statements. This method does not show pending schema updates, those may
@@ -1529,14 +1574,19 @@ pub mod database_admin_client {
         pub async fn get_database_ddl(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatabaseDdlRequest>,
-        ) -> Result<tonic::Response<super::GetDatabaseDdlResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::GetDatabaseDdlResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetDatabaseDdl");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "GetDatabaseDdl",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Sets the access control policy on a database or backup resource.
         /// Replaces any existing policy.
@@ -1548,14 +1598,20 @@ pub mod database_admin_client {
         pub async fn set_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/SetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "SetIamPolicy",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the access control policy for a database or backup resource.
         /// Returns an empty policy if a database or backup exists but does not have a
@@ -1568,14 +1624,20 @@ pub mod database_admin_client {
         pub async fn get_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "GetIamPolicy",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Returns permissions that the caller has on the specified database or backup
         /// resource.
@@ -1590,7 +1652,7 @@ pub mod database_admin_client {
         pub async fn test_iam_permissions(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::TestIamPermissionsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::iam::v1::TestIamPermissionsResponse>,
             tonic::Status,
         > {
@@ -1601,7 +1663,12 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/TestIamPermissions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "TestIamPermissions",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Starts creating a new Cloud Spanner Backup.
         /// The returned backup [long-running operation][google.longrunning.Operation]
@@ -1618,14 +1685,22 @@ pub mod database_admin_client {
         pub async fn create_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBackupRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CreateBackup");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "CreateBackup",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Starts copying a Cloud Spanner Backup.
         /// The returned backup [long-running operation][google.longrunning.Operation]
@@ -1642,53 +1717,72 @@ pub mod database_admin_client {
         pub async fn copy_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::CopyBackupRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/CopyBackup");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.admin.database.v1.DatabaseAdmin", "CopyBackup"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets metadata on a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
         pub async fn get_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::GetBackupRequest>,
-        ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Backup>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/GetBackup");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.admin.database.v1.DatabaseAdmin", "GetBackup"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
         pub async fn update_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBackupRequest>,
-        ) -> Result<tonic::Response<super::Backup>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Backup>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/UpdateBackup");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "UpdateBackup",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a pending or completed [Backup][google.spanner.admin.database.v1.Backup].
         pub async fn delete_backup(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBackupRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/DeleteBackup");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "DeleteBackup",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists completed and pending backups.
         /// Backups returned are ordered by `create_time` in descending order,
@@ -1696,14 +1790,17 @@ pub mod database_admin_client {
         pub async fn list_backups(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupsRequest>,
-        ) -> Result<tonic::Response<super::ListBackupsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListBackupsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/ListBackups");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.admin.database.v1.DatabaseAdmin", "ListBackups"));
+            self.inner.unary(req, path, codec).await
         }
         /// Create a new database by restoring from a completed backup. The new
         /// database must be in the same project and in an instance with the same
@@ -1725,14 +1822,22 @@ pub mod database_admin_client {
         pub async fn restore_database(
             &mut self,
             request: impl tonic::IntoRequest<super::RestoreDatabaseRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.database.v1.DatabaseAdmin/RestoreDatabase");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "RestoreDatabase",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists database [longrunning-operations][google.longrunning.Operation].
         /// A database operation has a name of the form
@@ -1745,7 +1850,7 @@ pub mod database_admin_client {
         pub async fn list_database_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseOperationsRequest>,
-        ) -> Result<tonic::Response<super::ListDatabaseOperationsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListDatabaseOperationsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -1753,7 +1858,12 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseOperations",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "ListDatabaseOperations",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the backup [long-running operations][google.longrunning.Operation] in
         /// the given instance. A backup operation has a name of the form
@@ -1768,7 +1878,7 @@ pub mod database_admin_client {
         pub async fn list_backup_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBackupOperationsRequest>,
-        ) -> Result<tonic::Response<super::ListBackupOperationsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListBackupOperationsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -1776,13 +1886,18 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListBackupOperations",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "ListBackupOperations",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists Cloud Spanner database roles.
         pub async fn list_database_roles(
             &mut self,
             request: impl tonic::IntoRequest<super::ListDatabaseRolesRequest>,
-        ) -> Result<tonic::Response<super::ListDatabaseRolesResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListDatabaseRolesResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -1790,7 +1905,12 @@ pub mod database_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.database.v1.DatabaseAdmin/ListDatabaseRoles",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.database.v1.DatabaseAdmin",
+                "ListDatabaseRoles",
+            ));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/google.spanner.admin.instance.v1.rs
+++ b/googleapis/src/google.spanner.admin.instance.v1.rs
@@ -793,7 +793,7 @@ pub mod instance_admin_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -842,11 +842,27 @@ pub mod instance_admin_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Lists the supported instance configurations for a given project.
         pub async fn list_instance_configs(
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstanceConfigsRequest>,
-        ) -> Result<tonic::Response<super::ListInstanceConfigsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListInstanceConfigsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -854,13 +870,18 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigs",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "ListInstanceConfigs",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets information about a particular instance configuration.
         pub async fn get_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceConfigRequest>,
-        ) -> Result<tonic::Response<super::InstanceConfig>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::InstanceConfig>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -868,7 +889,12 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/GetInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "GetInstanceConfig",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates an instance config and begins preparing it to be used. The
         /// returned [long-running operation][google.longrunning.Operation]
@@ -914,7 +940,10 @@ pub mod instance_admin_client {
         pub async fn create_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateInstanceConfigRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -922,7 +951,12 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "CreateInstanceConfig",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an instance config. The returned
         /// [long-running operation][google.longrunning.Operation] can be used to track
@@ -971,7 +1005,10 @@ pub mod instance_admin_client {
         pub async fn update_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateInstanceConfigRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -979,7 +1016,12 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "UpdateInstanceConfig",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes the instance config. Deletion is only allowed when no
         /// instances are using the configuration. If any instances are using
@@ -992,7 +1034,7 @@ pub mod instance_admin_client {
         pub async fn delete_instance_config(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteInstanceConfigRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -1000,7 +1042,12 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstanceConfig",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "DeleteInstanceConfig",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists the user-managed instance config [long-running
         /// operations][google.longrunning.Operation] in the given project. An instance
@@ -1016,7 +1063,7 @@ pub mod instance_admin_client {
         pub async fn list_instance_config_operations(
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstanceConfigOperationsRequest>,
-        ) -> Result<tonic::Response<super::ListInstanceConfigOperationsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListInstanceConfigOperationsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
@@ -1024,33 +1071,46 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/ListInstanceConfigOperations",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "ListInstanceConfigOperations",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists all instances in the given project.
         pub async fn list_instances(
             &mut self,
             request: impl tonic::IntoRequest<super::ListInstancesRequest>,
-        ) -> Result<tonic::Response<super::ListInstancesResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListInstancesResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/ListInstances");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "ListInstances",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets information about a particular instance.
         pub async fn get_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::GetInstanceRequest>,
-        ) -> Result<tonic::Response<super::Instance>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Instance>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/GetInstance");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.admin.instance.v1.InstanceAdmin", "GetInstance"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates an instance and begins preparing it to begin serving. The
         /// returned [long-running operation][google.longrunning.Operation]
@@ -1089,14 +1149,22 @@ pub mod instance_admin_client {
         pub async fn create_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateInstanceRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/CreateInstance");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "CreateInstance",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an instance, and begins allocating or releasing resources
         /// as requested. The returned [long-running
@@ -1141,14 +1209,22 @@ pub mod instance_admin_client {
         pub async fn update_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateInstanceRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::longrunning::Operation>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::super::super::longrunning::Operation>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/UpdateInstance");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "UpdateInstance",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes an instance.
         ///
@@ -1164,14 +1240,19 @@ pub mod instance_admin_client {
         pub async fn delete_instance(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteInstanceRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/DeleteInstance");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "DeleteInstance",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Sets the access control policy on an instance resource. Replaces any
         /// existing policy.
@@ -1181,14 +1262,20 @@ pub mod instance_admin_client {
         pub async fn set_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/SetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "SetIamPolicy",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the access control policy for an instance resource. Returns an empty
         /// policy if an instance exists but does not have a policy set.
@@ -1198,14 +1285,20 @@ pub mod instance_admin_client {
         pub async fn get_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::super::super::super::super::iam::v1::Policy>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path =
                 http::uri::PathAndQuery::from_static("/google.spanner.admin.instance.v1.InstanceAdmin/GetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "GetIamPolicy",
+            ));
+            self.inner.unary(req, path, codec).await
         }
         /// Returns permissions that the caller has on the specified instance resource.
         ///
@@ -1216,7 +1309,7 @@ pub mod instance_admin_client {
         pub async fn test_iam_permissions(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::super::super::iam::v1::TestIamPermissionsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::super::super::super::super::iam::v1::TestIamPermissionsResponse>,
             tonic::Status,
         > {
@@ -1227,7 +1320,12 @@ pub mod instance_admin_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/google.spanner.admin.instance.v1.InstanceAdmin/TestIamPermissions",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "google.spanner.admin.instance.v1.InstanceAdmin",
+                "TestIamPermissions",
+            ));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/google.spanner.v1.rs
+++ b/googleapis/src/google.spanner.v1.rs
@@ -2175,7 +2175,7 @@ pub mod spanner_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -2224,6 +2224,22 @@ pub mod spanner_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Creates a new session. A session can be used to perform
         /// transactions that read and/or modify data in a Cloud Spanner database.
         /// Sessions are meant to be reused for many consecutive
@@ -2246,13 +2262,16 @@ pub mod spanner_client {
         pub async fn create_session(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateSessionRequest>,
-        ) -> Result<tonic::Response<super::Session>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Session>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/CreateSession");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "CreateSession"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates multiple new sessions.
         ///
@@ -2261,13 +2280,16 @@ pub mod spanner_client {
         pub async fn batch_create_sessions(
             &mut self,
             request: impl tonic::IntoRequest<super::BatchCreateSessionsRequest>,
-        ) -> Result<tonic::Response<super::BatchCreateSessionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::BatchCreateSessionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/BatchCreateSessions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "BatchCreateSessions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets a session. Returns `NOT_FOUND` if the session does not exist.
         /// This is mainly useful for determining whether a session is still
@@ -2275,25 +2297,31 @@ pub mod spanner_client {
         pub async fn get_session(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSessionRequest>,
-        ) -> Result<tonic::Response<super::Session>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Session>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/GetSession");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "GetSession"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists all sessions in a given database.
         pub async fn list_sessions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSessionsRequest>,
-        ) -> Result<tonic::Response<super::ListSessionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListSessionsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ListSessions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "ListSessions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Ends a session, releasing server resources associated with it. This will
         /// asynchronously trigger cancellation of any operations that are running with
@@ -2301,13 +2329,16 @@ pub mod spanner_client {
         pub async fn delete_session(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteSessionRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/DeleteSession");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "DeleteSession"));
+            self.inner.unary(req, path, codec).await
         }
         /// Executes an SQL statement, returning all results in a single reply. This
         /// method cannot be used to return a result set larger than 10 MiB;
@@ -2323,13 +2354,16 @@ pub mod spanner_client {
         pub async fn execute_sql(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
-        ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ResultSet>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteSql");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "ExecuteSql"));
+            self.inner.unary(req, path, codec).await
         }
         /// Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the result
         /// set as a stream. Unlike [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], there
@@ -2339,13 +2373,17 @@ pub mod spanner_client {
         pub async fn execute_streaming_sql(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteSqlRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteStreamingSql");
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "ExecuteStreamingSql"));
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Executes a batch of SQL DML statements. This method allows many statements
         /// to be run with lower latency than submitting them sequentially with
@@ -2361,13 +2399,16 @@ pub mod spanner_client {
         pub async fn execute_batch_dml(
             &mut self,
             request: impl tonic::IntoRequest<super::ExecuteBatchDmlRequest>,
-        ) -> Result<tonic::Response<super::ExecuteBatchDmlResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ExecuteBatchDmlResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/ExecuteBatchDml");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "ExecuteBatchDml"));
+            self.inner.unary(req, path, codec).await
         }
         /// Reads rows from the database using key lookups and scans, as a
         /// simple key/value style alternative to
@@ -2385,13 +2426,16 @@ pub mod spanner_client {
         pub async fn read(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
-        ) -> Result<tonic::Response<super::ResultSet>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ResultSet>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Read");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "Read"));
+            self.inner.unary(req, path, codec).await
         }
         /// Like [Read][google.spanner.v1.Spanner.Read], except returns the result set as a
         /// stream. Unlike [Read][google.spanner.v1.Spanner.Read], there is no limit on the
@@ -2401,13 +2445,17 @@ pub mod spanner_client {
         pub async fn streaming_read(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<super::PartialResultSet>>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/StreamingRead");
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "StreamingRead"));
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Begins a new transaction. This step can often be skipped:
         /// [Read][google.spanner.v1.Spanner.Read], [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql] and
@@ -2416,13 +2464,16 @@ pub mod spanner_client {
         pub async fn begin_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::BeginTransactionRequest>,
-        ) -> Result<tonic::Response<super::Transaction>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Transaction>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/BeginTransaction");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "BeginTransaction"));
+            self.inner.unary(req, path, codec).await
         }
         /// Commits a transaction. The request includes the mutations to be
         /// applied to rows in the database.
@@ -2441,13 +2492,16 @@ pub mod spanner_client {
         pub async fn commit(
             &mut self,
             request: impl tonic::IntoRequest<super::CommitRequest>,
-        ) -> Result<tonic::Response<super::CommitResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::CommitResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Commit");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "Commit"));
+            self.inner.unary(req, path, codec).await
         }
         /// Rolls back a transaction, releasing any locks it holds. It is a good
         /// idea to call this for any transaction that includes one or more
@@ -2460,13 +2514,16 @@ pub mod spanner_client {
         pub async fn rollback(
             &mut self,
             request: impl tonic::IntoRequest<super::RollbackRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/Rollback");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "Rollback"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a query
         /// operation in parallel.  Each of the returned partition tokens can be used
@@ -2482,13 +2539,16 @@ pub mod spanner_client {
         pub async fn partition_query(
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionQueryRequest>,
-        ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/PartitionQuery");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "PartitionQuery"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a set of partition tokens that can be used to execute a read
         /// operation in parallel.  Each of the returned partition tokens can be used
@@ -2506,13 +2566,16 @@ pub mod spanner_client {
         pub async fn partition_read(
             &mut self,
             request: impl tonic::IntoRequest<super::PartitionReadRequest>,
-        ) -> Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::PartitionResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.spanner.v1.Spanner/PartitionRead");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.spanner.v1.Spanner", "PartitionRead"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/googleapis/src/google.storage.v2.rs
+++ b/googleapis/src/google.storage.v2.rs
@@ -2056,7 +2056,7 @@ pub mod storage_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -2105,65 +2105,96 @@ pub mod storage_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Permanently deletes an empty bucket.
         pub async fn delete_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteBucketRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteBucket");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "DeleteBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Returns metadata for the specified bucket.
         pub async fn get_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::GetBucketRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetBucket");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new bucket.
         pub async fn create_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateBucketRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateBucket");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "CreateBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves a list of buckets for a given project.
         pub async fn list_buckets(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBucketsRequest>,
-        ) -> Result<tonic::Response<super::ListBucketsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListBucketsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListBuckets");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ListBuckets"));
+            self.inner.unary(req, path, codec).await
         }
         /// Locks retention policy on a bucket.
         pub async fn lock_bucket_retention_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::LockBucketRetentionPolicyRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/LockBucketRetentionPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "LockBucketRetentionPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets the IAM policy for a specified bucket or object.
         /// The `resource` field in the request should be
@@ -2172,13 +2203,16 @@ pub mod storage_client {
         pub async fn get_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::iam::v1::GetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates an IAM policy for the specified bucket or object.
         /// The `resource` field in the request should be
@@ -2187,13 +2221,16 @@ pub mod storage_client {
         pub async fn set_iam_policy(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::iam::v1::SetIamPolicyRequest>,
-        ) -> Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::super::super::iam::v1::Policy>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/SetIamPolicy");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "SetIamPolicy"));
+            self.inner.unary(req, path, codec).await
         }
         /// Tests a set of permissions on the given bucket or object to see which, if
         /// any, are held by the caller.
@@ -2203,49 +2240,62 @@ pub mod storage_client {
         pub async fn test_iam_permissions(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::iam::v1::TestIamPermissionsRequest>,
-        ) -> Result<tonic::Response<super::super::super::iam::v1::TestIamPermissionsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::super::super::iam::v1::TestIamPermissionsResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/TestIamPermissions");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "TestIamPermissions"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates a bucket. Equivalent to JSON API's storage.buckets.patch method.
         pub async fn update_bucket(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateBucketRequest>,
-        ) -> Result<tonic::Response<super::Bucket>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Bucket>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateBucket");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "UpdateBucket"));
+            self.inner.unary(req, path, codec).await
         }
         /// Permanently deletes a NotificationConfig.
         pub async fn delete_notification_config(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteNotificationConfigRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteNotificationConfig");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "DeleteNotificationConfig"));
+            self.inner.unary(req, path, codec).await
         }
         /// View a NotificationConfig.
         pub async fn get_notification_config(
             &mut self,
             request: impl tonic::IntoRequest<super::GetNotificationConfigRequest>,
-        ) -> Result<tonic::Response<super::NotificationConfig>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::NotificationConfig>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetNotificationConfig");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetNotificationConfig"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a NotificationConfig for a given bucket.
         /// These NotificationConfigs, when triggered, publish messages to the
@@ -2254,38 +2304,47 @@ pub mod storage_client {
         pub async fn create_notification_config(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateNotificationConfigRequest>,
-        ) -> Result<tonic::Response<super::NotificationConfig>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::NotificationConfig>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateNotificationConfig");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "CreateNotificationConfig"));
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves a list of NotificationConfigs for a given bucket.
         pub async fn list_notification_configs(
             &mut self,
             request: impl tonic::IntoRequest<super::ListNotificationConfigsRequest>,
-        ) -> Result<tonic::Response<super::ListNotificationConfigsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListNotificationConfigsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListNotificationConfigs");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ListNotificationConfigs"));
+            self.inner.unary(req, path, codec).await
         }
         /// Concatenates a list of existing objects into a new object in the same
         /// bucket.
         pub async fn compose_object(
             &mut self,
             request: impl tonic::IntoRequest<super::ComposeObjectRequest>,
-        ) -> Result<tonic::Response<super::Object>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Object>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ComposeObject");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ComposeObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes an object and its metadata.
         ///
@@ -2296,13 +2355,16 @@ pub mod storage_client {
         pub async fn delete_object(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteObjectRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteObject");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "DeleteObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Cancels an in-progress resumable upload.
         ///
@@ -2315,50 +2377,63 @@ pub mod storage_client {
         pub async fn cancel_resumable_write(
             &mut self,
             request: impl tonic::IntoRequest<super::CancelResumableWriteRequest>,
-        ) -> Result<tonic::Response<super::CancelResumableWriteResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::CancelResumableWriteResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CancelResumableWrite");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "CancelResumableWrite"));
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves an object's metadata.
         pub async fn get_object(
             &mut self,
             request: impl tonic::IntoRequest<super::GetObjectRequest>,
-        ) -> Result<tonic::Response<super::Object>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Object>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetObject");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Reads an object's data.
         pub async fn read_object(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadObjectRequest>,
-        ) -> Result<tonic::Response<tonic::codec::Streaming<super::ReadObjectResponse>>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<tonic::codec::Streaming<super::ReadObjectResponse>>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ReadObject");
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ReadObject"));
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Updates an object's metadata.
         /// Equivalent to JSON API's storage.objects.patch.
         pub async fn update_object(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateObjectRequest>,
-        ) -> Result<tonic::Response<super::Object>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::Object>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateObject");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "UpdateObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Stores a new object and metadata.
         ///
@@ -2416,40 +2491,47 @@ pub mod storage_client {
         pub async fn write_object(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::WriteObjectRequest>,
-        ) -> Result<tonic::Response<super::WriteObjectResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::WriteObjectResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/WriteObject");
-            self.inner
-                .client_streaming(request.into_streaming_request(), path, codec)
-                .await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "WriteObject"));
+            self.inner.client_streaming(req, path, codec).await
         }
         /// Retrieves a list of objects matching the criteria.
         pub async fn list_objects(
             &mut self,
             request: impl tonic::IntoRequest<super::ListObjectsRequest>,
-        ) -> Result<tonic::Response<super::ListObjectsResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListObjectsResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListObjects");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ListObjects"));
+            self.inner.unary(req, path, codec).await
         }
         /// Rewrites a source object to a destination object. Optionally overrides
         /// metadata.
         pub async fn rewrite_object(
             &mut self,
             request: impl tonic::IntoRequest<super::RewriteObjectRequest>,
-        ) -> Result<tonic::Response<super::RewriteResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::RewriteResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/RewriteObject");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "RewriteObject"));
+            self.inner.unary(req, path, codec).await
         }
         /// Starts a resumable write. How long the write operation remains valid, and
         /// what happens when the write operation becomes invalid, are
@@ -2457,13 +2539,16 @@ pub mod storage_client {
         pub async fn start_resumable_write(
             &mut self,
             request: impl tonic::IntoRequest<super::StartResumableWriteRequest>,
-        ) -> Result<tonic::Response<super::StartResumableWriteResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::StartResumableWriteResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/StartResumableWrite");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "StartResumableWrite"));
+            self.inner.unary(req, path, codec).await
         }
         /// Determines the `persisted_size` for an object that is being written, which
         /// can then be used as the `write_offset` for the next `Write()` call.
@@ -2481,85 +2566,106 @@ pub mod storage_client {
         pub async fn query_write_status(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryWriteStatusRequest>,
-        ) -> Result<tonic::Response<super::QueryWriteStatusResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::QueryWriteStatusResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/QueryWriteStatus");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "QueryWriteStatus"));
+            self.inner.unary(req, path, codec).await
         }
         /// Retrieves the name of a project's Google Cloud Storage service account.
         pub async fn get_service_account(
             &mut self,
             request: impl tonic::IntoRequest<super::GetServiceAccountRequest>,
-        ) -> Result<tonic::Response<super::ServiceAccount>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ServiceAccount>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetServiceAccount");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetServiceAccount"));
+            self.inner.unary(req, path, codec).await
         }
         /// Creates a new HMAC key for the given service account.
         pub async fn create_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateHmacKeyRequest>,
-        ) -> Result<tonic::Response<super::CreateHmacKeyResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::CreateHmacKeyResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateHmacKey");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "CreateHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
         /// Deletes a given HMAC key.  Key must be in an INACTIVE state.
         pub async fn delete_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::DeleteHmacKeyRequest>,
-        ) -> Result<tonic::Response<()>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteHmacKey");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "DeleteHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
         /// Gets an existing HMAC key metadata for the given id.
         pub async fn get_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::GetHmacKeyRequest>,
-        ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetHmacKey");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "GetHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
         /// Lists HMAC keys under a given project with the additional filters provided.
         pub async fn list_hmac_keys(
             &mut self,
             request: impl tonic::IntoRequest<super::ListHmacKeysRequest>,
-        ) -> Result<tonic::Response<super::ListHmacKeysResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::ListHmacKeysResponse>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListHmacKeys");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "ListHmacKeys"));
+            self.inner.unary(req, path, codec).await
         }
         /// Updates a given HMAC key state between ACTIVE and INACTIVE.
         pub async fn update_hmac_key(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateHmacKeyRequest>,
-        ) -> Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::HmacKeyMetadata>, tonic::Status> {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateHmacKey");
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("google.storage.v2.Storage", "UpdateHmacKey"));
+            self.inner.unary(req, path, codec).await
         }
     }
 }

--- a/pubsub/src/apiv1/mod.rs
+++ b/pubsub/src/apiv1/mod.rs
@@ -6,6 +6,8 @@ pub mod publisher_client;
 pub mod schema_client;
 pub mod subscriber_client;
 
+const PUBSUB_MESSAGE_LIMIT: usize = 10 * 1024 * 1024; // 10MB
+
 pub fn default_retry_setting() -> RetrySetting {
     let mut setting = RetrySetting::default();
     setting.codes.push(Code::DeadlineExceeded);

--- a/pubsub/src/apiv1/publisher_client.rs
+++ b/pubsub/src/apiv1/publisher_client.rs
@@ -13,6 +13,7 @@ use google_cloud_googleapis::pubsub::v1::{
 };
 
 use crate::apiv1::conn_pool::ConnectionManager;
+use crate::apiv1::PUBSUB_MESSAGE_LIMIT;
 
 #[derive(Clone, Debug)]
 pub(crate) struct PublisherClient {
@@ -29,6 +30,8 @@ impl PublisherClient {
     #[inline]
     fn client(&self) -> InternalPublisherClient<Channel> {
         InternalPublisherClient::new(self.cm.conn())
+            .max_decoding_message_size(PUBSUB_MESSAGE_LIMIT)
+            .max_encoding_message_size(PUBSUB_MESSAGE_LIMIT)
     }
 
     /// create_topic creates the given topic with the given name. See the [resource name rules]

--- a/pubsub/src/apiv1/subscriber_client.rs
+++ b/pubsub/src/apiv1/subscriber_client.rs
@@ -15,6 +15,7 @@ use google_cloud_googleapis::pubsub::v1::{
 };
 
 use crate::apiv1::conn_pool::ConnectionManager;
+use crate::apiv1::PUBSUB_MESSAGE_LIMIT;
 
 pub(crate) fn create_empty_streaming_pull_request() -> StreamingPullRequest {
     StreamingPullRequest {
@@ -44,6 +45,8 @@ impl SubscriberClient {
     #[inline]
     fn client(&self) -> InternalSubscriberClient<Channel> {
         InternalSubscriberClient::new(self.cm.conn())
+            .max_decoding_message_size(PUBSUB_MESSAGE_LIMIT)
+            .max_encoding_message_size(PUBSUB_MESSAGE_LIMIT)
     }
 
     /// create_subscription creates a subscription to a given topic. See the [resource name rules]


### PR DESCRIPTION
Sets the tonic encode/decode message size limit of both the SubscriberClient (InternalSubscriberClient) and PubisherClient (InternalPublisherClient) to 10MB (10,485,760 bytes). This fixes the reproduction of my [issue](https://github.com/yoshidan/google-cloud-rust/issues/151).

I think PubSub is using 10MB = 10,000,00 as their limit, but it's not disadvantageous to use more than the PubSub limit. We never want to be failing to publish/pull messages due to encoding/decoding failure that PubSub could accept. 

Do you think we need to write a test for this? It wouldn't be too hard.