### PR TITLE
Add timeout and connect timeout for spanner connections

### DIFF
--- a/foundation/gax/src/conn.rs
+++ b/foundation/gax/src/conn.rs
@@ -118,7 +118,7 @@ impl<'a> ConnectionManager {
         domain_name: impl Into<String>,
         audience: &'static str,
         environment: &Environment,
-	conn_options: &'a ConnectionOptions,
+        conn_options: &'a ConnectionOptions,
     ) -> Result<Self, Error> {
         let conns = match environment {
             Environment::GoogleCloud(ts_provider) => {

--- a/pubsub/src/apiv1/conn_pool.rs
+++ b/pubsub/src/apiv1/conn_pool.rs
@@ -1,5 +1,5 @@
 use google_cloud_gax::conn::{Channel, Environment};
-use google_cloud_gax::conn::{ConnectionManager as GRPCConnectionManager, Error, ConnectionOptions};
+use google_cloud_gax::conn::{ConnectionManager as GRPCConnectionManager, ConnectionOptions, Error};
 
 pub const AUDIENCE: &str = "https://pubsub.googleapis.com/";
 pub const PUBSUB: &str = "pubsub.googleapis.com";
@@ -14,7 +14,12 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub async fn new(pool_size: usize, domain: &str, environment: &Environment, conn_options: &ConnectionOptions) -> Result<Self, Error> {
+    pub async fn new(
+        pool_size: usize,
+        domain: &str,
+        environment: &Environment,
+        conn_options: &ConnectionOptions,
+    ) -> Result<Self, Error> {
         Ok(ConnectionManager {
             inner: GRPCConnectionManager::new(pool_size, domain, AUDIENCE, environment, conn_options).await?,
         })

--- a/pubsub/src/apiv1/conn_pool.rs
+++ b/pubsub/src/apiv1/conn_pool.rs
@@ -1,5 +1,5 @@
 use google_cloud_gax::conn::{Channel, Environment};
-use google_cloud_gax::conn::{ConnectionManager as GRPCConnectionManager, Error};
+use google_cloud_gax::conn::{ConnectionManager as GRPCConnectionManager, Error, ConnectionOptions};
 
 pub const AUDIENCE: &str = "https://pubsub.googleapis.com/";
 pub const PUBSUB: &str = "pubsub.googleapis.com";
@@ -14,9 +14,9 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub async fn new(pool_size: usize, domain: &str, environment: &Environment) -> Result<Self, Error> {
+    pub async fn new(pool_size: usize, domain: &str, environment: &Environment, conn_options: &ConnectionOptions) -> Result<Self, Error> {
         Ok(ConnectionManager {
-            inner: GRPCConnectionManager::new(pool_size, domain, AUDIENCE, environment).await?,
+            inner: GRPCConnectionManager::new(pool_size, domain, AUDIENCE, environment, conn_options).await?,
         })
     }
 

--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -1,6 +1,6 @@
 use std::env::var;
 
-use google_cloud_gax::conn::Environment;
+use google_cloud_gax::conn::{ConnectionOptions, Environment};
 use google_cloud_gax::grpc::Status;
 use google_cloud_gax::retry::RetrySetting;
 use google_cloud_googleapis::pubsub::v1::{
@@ -68,10 +68,10 @@ impl Client {
         let pool_size = config.pool_size.unwrap_or_default();
 
         let pubc = PublisherClient::new(
-            ConnectionManager::new(pool_size, config.endpoint.as_str(), &config.environment).await?,
+            ConnectionManager::new(pool_size, config.endpoint.as_str(), &config.environment, &ConnectionOptions::default()).await?,
         );
         let subc = SubscriberClient::new(
-            ConnectionManager::new(pool_size, config.endpoint.as_str(), &config.environment).await?,
+            ConnectionManager::new(pool_size, config.endpoint.as_str(), &config.environment, &ConnectionOptions::default()).await?,
         );
 
         Ok(Self {

--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -68,10 +68,22 @@ impl Client {
         let pool_size = config.pool_size.unwrap_or_default();
 
         let pubc = PublisherClient::new(
-            ConnectionManager::new(pool_size, config.endpoint.as_str(), &config.environment, &ConnectionOptions::default()).await?,
+            ConnectionManager::new(
+                pool_size,
+                config.endpoint.as_str(),
+                &config.environment,
+                &ConnectionOptions::default(),
+            )
+            .await?,
         );
         let subc = SubscriberClient::new(
-            ConnectionManager::new(pool_size, config.endpoint.as_str(), &config.environment, &ConnectionOptions::default()).await?,
+            ConnectionManager::new(
+                pool_size,
+                config.endpoint.as_str(),
+                &config.environment,
+                &ConnectionOptions::default(),
+            )
+            .await?,
         );
 
         Ok(Self {

--- a/pubsub/src/subscriber.rs
+++ b/pubsub/src/subscriber.rs
@@ -301,7 +301,7 @@ pub(crate) async fn ack(
 mod tests {
     use serial_test::serial;
 
-    use google_cloud_gax::conn::Environment;
+    use google_cloud_gax::conn::{ConnectionOptions, Environment};
     use google_cloud_googleapis::pubsub::v1::{PublishRequest, PubsubMessage, PullRequest};
 
     use crate::apiv1::conn_pool::ConnectionManager;
@@ -318,7 +318,7 @@ mod tests {
     #[serial]
     async fn test_handle_message_immediately_nack() {
         let cm = || async {
-            ConnectionManager::new(4, "", &Environment::Emulator("localhost:8681".to_string()))
+            ConnectionManager::new(4, "", &Environment::Emulator("localhost:8681".to_string()), &ConnectionOptions::default())
                 .await
                 .unwrap()
         };

--- a/pubsub/src/subscriber.rs
+++ b/pubsub/src/subscriber.rs
@@ -318,9 +318,14 @@ mod tests {
     #[serial]
     async fn test_handle_message_immediately_nack() {
         let cm = || async {
-            ConnectionManager::new(4, "", &Environment::Emulator("localhost:8681".to_string()), &ConnectionOptions::default())
-                .await
-                .unwrap()
+            ConnectionManager::new(
+                4,
+                "",
+                &Environment::Emulator("localhost:8681".to_string()),
+                &ConnectionOptions::default(),
+            )
+            .await
+            .unwrap()
         };
         let subc = SubscriberClient::new(cm().await);
         let pubc = PublisherClient::new(cm().await);

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -585,9 +585,14 @@ mod tests {
     }
 
     async fn create_subscription(enable_exactly_once_delivery: bool) -> Subscription {
-        let cm = ConnectionManager::new(4, "", &Environment::Emulator(EMULATOR.to_string()), &ConnectionOptions::default())
-            .await
-            .unwrap();
+        let cm = ConnectionManager::new(
+            4,
+            "",
+            &Environment::Emulator(EMULATOR.to_string()),
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let client = SubscriberClient::new(cm);
 
         let uuid = Uuid::new_v4().hyphenated().to_string();
@@ -606,9 +611,14 @@ mod tests {
 
     async fn publish() {
         let pubc = PublisherClient::new(
-            ConnectionManager::new(4, "", &Environment::Emulator(EMULATOR.to_string()), &ConnectionOptions::default())
-                .await
-                .unwrap(),
+            ConnectionManager::new(
+                4,
+                "",
+                &Environment::Emulator(EMULATOR.to_string()),
+                &ConnectionOptions::default(),
+            )
+            .await
+            .unwrap(),
         );
         let msg = PubsubMessage {
             data: "test_message".into(),

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -567,7 +567,7 @@ mod tests {
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
-    use google_cloud_gax::conn::Environment;
+    use google_cloud_gax::conn::{ConnectionOptions, Environment};
     use google_cloud_googleapis::pubsub::v1::{PublishRequest, PubsubMessage};
 
     use crate::apiv1::conn_pool::ConnectionManager;
@@ -585,7 +585,7 @@ mod tests {
     }
 
     async fn create_subscription(enable_exactly_once_delivery: bool) -> Subscription {
-        let cm = ConnectionManager::new(4, "", &Environment::Emulator(EMULATOR.to_string()))
+        let cm = ConnectionManager::new(4, "", &Environment::Emulator(EMULATOR.to_string()), &ConnectionOptions::default())
             .await
             .unwrap();
         let client = SubscriberClient::new(cm);
@@ -606,7 +606,7 @@ mod tests {
 
     async fn publish() {
         let pubc = PublisherClient::new(
-            ConnectionManager::new(4, "", &Environment::Emulator(EMULATOR.to_string()))
+            ConnectionManager::new(4, "", &Environment::Emulator(EMULATOR.to_string()), &ConnectionOptions::default())
                 .await
                 .unwrap(),
         );

--- a/pubsub/src/topic.rs
+++ b/pubsub/src/topic.rs
@@ -157,9 +157,13 @@ mod tests {
 
     async fn create_topic() -> Topic {
         let environment = Environment::Emulator("localhost:8681".to_string());
-        let cm1 = ConnectionManager::new(4, "", &environment, &ConnectionOptions::default()).await.unwrap();
+        let cm1 = ConnectionManager::new(4, "", &environment, &ConnectionOptions::default())
+            .await
+            .unwrap();
         let pubc = PublisherClient::new(cm1);
-        let cm2 = ConnectionManager::new(4, "", &environment, &ConnectionOptions::default()).await.unwrap();
+        let cm2 = ConnectionManager::new(4, "", &environment, &ConnectionOptions::default())
+            .await
+            .unwrap();
         let subc = SubscriberClient::new(cm2);
 
         let uuid = Uuid::new_v4().hyphenated().to_string();

--- a/pubsub/src/topic.rs
+++ b/pubsub/src/topic.rs
@@ -140,7 +140,7 @@ mod tests {
     use tokio::time::sleep;
     use uuid::Uuid;
 
-    use google_cloud_gax::conn::Environment;
+    use google_cloud_gax::conn::{ConnectionOptions, Environment};
     use google_cloud_gax::grpc::{Code, Status};
     use google_cloud_googleapis::pubsub::v1::PubsubMessage;
 
@@ -157,9 +157,9 @@ mod tests {
 
     async fn create_topic() -> Topic {
         let environment = Environment::Emulator("localhost:8681".to_string());
-        let cm1 = ConnectionManager::new(4, "", &environment).await.unwrap();
+        let cm1 = ConnectionManager::new(4, "", &environment, &ConnectionOptions::default()).await.unwrap();
         let pubc = PublisherClient::new(cm1);
-        let cm2 = ConnectionManager::new(4, "", &environment).await.unwrap();
+        let cm2 = ConnectionManager::new(4, "", &environment, &ConnectionOptions::default()).await.unwrap();
         let subc = SubscriberClient::new(cm2);
 
         let uuid = Uuid::new_v4().hyphenated().to_string();

--- a/spanner/src/admin/client.rs
+++ b/spanner/src/admin/client.rs
@@ -1,4 +1,5 @@
-use google_cloud_gax::conn::{Channel, ConnectionManager, Error};
+use google_cloud_gax::conn::{Channel, ConnectionManager, ConnectionOptions, Error};
+use std::time::Duration;
 
 use google_cloud_longrunning::autogen::operations_client::OperationsClient;
 
@@ -33,7 +34,11 @@ impl Client {
 }
 
 async fn internal_client(config: &AdminClientConfig) -> Result<(Channel, OperationsClient), Error> {
-    let conn_pool = ConnectionManager::new(1, SPANNER, AUDIENCE, &config.environment).await?;
+    let conn_options = ConnectionOptions {
+        timeout: Some(Duration::from_secs(30)),
+        connect_timeout: Some(Duration::from_secs(30)),
+    };
+    let conn_pool = ConnectionManager::new(1, SPANNER, AUDIENCE, &config.environment, &conn_options).await?;
     let conn = conn_pool.conn();
     let lro_client = OperationsClient::new(conn).await?;
     Ok((conn_pool.conn(), lro_client))

--- a/spanner/src/admin/database/mod.rs
+++ b/spanner/src/admin/database/mod.rs
@@ -5,7 +5,7 @@ mod tests {
     use serial_test::serial;
     use time::OffsetDateTime;
 
-    use google_cloud_gax::conn::{ConnectionManager, Environment};
+    use google_cloud_gax::conn::{ConnectionManager, ConnectionOptions, Environment};
     use google_cloud_googleapis::spanner::admin::database::v1::database::State;
 
     use google_cloud_googleapis::spanner::admin::database::v1::{
@@ -18,10 +18,15 @@ mod tests {
     use crate::apiv1::conn_pool::{AUDIENCE, SPANNER};
 
     async fn new_client() -> DatabaseAdminClient {
-        let conn_pool =
-            ConnectionManager::new(1, SPANNER, AUDIENCE, &Environment::Emulator("localhost:9010".to_string()))
-                .await
-                .unwrap();
+        let conn_pool = ConnectionManager::new(
+            1,
+            SPANNER,
+            AUDIENCE,
+            &Environment::Emulator("localhost:9010".to_string()),
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let lro_client = OperationsClient::new(conn_pool.conn()).await.unwrap();
         DatabaseAdminClient::new(conn_pool.conn(), lro_client)
     }

--- a/spanner/src/admin/instance/mod.rs
+++ b/spanner/src/admin/instance/mod.rs
@@ -5,7 +5,7 @@ mod tests {
     use serial_test::serial;
     use time::OffsetDateTime;
 
-    use google_cloud_gax::conn::{ConnectionManager, Environment};
+    use google_cloud_gax::conn::{ConnectionManager, ConnectionOptions, Environment};
     use google_cloud_googleapis::spanner::admin::instance::v1::instance::State;
 
     use google_cloud_googleapis::spanner::admin::instance::v1::{
@@ -18,10 +18,15 @@ mod tests {
     use crate::apiv1::conn_pool::{AUDIENCE, SPANNER};
 
     async fn new_client() -> InstanceAdminClient {
-        let conn_pool =
-            ConnectionManager::new(1, SPANNER, AUDIENCE, &Environment::Emulator("localhost:9010".to_string()))
-                .await
-                .unwrap();
+        let conn_pool = ConnectionManager::new(
+            1,
+            SPANNER,
+            AUDIENCE,
+            &Environment::Emulator("localhost:9010".to_string()),
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let lro_client = OperationsClient::new(conn_pool.conn()).await.unwrap();
         InstanceAdminClient::new(conn_pool.conn(), lro_client)
     }

--- a/spanner/src/apiv1/conn_pool.rs
+++ b/spanner/src/apiv1/conn_pool.rs
@@ -1,4 +1,4 @@
-use google_cloud_gax::conn::{ConnectionManager as GRPCConnectionManager, Environment, Error};
+use google_cloud_gax::conn::{ConnectionManager as GRPCConnectionManager, ConnectionOptions, Environment, Error};
 use google_cloud_googleapis::spanner::v1::spanner_client::SpannerClient;
 
 use crate::apiv1::spanner_client::Client;
@@ -15,9 +15,14 @@ pub struct ConnectionManager {
 }
 
 impl ConnectionManager {
-    pub async fn new(pool_size: usize, environment: &Environment, domain: &str) -> Result<Self, Error> {
+    pub async fn new(
+        pool_size: usize,
+        environment: &Environment,
+        domain: &str,
+        conn_options: &ConnectionOptions,
+    ) -> Result<Self, Error> {
         Ok(ConnectionManager {
-            inner: GRPCConnectionManager::new(pool_size, domain, AUDIENCE, environment).await?,
+            inner: GRPCConnectionManager::new(pool_size, domain, AUDIENCE, environment, conn_options).await?,
         })
     }
 

--- a/spanner/src/apiv1/mod.rs
+++ b/spanner/src/apiv1/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use prost_types::{value::Kind, ListValue, Value};
     use serial_test::serial;
 
-    use google_cloud_gax::conn::Environment;
+    use google_cloud_gax::conn::{ConnectionOptions, Environment};
     use google_cloud_gax::grpc::Code;
     use google_cloud_googleapis::spanner::v1::mutation::{Operation, Write};
     use google_cloud_googleapis::spanner::v1::{
@@ -23,9 +23,14 @@ mod tests {
     const DATABASE: &str = "projects/local-project/instances/test-instance/databases/local-database";
 
     async fn create_spanner_client() -> Client {
-        let cm = ConnectionManager::new(1, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let cm = ConnectionManager::new(
+            1,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         cm.conn()
     }
 

--- a/spanner/src/session.rs
+++ b/spanner/src/session.rs
@@ -641,7 +641,7 @@ mod tests {
     use tokio::time::sleep;
     use tokio_util::sync::CancellationToken;
 
-    use google_cloud_gax::conn::Environment;
+    use google_cloud_gax::conn::{ConnectionOptions, Environment};
     use google_cloud_googleapis::spanner::v1::ExecuteSqlRequest;
 
     use crate::apiv1::conn_pool::ConnectionManager;
@@ -657,9 +657,14 @@ mod tests {
     }
 
     async fn assert_rush(use_invalidate: bool, config: SessionConfig) -> Arc<SessionManager> {
-        let cm = ConnectionManager::new(4, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let cm = ConnectionManager::new(
+            4,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let sm = SessionManager::new(DATABASE, cm, config).await.unwrap();
 
         let counter = Arc::new(AtomicI64::new(0));
@@ -685,9 +690,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_health_check_checked() {
-        let cm = ConnectionManager::new(4, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let cm = ConnectionManager::new(
+            4,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let session_alive_trust_duration = Duration::from_millis(10);
         let config = SessionConfig {
             min_opened: 5,
@@ -709,9 +719,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_health_check_not_checked() {
-        let cm = ConnectionManager::new(4, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let cm = ConnectionManager::new(
+            4,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let session_alive_trust_duration = Duration::from_secs(10);
         let config = SessionConfig {
             min_opened: 5,
@@ -733,9 +748,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_increase_session_and_idle_session_expired() {
-        let conn_pool = ConnectionManager::new(4, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let conn_pool = ConnectionManager::new(
+            4,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let config = SessionConfig {
             idle_timeout: Duration::from_millis(10),
             min_opened: 10,
@@ -767,9 +787,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_too_many_session_timeout() {
-        let conn_pool = ConnectionManager::new(4, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let conn_pool = ConnectionManager::new(
+            4,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let config = SessionConfig {
             idle_timeout: Duration::from_millis(10),
             min_opened: 10,
@@ -1025,9 +1050,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_close() {
-        let cm = ConnectionManager::new(4, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let cm = ConnectionManager::new(
+            4,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let config = SessionConfig::default();
         let sm = SessionManager::new(DATABASE, cm, config.clone()).await.unwrap();
         assert_eq!(sm.num_opened(), config.min_opened);
@@ -1039,9 +1069,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
     async fn test_batch_create_sessions() {
-        let cm = ConnectionManager::new(1, &Environment::Emulator("localhost:9010".to_string()), "")
-            .await
-            .unwrap();
+        let cm = ConnectionManager::new(
+            1,
+            &Environment::Emulator("localhost:9010".to_string()),
+            "",
+            &ConnectionOptions::default(),
+        )
+        .await
+        .unwrap();
         let client = cm.conn();
         let session_count = 125;
         let result = batch_create_sessions(client.clone(), DATABASE, session_count).await;

--- a/spanner/tests/common.rs
+++ b/spanner/tests/common.rs
@@ -87,7 +87,10 @@ pub async fn create_data_client() -> Client {
         ClientConfig {
             session_config,
             environment: Environment::Emulator("localhost:9010".to_string()),
-            channel_config: ChannelConfig { num_channels: 1 },
+            channel_config: ChannelConfig {
+                num_channels: 1,
+                ..Default::default()
+            },
             ..Default::default()
         },
     )


### PR DESCRIPTION
We encountered an issue with a broken spanner instance where when we connected the process just sat there doing nothing. Further investigation showed it was a server side problem. Other clients failed to connect also. But when the other clients failed they gave a error that the request to create sessions had timed out.

The rust client should do this also. I've added default timeouts for the spanner client based on the values in
https://github.com/googleapis/google-cloud-go/blob/main/spanner/apiv1/spanner_client.go#L65 In the go client, some requests take a higher timeout, but the structure of the rust client doesn't allow this, so I set both defaults to 30s. Other users can increase, via channel_config, if they find this to be too low.

I didn't set defaults for pubsub as we don't use it.