### PR TITLE
Bump auth version

### DIFF
--- a/default/Cargo.toml
+++ b/default/Cargo.toml
@@ -12,7 +12,7 @@ description = "Google Cloud Platform default config."
 [dependencies]
 async-trait = "0.1"
 
-google-cloud-auth = { version = "0.9", path = "../foundation/auth", default-features = false }
+google-cloud-auth = { version = "0.10", path = "../foundation/auth", default-features = false }
 
 # optional
 google-cloud-metadata = { version = "0.3", path = "../foundation/metadata", optional = true }

--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-auth"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/auth"

--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-auth"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/auth"

--- a/foundation/auth/README.md
+++ b/foundation/auth/README.md
@@ -54,7 +54,7 @@ preferring the first location found:
 - [x] [Service Account(JWT)](https://developers.google.com/identity/protocols/oauth2/service-account#jwt-auth)
 - [x] [Service Account(OAuth 2.0)](https://developers.google.com/identity/protocols/oauth2/service-account)
 - [x] [Authorized User](https://cloud.google.com/docs/authentication/end-user)
-- [ ] [External Account](https://cloud.google.com/anthos/clusters/docs/aws/how-to/workload-identity-gcp?hl=ja)
+- [ ] [External Account](https://cloud.google.com/anthos/clusters/docs/aws/how-to/workload-identity-gcp)
 - [ ] Google Developers Console client_credentials.json
 
 ## Supported Workload Identity


### PR DESCRIPTION
Bumps `auth` version.

A new release on [crates.io](https://crates.io/crates/google-cloud-auth) is required to publish the changes of #150.