### PR TITLE
Session handling leaks sessions

### DIFF
--- a/spanner/src/session.rs
+++ b/spanner/src/session.rs
@@ -113,7 +113,7 @@ impl DerefMut for ManagedSession {
 struct Sessions {
     available_sessions: VecDeque<SessionHandle>,
 
-    waiters: VecDeque<oneshot::Sender<SessionHandle>>,
+    waiters: VecDeque<oneshot::Sender<()>>,
 
     /// Invalid sessions living in the server.
     orphans: Vec<SessionHandle>,
@@ -130,7 +130,7 @@ impl Sessions {
         self.num_inuse + self.available_sessions.len()
     }
 
-    fn take_waiter(&mut self) -> Option<oneshot::Sender<SessionHandle>> {
+    fn take_waiter(&mut self) -> Option<oneshot::Sender<()>> {
         while let Some(waiter) = self.waiters.pop_front() {
             // Waiter can be closed when session acquisition times out.
             if !waiter.is_closed() {
@@ -187,19 +187,10 @@ impl Sessions {
         match result {
             Ok(mut new_sessions) => {
                 while let Some(session) = new_sessions.pop() {
-                    match self.take_waiter() {
-                        Some(waiter) => match waiter.send(session) {
-                            // When it just barely timed out
-                            Err(session) => {
-                                self.available_sessions.push_back(session);
-                            }
-                            Ok(_) => {
-                                // Mark as using when notify to waiter directory.
-                                self.num_inuse += 1;
-                            }
-                        },
-                        None => self.available_sessions.push_back(session),
-                    }
+		    self.available_sessions.push_back(session);
+                    if let Some(waiter) = self.take_waiter() {
+			let _ = waiter.send(());
+		    }
                 }
             }
             Err(e) => tracing::error!("failed to create new sessions {:?}", e),
@@ -265,38 +256,55 @@ impl SessionPool {
     /// The client on the waiting list will be notified when another client's session has finished and
     /// when the process of replenishing the available sessions is complete.
     async fn acquire(&self) -> Result<ManagedSession, SessionError> {
-        let (on_session_acquired, session_count) = {
-            let mut sessions = self.inner.write();
+	loop {
+            let (on_session_acquired, session_count) = {
+		let mut sessions = self.inner.write();
 
-            // Prioritize waiters over new acquirers.
-            if sessions.waiters.is_empty() {
-                if let Some(mut s) = sessions.take() {
-                    s.last_used_at = Instant::now();
-                    return Ok(ManagedSession::new(self.clone(), s));
-                }
+		// Prioritize waiters over new acquirers.
+		if sessions.waiters.is_empty() {
+                    if let Some(mut s) = sessions.take() {
+			s.last_used_at = Instant::now();
+			return Ok(ManagedSession::new(self.clone(), s));
+                    }
+		}
+		// Add the participant to the waiting list.
+		let (sender, receiver) = oneshot::channel();
+		sessions.waiters.push_back(sender);
+		let session_count = sessions.reserve(self.config.max_opened, self.config.inc_step);
+		(receiver, session_count)
+            };
+
+            if session_count > 0 {
+		let _ = self.session_creation_sender.send(session_count);
             }
-            // Add the participant to the waiting list.
-            let (sender, receiver) = oneshot::channel();
-            sessions.waiters.push_back(sender);
-            let session_count = sessions.reserve(self.config.max_opened, self.config.inc_step);
-            (receiver, session_count)
-        };
 
-        if session_count > 0 {
-            let _ = self.session_creation_sender.send(session_count);
-        }
-
-        // Wait for the session available notification.
-        match timeout(self.config.session_get_timeout, on_session_acquired).await {
-            Ok(Ok(mut session)) => {
-                session.last_used_at = Instant::now();
-                Ok(ManagedSession {
-                    session_pool: self.clone(),
-                    session: Some(session),
-                })
+            // Wait for the session available notification.
+            match timeout(self.config.session_get_timeout, on_session_acquired).await {
+		Ok(Ok(())) => {
+		    let mut sessions = self.inner.write();
+		    if let Some(mut s) = sessions.take() {
+			s.last_used_at = Instant::now();
+			return Ok(ManagedSession::new(self.clone(), s));
+                    } else {
+			continue; // another waiter raced for session
+		    }
+		}
+		_ => {
+		    {
+			let sessions = self.inner.write();
+			tracing::info!(
+			    available = sessions.available_sessions.len(),
+			    waiters = sessions.waiters.len(),
+			    orphans = sessions.orphans.len(),
+			    num_inuse = sessions.num_inuse,
+			    num_creating = sessions.num_creating,
+			    max_opened = self.config.max_opened,
+			    "Timeout acquiring session");
+		    }
+		    return Err(SessionError::SessionGetTimeout);
+		},
             }
-            _ => Err(SessionError::SessionGetTimeout),
-        }
+	}
     }
 
     /// If the session is valid
@@ -307,24 +315,18 @@ impl SessionPool {
     fn recycle(&self, mut session: SessionHandle) {
         if session.valid {
             let mut sessions = self.inner.write();
-            match sessions.take_waiter() {
-                // Immediately reuse session when the waiter exist
-                Some(c) => {
-                    tracing::trace!("sent waiter name={}", session.session.name);
-                    if let Err(session) = c.send(session) {
-                        sessions.release(session)
-                    }
-                }
-                None => {
-                    if sessions.num_opened() > self.config.max_idle
-                        && session.created_at + self.config.idle_timeout < Instant::now()
-                    {
-                        // Not reuse expired idle session
-                        session.valid = false
-                    }
-                    sessions.release(session)
-                }
-            };
+	    let waiter = sessions.take_waiter();
+	    if sessions.num_opened() > self.config.max_idle
+                && session.created_at + self.config.idle_timeout < Instant::now()
+		&& waiter.is_none()
+            {
+                // Not reuse expired idle session
+                session.valid = false
+            }
+	    sessions.release(session);
+            if let Some(waiter) = waiter {
+		let _ = waiter.send(());
+	    }
         } else {
             let session_count = {
                 let mut sessions = self.inner.write();

--- a/spanner/src/session.rs
+++ b/spanner/src/session.rs
@@ -187,10 +187,10 @@ impl Sessions {
         match result {
             Ok(mut new_sessions) => {
                 while let Some(session) = new_sessions.pop() {
-		    self.available_sessions.push_back(session);
+                    self.available_sessions.push_back(session);
                     if let Some(waiter) = self.take_waiter() {
-			let _ = waiter.send(());
-		    }
+                        let _ = waiter.send(());
+                    }
                 }
             }
             Err(e) => tracing::error!("failed to create new sessions {:?}", e),
@@ -256,55 +256,56 @@ impl SessionPool {
     /// The client on the waiting list will be notified when another client's session has finished and
     /// when the process of replenishing the available sessions is complete.
     async fn acquire(&self) -> Result<ManagedSession, SessionError> {
-	loop {
+        loop {
             let (on_session_acquired, session_count) = {
-		let mut sessions = self.inner.write();
+                let mut sessions = self.inner.write();
 
-		// Prioritize waiters over new acquirers.
-		if sessions.waiters.is_empty() {
+                // Prioritize waiters over new acquirers.
+                if sessions.waiters.is_empty() {
                     if let Some(mut s) = sessions.take() {
-			s.last_used_at = Instant::now();
-			return Ok(ManagedSession::new(self.clone(), s));
+                        s.last_used_at = Instant::now();
+                        return Ok(ManagedSession::new(self.clone(), s));
                     }
-		}
-		// Add the participant to the waiting list.
-		let (sender, receiver) = oneshot::channel();
-		sessions.waiters.push_back(sender);
-		let session_count = sessions.reserve(self.config.max_opened, self.config.inc_step);
-		(receiver, session_count)
+                }
+                // Add the participant to the waiting list.
+                let (sender, receiver) = oneshot::channel();
+                sessions.waiters.push_back(sender);
+                let session_count = sessions.reserve(self.config.max_opened, self.config.inc_step);
+                (receiver, session_count)
             };
 
             if session_count > 0 {
-		let _ = self.session_creation_sender.send(session_count);
+                let _ = self.session_creation_sender.send(session_count);
             }
 
             // Wait for the session available notification.
             match timeout(self.config.session_get_timeout, on_session_acquired).await {
-		Ok(Ok(())) => {
-		    let mut sessions = self.inner.write();
-		    if let Some(mut s) = sessions.take() {
-			s.last_used_at = Instant::now();
-			return Ok(ManagedSession::new(self.clone(), s));
+                Ok(Ok(())) => {
+                    let mut sessions = self.inner.write();
+                    if let Some(mut s) = sessions.take() {
+                        s.last_used_at = Instant::now();
+                        return Ok(ManagedSession::new(self.clone(), s));
                     } else {
-			continue; // another waiter raced for session
-		    }
-		}
-		_ => {
-		    {
-			let sessions = self.inner.write();
-			tracing::info!(
-			    available = sessions.available_sessions.len(),
-			    waiters = sessions.waiters.len(),
-			    orphans = sessions.orphans.len(),
-			    num_inuse = sessions.num_inuse,
-			    num_creating = sessions.num_creating,
-			    max_opened = self.config.max_opened,
-			    "Timeout acquiring session");
-		    }
-		    return Err(SessionError::SessionGetTimeout);
-		},
+                        continue; // another waiter raced for session
+                    }
+                }
+                _ => {
+                    {
+                        let sessions = self.inner.write();
+                        tracing::info!(
+                            available = sessions.available_sessions.len(),
+                            waiters = sessions.waiters.len(),
+                            orphans = sessions.orphans.len(),
+                            num_inuse = sessions.num_inuse,
+                            num_creating = sessions.num_creating,
+                            max_opened = self.config.max_opened,
+                            "Timeout acquiring session"
+                        );
+                    }
+                    return Err(SessionError::SessionGetTimeout);
+                }
             }
-	}
+        }
     }
 
     /// If the session is valid
@@ -315,18 +316,18 @@ impl SessionPool {
     fn recycle(&self, mut session: SessionHandle) {
         if session.valid {
             let mut sessions = self.inner.write();
-	    let waiter = sessions.take_waiter();
-	    if sessions.num_opened() > self.config.max_idle
+            let waiter = sessions.take_waiter();
+            if sessions.num_opened() > self.config.max_idle
                 && session.created_at + self.config.idle_timeout < Instant::now()
-		&& waiter.is_none()
+                && waiter.is_none()
             {
                 // Not reuse expired idle session
                 session.valid = false
             }
-	    sessions.release(session);
+            sessions.release(session);
             if let Some(waiter) = waiter {
-		let _ = waiter.send(());
-	    }
+                let _ = waiter.send(());
+            }
         } else {
             let session_count = {
                 let mut sessions = self.inner.write();


### PR DESCRIPTION
I came across this issue running a heavy load against spanner, with multiple tasks using the same client. The root cause is a race in the timeout passing a session to a waiter via a oneshot.

In acquire, it creates a oneshot that which it adds to the waiters and then receives from the oneshot under a timeout. When a session becomes free it is sent via the oneshot, and acquire gets a session.

The problem is if there's a race with the timeout. The timeout can complete, and that same instant a session becomes free and is placed in the oneshot. Since the timeout completed, nothing ever receives the session, so it is leaked. Most importantly, the in_use is never updated, so the session appears to be still in_use even though it has been dropped. When this happens enough times we end up leaking all sessions, and no more are created because we've hit max open.

The solution is to not send the session through the oneshot. Instead use the oneshot to notify the waiter that a session is available in available_sessions. It can then try to take from there. This is wrapped in a loop to allow for racing with other acquire calls.