### PR TITLE
auth: identity token source

### DIFF
--- a/foundation/auth/src/idtoken.rs
+++ b/foundation/auth/src/idtoken.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+use crate::{
+    credentials::CredentialsFile,
+    error,
+    project::{create_token_source_from_credentials, project, Config, Project, SERVICE_ACCOUNT_KEY},
+    token_source::{
+        compute_identity_source::ComputeIdentitySource, reuse_token_source::ReuseTokenSource,
+        service_account_token_source::OAuth2ServiceAccountTokenSource, TokenSource,
+    },
+};
+
+#[derive(Clone)]
+pub struct IdTokenConfig {
+    credentials: Option<CredentialsFile>,
+    custom_claims: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl std::fmt::Debug for IdTokenConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdTokenConfig")
+            .field("custom_claims", &self.custom_claims)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IdTokenConfig {
+    pub fn with_credentials(mut self, creds: CredentialsFile) -> Self {
+        self.credentials.replace(creds);
+        self
+    }
+}
+
+pub async fn create_id_token_source(
+    config: IdTokenConfig,
+    audience: &str,
+) -> Result<Box<dyn TokenSource>, error::Error> {
+    if audience.is_empty() {
+        return Err(error::Error::ScopeOrAudienceRequired);
+    }
+
+    if let Some(credentials) = config.credentials {
+        return create_token_source_from_credentials(
+            &credentials,
+            &Config {
+                audience: audience.into(),
+                ..Default::default()
+            },
+        )
+        .await;
+    }
+
+    match project().await? {
+        Project::FromFile(credentials) => {
+            let ts = id_token_source_from_credentials(config, &credentials, audience).await?;
+            let token = ts.token().await?;
+            Ok(Box::new(ReuseTokenSource::new(ts, token)))
+        }
+        Project::FromMetadataServer(_) => {
+            let ts = ComputeIdentitySource::new(audience)?;
+            let token = ts.token().await?;
+            Ok(Box::new(ReuseTokenSource::new(Box::new(ts), token)))
+        }
+    }
+}
+
+async fn id_token_source_from_credentials(
+    config: IdTokenConfig,
+    credentials: &CredentialsFile,
+    audience: &str,
+) -> Result<Box<dyn TokenSource>, error::Error> {
+    match credentials.tp.as_str() {
+        SERVICE_ACCOUNT_KEY => {
+            let mut claims = config.custom_claims.unwrap_or_default();
+            claims.insert("target_audience".into(), audience.into());
+
+            let source = OAuth2ServiceAccountTokenSource::new(credentials, "", None)?
+                .with_use_id_token()
+                .with_private_claims(claims);
+
+            Ok(Box::new(source))
+        }
+        // TODO: support impersonation and external account
+        _ => Err(error::Error::UnsupportedAccountType(credentials.tp.to_string())),
+    }
+}

--- a/foundation/auth/src/lib.rs
+++ b/foundation/auth/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod credentials;
 pub mod error;
+pub mod idtoken;
 mod misc;
 pub mod project;
 pub mod token;

--- a/foundation/auth/src/token_source/compute_identity_source.rs
+++ b/foundation/auth/src/token_source/compute_identity_source.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use jsonwebtoken::Validation;
+use serde::Deserialize;
+use time::OffsetDateTime;
+use urlencoding::encode;
+
+use google_cloud_metadata::{METADATA_FLAVOR_KEY, METADATA_GOOGLE, METADATA_HOST_ENV, METADATA_IP};
+
+use crate::error::Error;
+use crate::token::Token;
+use crate::token_source::{default_http_client, TokenSource};
+
+/// Fetches a JWT token from the metadata server.
+/// using the `identity` endpoint.
+///
+/// This token source is useful for service-to-service authentication, notably on Cloud Run.
+///
+/// See <https://cloud.google.com/run/docs/authenticating/service-to-service#use_the_metadata_server>
+#[derive(Clone)]
+pub struct ComputeIdentitySource {
+    token_url: String,
+    client: reqwest::Client,
+    decoding_key: jsonwebtoken::DecodingKey,
+    validation: jsonwebtoken::Validation,
+}
+
+impl std::fmt::Debug for ComputeIdentitySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComputeIdentitySource")
+            .field("token_url", &self.token_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ComputeIdentitySource {
+    pub(crate) fn new(audience: &str) -> Result<ComputeIdentitySource, Error> {
+        let host = match std::env::var(METADATA_HOST_ENV) {
+            Ok(s) => s,
+            Err(_e) => METADATA_IP.to_string(),
+        };
+
+        // Only used to extract the expiry without checking the signature.
+        let mut validation = Validation::default();
+        validation.insecure_disable_signature_validation();
+        let decoding_key = jsonwebtoken::DecodingKey::from_secret(b"");
+
+        Ok(ComputeIdentitySource {
+            token_url: format!(
+                "http://{}/computeMetadata/v1/instance/service-accounts/default/identity?audience={}",
+                host,
+                encode(audience)
+            ),
+            client: default_http_client(),
+            decoding_key,
+            validation,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct ExpClaim {
+    exp: i64,
+}
+
+#[async_trait]
+impl TokenSource for ComputeIdentitySource {
+    async fn token(&self) -> Result<Token, Error> {
+        let jwt = self
+            .client
+            .get(self.token_url.to_string())
+            .header(METADATA_FLAVOR_KEY, METADATA_GOOGLE)
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        let exp = jsonwebtoken::decode::<ExpClaim>(&jwt, &self.decoding_key, &self.validation)?
+            .claims
+            .exp;
+
+        Ok(Token {
+            access_token: jwt,
+            token_type: "Bearer".into(),
+            expiry: OffsetDateTime::from_unix_timestamp(exp).ok(),
+        })
+    }
+}

--- a/foundation/auth/src/token_source/mod.rs
+++ b/foundation/auth/src/token_source/mod.rs
@@ -8,6 +8,7 @@ use crate::error::Error;
 use crate::token::Token;
 
 pub mod authorized_user_token_source;
+pub mod compute_identity_source;
 pub mod compute_token_source;
 pub mod reuse_token_source;
 pub mod service_account_token_source;


### PR DESCRIPTION
Adds a token source to fetch a JWT token from the metadata server for a specific audience.

See:

https://cloud.google.com/run/docs/authenticating/service-to-service#use_the_metadata_server