### PR TITLE
Add option to disable auto resume in RowIterator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,6 +137,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v0.6.0
+        with:
+          service_account_key: ${{ secrets.STORAGE_CREDENTIALS }}
+          export_default_credentials: true
       - uses: actions-rs/cargo@v1
         name: test
         with:

--- a/default/Cargo.toml
+++ b/default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-default"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/auth"
@@ -20,7 +20,7 @@ google-cloud-gax = { version = "0.14", path = "../foundation/gax", optional = tr
 
 # components
 google-cloud-pubsub = { version = "0.15", path = "../pubsub", optional = true }
-google-cloud-spanner = { version = "0.19", path = "../spanner", optional = true }
+google-cloud-spanner = { version = "0.20", path = "../spanner", optional = true }
 google-cloud-storage = { version = "0.11", path = "../storage", default-features=false, optional = true }
 
 [dev-dependencies]

--- a/spanner/Cargo.toml
+++ b/spanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-spanner"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/spanner"
@@ -32,6 +32,7 @@ tokio = { version="1.20", features=["rt-multi-thread"] }
 tracing-subscriber = { version="0.3", features=["env-filter"] }
 serial_test = "0.9"
 ctor = "0.1"
+google-cloud-auth = { path="../foundation/auth", default-features=false, features=["rustls-tls"]}
 
 [features]
 default = ["serde"]

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -59,7 +59,6 @@ impl Reader for StatementReader {
 }
 
 pub struct TableReader {
-    pub enable_resume: bool,
     pub request: ReadRequest,
 }
 
@@ -81,7 +80,7 @@ impl Reader for TableReader {
     }
 
     fn can_resume(&self) -> bool {
-        self.enable_resume && !self.request.resume_token.is_empty()
+        !self.request.resume_token.is_empty()
     }
 }
 

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -28,10 +28,11 @@ pub trait Reader {
 
     fn update_token(&mut self, resume_token: Vec<u8>);
 
-    fn can_retry(&self) -> bool;
+    fn can_resume(&self) -> bool;
 }
 
 pub struct StatementReader {
+    pub enable_resume: bool,
     pub request: ExecuteSqlRequest,
 }
 
@@ -52,12 +53,13 @@ impl Reader for StatementReader {
         self.request.resume_token = resume_token;
     }
 
-    fn can_retry(&self) -> bool {
-        !self.request.resume_token.is_empty()
+    fn can_resume(&self) -> bool {
+        self.enable_resume && !self.request.resume_token.is_empty()
     }
 }
 
 pub struct TableReader {
+    pub enable_resume: bool,
     pub request: ReadRequest,
 }
 
@@ -78,8 +80,8 @@ impl Reader for TableReader {
         self.request.resume_token = resume_token;
     }
 
-    fn can_retry(&self) -> bool {
-        !self.request.resume_token.is_empty()
+    fn can_resume(&self) -> bool {
+        self.enable_resume && !self.request.resume_token.is_empty()
     }
 }
 
@@ -225,7 +227,7 @@ impl<'a> RowIterator<'a> {
         let maybe_result_set = match self.streaming.message().await {
             Ok(s) => s,
             Err(e) => {
-                if !self.reader.can_retry() {
+                if !self.reader.can_resume() {
                     return Err(e);
                 }
                 tracing::debug!("streaming error: {}. resume reading by resume_token", e);
@@ -266,15 +268,16 @@ impl<'a> AsyncIterator for RowIterator<'a> {
     /// next returns the next result.
     /// Its second return value is None if there are no more results.
     async fn next(&mut self) -> Result<Option<Row>, Status> {
-        let row = self.rs.next();
-        if row.is_some() {
-            return Ok(row);
+        loop {
+            let row = self.rs.next();
+            if row.is_some() {
+                return Ok(row);
+            }
+            // no data found or record chunked.
+            if !self.try_recv(self.reader_option.clone()).await? {
+                return Ok(None);
+            }
         }
-        // no data found or record chunked.
-        if !self.try_recv(self.reader_option.clone()).await? {
-            return Ok(None);
-        }
-        return self.next().await;
     }
 }
 

--- a/spanner/src/transaction.rs
+++ b/spanner/src/transaction.rs
@@ -35,6 +35,8 @@ pub struct ReadOptions {
     pub limit: i64,
 
     pub call_options: CallOptions,
+
+    pub enable_resume: bool,
 }
 
 impl Default for ReadOptions {
@@ -43,6 +45,7 @@ impl Default for ReadOptions {
             index: "".to_string(),
             limit: 0,
             call_options: CallOptions::default(),
+            enable_resume: true
         }
     }
 }
@@ -52,6 +55,7 @@ pub struct QueryOptions {
     pub mode: QueryMode,
     pub optimizer_options: Option<ExecuteQueryOptions>,
     pub call_options: CallOptions,
+    pub enable_resume: bool,
 }
 
 impl Default for QueryOptions {
@@ -60,6 +64,7 @@ impl Default for QueryOptions {
             mode: QueryMode::Normal,
             optimizer_options: None,
             call_options: CallOptions::default(),
+            enable_resume: true,
         }
     }
 }
@@ -114,7 +119,10 @@ impl Transaction {
             data_boost_enabled: false,
         };
         let session = self.session.as_mut().unwrap().deref_mut();
-        let reader = Box::new(StatementReader { request });
+        let reader = Box::new(StatementReader {
+            enable_resume: options.enable_resume,
+            request
+        });
         RowIterator::new(session, reader, Some(options.call_options)).await
     }
 
@@ -172,7 +180,10 @@ impl Transaction {
         };
 
         let session = self.as_mut_session();
-        let reader = Box::new(TableReader { request });
+        let reader = Box::new(TableReader {
+            enable_resume: options.enable_resume,
+            request
+        });
         RowIterator::new(session, reader, Some(options.call_options)).await
     }
 

--- a/spanner/src/transaction.rs
+++ b/spanner/src/transaction.rs
@@ -45,7 +45,7 @@ impl Default for ReadOptions {
             index: "".to_string(),
             limit: 0,
             call_options: CallOptions::default(),
-            enable_resume: true
+            enable_resume: true,
         }
     }
 }
@@ -121,7 +121,7 @@ impl Transaction {
         let session = self.session.as_mut().unwrap().deref_mut();
         let reader = Box::new(StatementReader {
             enable_resume: options.enable_resume,
-            request
+            request,
         });
         RowIterator::new(session, reader, Some(options.call_options)).await
     }
@@ -182,7 +182,7 @@ impl Transaction {
         let session = self.as_mut_session();
         let reader = Box::new(TableReader {
             enable_resume: options.enable_resume,
-            request
+            request,
         });
         RowIterator::new(session, reader, Some(options.call_options)).await
     }

--- a/spanner/src/transaction.rs
+++ b/spanner/src/transaction.rs
@@ -53,6 +53,7 @@ pub struct QueryOptions {
     /// If cancel safe is required, such as when tokio::select is used, set to false.
     /// ```
     /// use time::{Duration, OffsetDateTime};
+    /// use google_cloud_spanner::reader::AsyncIterator;
     /// use google_cloud_spanner::client::Client;
     /// use google_cloud_spanner::key::Key;
     /// use google_cloud_spanner::statement::Statement;
@@ -71,8 +72,8 @@ pub struct QueryOptions {
     ///           heartbeat_milliseconds => 10000
     ///   )");
     ///   stmt.add_param("now", &OffsetDateTime::now_utc());
-    ///   let mut rows = tx.query_with_option(stmt, option);
-    ///   let mut tick = tokio::time::interval(Duration::from_millis(100));
+    ///   let mut rows = tx.query_with_option(stmt, option).await.unwrap();
+    ///   let mut tick = tokio::time::interval(tokio::time::Duration::from_millis(100));
     ///   loop {
     ///     tokio::select! {
     ///        _ = tick.tick() => {
@@ -81,7 +82,8 @@ pub struct QueryOptions {
     ///        maybe = rows.next() =>  {
     ///          let row = maybe.unwrap().unwrap();
     ///        }
-    ///    }
+    ///     }
+    ///   }
     /// }
     pub enable_resume: bool,
 }

--- a/spanner/src/transaction_ro.rs
+++ b/spanner/src/transaction_ro.rs
@@ -33,7 +33,7 @@ use crate::value::TimestampBound;
 /// TimestampBound for more details.
 pub struct ReadOnlyTransaction {
     base_tx: Transaction,
-    pub rts: Option<time::OffsetDateTime>,
+    pub rts: Option<OffsetDateTime>,
 }
 
 impl Deref for ReadOnlyTransaction {
@@ -189,6 +189,7 @@ impl BatchReadOnlyTransaction {
                 .into_iter()
                 .map(|x| Partition {
                     reader: TableReader {
+                        enable_resume: ro.enable_resume,
                         request: ReadRequest {
                             session: self.get_session_name(),
                             transaction: Some(self.transaction_selector.clone()),
@@ -246,6 +247,7 @@ impl BatchReadOnlyTransaction {
                 .into_iter()
                 .map(|x| Partition {
                     reader: StatementReader {
+                        enable_resume: qo.enable_resume,
                         request: ExecuteSqlRequest {
                             session: self.get_session_name(),
                             transaction: Some(self.transaction_selector.clone()),

--- a/spanner/src/transaction_ro.rs
+++ b/spanner/src/transaction_ro.rs
@@ -189,7 +189,6 @@ impl BatchReadOnlyTransaction {
                 .into_iter()
                 .map(|x| Partition {
                     reader: TableReader {
-                        enable_resume: ro.enable_resume,
                         request: ReadRequest {
                             session: self.get_session_name(),
                             transaction: Some(self.transaction_selector.clone()),

--- a/spanner/tests/change_stream_test.rs
+++ b/spanner/tests/change_stream_test.rs
@@ -1,0 +1,242 @@
+use std::collections::HashMap;
+use std::ops::Sub;
+use tokio::time::sleep;
+use std::time::Duration;
+
+use serial_test::serial;
+use time::OffsetDateTime;
+use tokio::task::JoinHandle;
+
+use common::*;
+use google_cloud_gax::conn::Environment;
+use google_cloud_gax::conn::Environment::{Emulator, GoogleCloud};
+use google_cloud_gax::grpc::{Code, Status};
+use google_cloud_googleapis::spanner::admin::database::v1::UpdateDatabaseDdlRequest;
+use google_cloud_googleapis::spanner::v1::spanner_client::SpannerClient;
+use google_cloud_spanner::admin;
+use google_cloud_spanner::admin::AdminClientConfig;
+use google_cloud_spanner::client::{Client, ClientConfig};
+use google_cloud_spanner::key::Key;
+use google_cloud_spanner::reader::{AsyncIterator, RowIterator};
+use google_cloud_spanner::row::{Error, Row, Struct, TryFromStruct};
+use google_cloud_spanner::statement::Statement;
+use google_cloud_spanner::transaction::QueryOptions;
+use google_cloud_spanner::transaction_ro::ReadOnlyTransaction;
+
+mod common;
+
+#[ctor::ctor]
+fn init() {
+    let filter = tracing_subscriber::filter::EnvFilter::from_default_env()
+        .add_directive("google_cloud_spanner=trace".parse().unwrap());
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+#[derive(Debug)]
+struct ChangeRecord {
+    pub data_change_record: Vec<DataChangeRecord>,
+    pub child_partitions_record: Vec<ChildPartitionsRecord>
+}
+
+impl TryFromStruct for ChangeRecord {
+    fn try_from_struct(s: Struct<'_>) -> Result<Self, Error> {
+        Ok(Self {
+            data_change_record: s.column_by_name("data_change_record")?,
+            child_partitions_record: s.column_by_name("child_partitions_record")?
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ChildPartitionsRecord {
+    pub start_timestamp: OffsetDateTime,
+    pub record_sequence: String,
+    pub child_partitions: Vec<ChildPartition>
+}
+
+impl TryFromStruct for ChildPartitionsRecord {
+    fn try_from_struct(s: Struct<'_>) -> Result<Self, Error> {
+        Ok(Self {
+            start_timestamp: s.column_by_name("start_timestamp")?,
+            record_sequence: s.column_by_name("record_sequence")?,
+            child_partitions: s.column_by_name("child_partitions")?,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ChildPartition {
+    pub token: String,
+    pub parent_partition_tokens: Vec<String>
+}
+
+impl TryFromStruct for ChildPartition {
+    fn try_from_struct(s: Struct<'_>) -> Result<Self, Error> {
+        Ok(Self {
+            token: s.column_by_name("token")?,
+            parent_partition_tokens: s.column_by_name("parent_partition_tokens")?
+        })
+    }
+}
+
+#[derive(Debug)]
+struct DataChangeRecord {
+    pub commit_timestamp: OffsetDateTime,
+    pub record_sequence: String,
+    pub server_transaction_id: String,
+    pub is_last_record_in_transaction_in_partition: bool,
+    pub table_name: String,
+    pub mod_type: String,
+    pub value_capture_type: String,
+    pub number_of_records_in_transaction: i64,
+    pub number_of_partitions_in_transaction: i64,
+    pub transaction_tag: String,
+    pub is_system_transaction:bool
+}
+impl TryFromStruct for DataChangeRecord {
+    fn try_from_struct(s: Struct<'_>) -> Result<Self, Error> {
+        Ok(Self {
+            commit_timestamp: s.column_by_name("commit_timestamp")?,
+            record_sequence: s.column_by_name("record_sequence")?,
+            server_transaction_id: s.column_by_name("server_transaction_id")?,
+            is_last_record_in_transaction_in_partition: s.column_by_name("is_last_record_in_transaction_in_partition")?,
+            table_name: s.column_by_name("table_name")?,
+            mod_type: s.column_by_name("mod_type")?,
+            value_capture_type: s.column_by_name("value_capture_type")?,
+            number_of_records_in_transaction: s.column_by_name("number_of_records_in_transaction")?,
+            number_of_partitions_in_transaction: s.column_by_name("number_of_partitions_in_transaction")?,
+            transaction_tag: s.column_by_name("transaction_tag")?,
+            is_system_transaction: s.column_by_name("is_system_transaction")?,
+        })
+    }
+}
+
+async fn create_environment() -> Environment {
+    let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(google_cloud_auth::project::Config {
+        audience: Some(google_cloud_spanner::apiv1::conn_pool::AUDIENCE),
+        scopes: Some(&google_cloud_spanner::apiv1::conn_pool::SCOPES),
+        sub: None,
+    }).await.unwrap();
+    GoogleCloud(Box::new(ts))
+}
+
+async fn query_change_record(tx: &mut ReadOnlyTransaction, now: OffsetDateTime, token: Option<String>) -> RowIterator {
+    let query = format!("
+        SELECT ChangeRecord FROM READ_UserItemChangeStream (
+          start_timestamp => @now,
+          end_timestamp => NULL,
+          partition_token => {},
+          heartbeat_milliseconds => 10000
+        )", match &token {
+            Some(_) => "@token",
+            None => "NULL"
+        }
+    );
+    tracing::info!("query = {}", query);
+    let mut stmt = Statement::new(query);
+    stmt.add_param("now", &now);
+    if let Some(token) = token {
+        stmt.add_param("token", &token);
+    }
+    tx.query_with_option(stmt, QueryOptions {
+        enable_resume: false,
+        ..Default::default()
+    }).await.unwrap()
+
+}
+
+#[tokio::test(flavor="multi_thread")]
+#[serial]
+async fn test_read_change_stream() {
+
+    // Create Change Stream
+    let db = "projects/atl-dev1/instances/test-instance/databases/local-database";
+    let admin_client = admin::client::Client::new(AdminClientConfig {
+       environment: create_environment().await
+    }).await.unwrap();
+    let _ = admin_client.database().update_database_ddl(UpdateDatabaseDdlRequest {
+        database: db.to_string(),
+        statements: vec!["CREATE CHANGE STREAM UserItemChangeStream FOR UserItem".to_string()],
+        operation_id: "".to_string()
+    }, None).await;
+
+    sleep(Duration::from_secs(20)).await;
+
+    let now = OffsetDateTime::now_utc();
+
+    // Select Changed Data
+    let mut config = ClientConfig {
+        environment: create_environment().await,
+        ..Default::default()
+    };
+    let client = Client::new(db, config).await.unwrap();
+    let mut tx = client.single().await.unwrap();
+    let mut row = query_change_record(&mut tx, now, None).await;
+    let mut tasks = vec![];
+    let mut index = 0;
+    while let Some(row) = row.next().await.unwrap() {
+        tasks.push(create_watcher(client.clone(), index, now, row).await);
+        index+=1;
+    }
+
+    sleep(Duration::from_secs(30)).await;
+
+    // Drop change stream
+    tracing::info!("drop change stream");
+    admin_client.database().update_database_ddl(UpdateDatabaseDdlRequest {
+        database: db.to_string(),
+        statements: vec!["DROP CHANGE STREAM UserItemChangeStream".to_string()],
+        operation_id: "".to_string()
+    }, None).await.unwrap();
+
+    for task in tasks {
+        let _ = task.await;
+    }
+}
+
+async fn create_watcher(client: Client, i: usize, now: OffsetDateTime, row: Row) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let change_record: Vec<ChangeRecord> = row.column(0).unwrap();
+        tracing::info!("change_{}={:?}", i, change_record);
+        let mut tasks = vec![];
+        for change in change_record {
+            for child in change.child_partitions_record {
+                for p in child.child_partitions {
+                    let client = client.clone();
+                    tasks.push(tokio::spawn(async move {
+                        let mut tx = client.single().await.unwrap();
+                        let mut rows = query_change_record(&mut tx, now, Some(p.token)) .await;
+                        let mut tick = tokio::time::interval(Duration::from_millis(100));
+                        loop {
+                            tokio::select! {
+                                _ = tick.tick() => {
+                                    tracing::info!("tick_{}", i);
+                                    sleep(Duration::from_secs(10)).await;
+                                },
+                                row = rows.next() => {
+                                    let row = match row {
+                                        Ok(row) => match row {
+                                            Some(row) => row,
+                                            None => unreachable!("")
+                                        },
+                                        Err(e) => {
+                                            // Detect Not Found error
+                                            tracing::error!("expected error : {:?}", e);
+                                            assert_eq!(e.code(), Code::NotFound);
+                                            break;
+                                        }
+                                    };
+                                    let change_record: Vec<ChangeRecord> = row.column(0).unwrap();
+                                    tracing::info!("child_{i}={:?}", change_record);
+                                }
+                            }
+                        }
+                    }));
+                }
+            }
+        }
+        for task in tasks {
+            let _ = task.await;
+        }
+    })
+}


### PR DESCRIPTION
This PR will fix #158.


If the future can be dropped by `tokio::select` or other methods when searching for a change stream, the resume process after an error occurs in `stream.message()` will remain in the Pending state forever. `enable_resume=false` in `QueryOption` to immediately return an error without performing the resume process.

```rust
async fn query(client: Client) {
    let mut tx = client.single().await.unwrap();
    let option = QueryOptions {
        enable_resume: false,
        ..Default::default()
    };
    let mut stmt = Statement::new("SELECT ChangeRecord FROM READ_UserItemChangeStream (
           start_timestamp => @now,
           end_timestamp => NULL,
           partition_token => {},
           heartbeat_milliseconds => 10000
     )");
    stmt.add_param("now", &OffsetDateTime::now_utc());
    let mut rows = tx.query_with_option(stmt, option).await.unwrap();
    let mut tick = tokio::time::interval(tokio::time::Duration::from_millis(100));
    loop {
          tokio::select! {
                 _ = tick.tick() => {
                      // run task
                 },
                 maybe = rows.next() =>  {
                      let row = maybe.unwrap().unwrap();
                 }
           }
     }
}
```