### PR TITLE
bigquery: Support storage api for query

### DIFF
--- a/bigquery/Cargo.toml
+++ b/bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-bigquery"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/bigquery"

--- a/bigquery/src/client.rs
+++ b/bigquery/src/client.rs
@@ -93,7 +93,7 @@ impl ClientConfig {
 
 use crate::http::job::get::GetJobRequest;
 use crate::http::job::list::ListJobsRequest;
-use crate::http::model::HolidayRegion::De;
+
 #[cfg(feature = "auth")]
 pub use google_cloud_auth;
 
@@ -284,7 +284,7 @@ impl Client {
     ///         ..Default::default()
     ///     };
     ///     let retry = ExponentialBuilder::default().with_max_times(10);
-    ///     let option = QueryOption::default().with_retry(retry);
+    ///     let option = QueryOption::default().with_retry(retry).with_enable_storage_read(true);
     ///     let mut iter = client.query_with_option::<Row>(project_id, request, option).await.unwrap();
     ///     while let Some(row) = iter.next().await.unwrap() {
     ///         let col1 = row.column::<String>(0);
@@ -410,7 +410,7 @@ impl Client {
                 break;
             }
         }
-        return Err(QueryError::NoChildJobs(job.clone()));
+        Err(QueryError::NoChildJobs(job.clone()))
     }
 
     async fn wait_for_query(
@@ -741,7 +741,7 @@ mod tests {
                     query: "SELECT * FROM rust_test_job.table_data_1686707863".to_string(),
                     ..Default::default()
                 },
-                option,
+                option.clone(),
             )
             .await
             .unwrap();
@@ -760,12 +760,13 @@ mod tests {
         }
         let mut data_as_struct: Vec<TestData> = vec![];
         let mut iterator_as_struct = client
-            .query::<TestData>(
+            .query_with_option::<TestData>(
                 &project_id,
                 QueryRequest {
                     query: "SELECT * FROM rust_test_job.table_data_1686707863".to_string(),
                     ..Default::default()
                 },
+                option,
             )
             .await
             .unwrap();

--- a/bigquery/src/http/bigquery_client.rs
+++ b/bigquery/src/http/bigquery_client.rs
@@ -104,10 +104,10 @@ pub(crate) mod test {
     use google_cloud_token::TokenSourceProvider;
 
     use crate::http::bigquery_client::{BigqueryClient, SCOPES};
+    use crate::http::query;
+    use crate::http::query::value::Decodable as QueryDecodable;
     use crate::http::table::{TableFieldMode, TableFieldSchema, TableFieldType, TableSchema};
     use crate::http::tabledata::list::Tuple;
-    use crate::query;
-    use crate::query::value::Decodable as QueryDecodable;
     use crate::storage;
     use crate::storage::array::ArrayRef;
     use crate::storage::value::Decodable as StorageDecodable;

--- a/bigquery/src/http/job/list.rs
+++ b/bigquery/src/http/job/list.rs
@@ -47,7 +47,7 @@ pub struct JobOverview {
     /// A result object that will be present only if the job has failed.
     pub error_result: Option<ErrorProto>,
     /// Output only. Information about the job, including starting time and ending time of the job.
-    pub statistics: JobStatistics,
+    pub statistics: Option<JobStatistics>,
     /// Required. Describes the job configuration.
     pub configuration: JobConfiguration,
     /// [Full-projection-only] Describes the status of this job.

--- a/bigquery/src/http/job/mod.rs
+++ b/bigquery/src/http/job/mod.rs
@@ -495,6 +495,8 @@ pub struct Job {
     pub status: JobStatus,
 }
 
+impl Job {}
+
 #[derive(Clone, PartialEq, serde::Deserialize, serde::Serialize, Debug, Default)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum JobState {
@@ -1163,4 +1165,30 @@ pub enum TrainingType {
     SingleTraining,
     /// Hyperparameter tuning training.
     HparamTuning,
+}
+
+pub fn is_select_query(statistics: &Option<JobStatistics>, config: &JobConfiguration) -> bool {
+    has_statement_type(statistics, config, "SELECT")
+}
+pub fn is_script(statistics: &Option<JobStatistics>, config: &JobConfiguration) -> bool {
+    has_statement_type(statistics, config, "SCRIPT")
+}
+fn has_statement_type(statistics: &Option<JobStatistics>, config: &JobConfiguration, statement_type: &str) -> bool {
+    match config.job {
+        JobType::Query(_) => {}
+        _ => return false,
+    }
+    let statistics = match &statistics {
+        Some(v) => v,
+        None => return false,
+    };
+    let query = match &statistics.query {
+        Some(v) => v,
+        None => return false,
+    };
+    let stmt = match &query.statement_type {
+        Some(v) => v,
+        None => return false,
+    };
+    return stmt == statement_type;
 }

--- a/bigquery/src/http/job/mod.rs
+++ b/bigquery/src/http/job/mod.rs
@@ -1190,5 +1190,5 @@ fn has_statement_type(statistics: &Option<JobStatistics>, config: &JobConfigurat
         Some(v) => v,
         None => return false,
     };
-    return stmt == statement_type;
+    stmt == statement_type
 }

--- a/bigquery/src/http/mod.rs
+++ b/bigquery/src/http/mod.rs
@@ -16,6 +16,7 @@ pub mod dataset;
 pub mod error;
 pub mod job;
 pub mod model;
+pub mod query;
 pub mod routine;
 pub mod row_access_policy;
 pub mod table;

--- a/bigquery/src/http/query.rs
+++ b/bigquery/src/http/query.rs
@@ -221,7 +221,7 @@ pub mod value {
         fn decode(value: &Value) -> Result<Self, Error> {
             match value {
                 Value::String(v) => {
-                    let split: Vec<&str> = v.split(".").collect();
+                    let split: Vec<&str> = v.split('.').collect();
                     let mut time = Time::parse(split[0], format_description!("[hour]:[minute]:[second]"))?;
                     if split.len() > 1 {
                         let micro: u64 = split[1].parse()?;

--- a/bigquery/src/http/query.rs
+++ b/bigquery/src/http/query.rs
@@ -1,0 +1,267 @@
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+
+use crate::http::bigquery_job_client::BigqueryJobClient;
+use crate::http::error::Error as HttpError;
+use crate::http::job::get_query_results::GetQueryResultsRequest;
+use crate::http::query::value::StructDecodable;
+use crate::http::tabledata::list::Tuple;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Http(#[from] HttpError),
+    #[error(transparent)]
+    Value(#[from] value::Error),
+}
+
+pub struct Iterator<T: StructDecodable> {
+    pub(crate) client: BigqueryJobClient,
+    pub(crate) project_id: String,
+    pub(crate) job_id: String,
+    pub(crate) request: GetQueryResultsRequest,
+    pub(crate) chunk: VecDeque<Tuple>,
+    pub(crate) force_first_fetch: bool,
+    pub total_size: i64,
+    pub(crate) _marker: PhantomData<T>,
+}
+
+impl<T: StructDecodable> Iterator<T> {
+    pub async fn next(&mut self) -> Result<Option<T>, Error> {
+        loop {
+            if let Some(v) = self.chunk.pop_front() {
+                return Ok(T::decode(v).map(Some)?);
+            }
+            if self.force_first_fetch {
+                self.force_first_fetch = false
+            } else if self.request.page_token.is_none() {
+                return Ok(None);
+            }
+            let response = self
+                .client
+                .get_query_results(self.project_id.as_str(), self.job_id.as_str(), &self.request)
+                .await?;
+            if response.rows.is_none() {
+                return Ok(None);
+            }
+            let v = response.rows.unwrap();
+            self.chunk = VecDeque::from(v);
+            self.request.page_token = response.page_token;
+        }
+    }
+}
+
+pub mod row {
+    use crate::http::query::value::StructDecodable;
+    use crate::http::tabledata::list::{Cell, Tuple};
+
+    #[derive(thiserror::Error, Debug)]
+    pub enum Error {
+        #[error("no data found: {0}")]
+        UnexpectedColumnIndex(usize),
+        #[error(transparent)]
+        Value(#[from] super::value::Error),
+    }
+
+    pub struct Row {
+        inner: Vec<Cell>,
+    }
+
+    impl Row {
+        pub fn column<'a, T: super::value::Decodable<'a>>(&'a self, index: usize) -> Result<T, Error> {
+            let cell: &Cell = self.inner.get(index).ok_or(Error::UnexpectedColumnIndex(index))?;
+            Ok(T::decode(&cell.v)?)
+        }
+    }
+
+    impl StructDecodable for Row {
+        fn decode(value: Tuple) -> Result<Self, crate::http::query::value::Error> {
+            Ok(Self { inner: value.f })
+        }
+    }
+}
+
+pub mod value {
+    use std::str::FromStr;
+
+    use base64::prelude::BASE64_STANDARD;
+    use base64::Engine;
+    use bigdecimal::BigDecimal;
+    use time::error::ComponentRange;
+    use time::macros::format_description;
+    use time::{Date, OffsetDateTime, Time};
+
+    use crate::http::tabledata::list::{Tuple, Value};
+
+    #[derive(thiserror::Error, Debug)]
+    pub enum Error {
+        #[error("invalid type")]
+        InvalidType,
+        #[error("unexpected null value")]
+        UnexpectedNullValue,
+        #[error(transparent)]
+        Timestamp(#[from] ComponentRange),
+        #[error("invalid number {0}")]
+        FromString(String),
+        #[error(transparent)]
+        Base64(#[from] base64::DecodeError),
+        #[error(transparent)]
+        ParseDateTime(#[from] time::error::Parse),
+        #[error(transparent)]
+        ParseBigDecimal(#[from] bigdecimal::ParseBigDecimalError),
+    }
+
+    pub trait Decodable<'a>: Sized {
+        fn decode(value: &'a Value) -> Result<Self, Error>;
+    }
+
+    pub trait StructDecodable: Sized {
+        fn decode(value: Tuple) -> Result<Self, Error>;
+    }
+
+    impl<'a, T: StructDecodable> Decodable<'a> for T {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::Struct(v) => T::decode(v.clone()),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    /*
+    impl<'a> Decodable<'a> for &'a str {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(v.as_str()),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+     */
+
+    impl<'a> Decodable<'a> for String {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(v.to_string()),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a> Decodable<'a> for Vec<u8> {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(BASE64_STANDARD.decode(v)?),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a> Decodable<'a> for bool {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(v.parse::<bool>().map_err(|_| Error::FromString(v.clone()))?),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a> Decodable<'a> for f64 {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(v.parse::<f64>().map_err(|_| Error::FromString(v.clone()))?),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a> Decodable<'a> for i64 {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(v.parse::<i64>().map_err(|_| Error::FromString(v.clone()))?),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a> Decodable<'a> for BigDecimal {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(BigDecimal::from_str(v)?),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a> Decodable<'a> for OffsetDateTime {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            let f = f64::decode(value)?;
+            let sec = f.trunc();
+            // Timestamps in BigQuery have microsecond precision, so we must
+            // return a round number of microseconds.
+            let micro = ((f - sec) * 1000000.0 + 0.5).trunc();
+            Ok(OffsetDateTime::from_unix_timestamp_nanos(
+                sec as i128 * 1_000_000_000 + micro as i128 * 1000,
+            )?)
+        }
+    }
+
+    impl<'a> Decodable<'a> for Date {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(Date::parse(v, format_description!("[year]-[month]-[day]"))?),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a> Decodable<'a> for Time {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::String(v) => Ok(Time::parse(v, format_description!("[hour]:[minute]:[second]"))?),
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a, T> Decodable<'a> for Vec<T>
+    where
+        T: Decodable<'a>,
+    {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::Array(v) => {
+                    let mut result = Vec::with_capacity(v.len());
+                    for element in v {
+                        result.push(T::decode(&element.v)?);
+                    }
+                    Ok(result)
+                }
+                Value::Null => Err(Error::UnexpectedNullValue),
+                _ => Err(Error::InvalidType),
+            }
+        }
+    }
+
+    impl<'a, T> Decodable<'a> for Option<T>
+    where
+        T: Decodable<'a>,
+    {
+        fn decode(value: &'a Value) -> Result<Self, Error> {
+            match value {
+                Value::Null => Ok(None),
+                _ => Ok(Some(T::decode(value)?)),
+            }
+        }
+    }
+}

--- a/bigquery/src/lib.rs
+++ b/bigquery/src/lib.rs
@@ -47,8 +47,8 @@
 //!         query: "SELECT * FROM dataset.table".to_string(),
 //!         ..Default::default()
 //!     };
-//!     let mut iter = client.query(project_id, request).await.unwrap();
-//!     while let Some(row) = iter.next::<Row>().await.unwrap() {
+//!     let mut iter = client.query::<Row>(project_id, request).await.unwrap();
+//!     while let Some(row) = iter.next().await.unwrap() {
 //!         let col1 = row.column::<String>(0);
 //!         let col2 = row.column::<Option<String>>(1);
 //!     }

--- a/bigquery/src/query.rs
+++ b/bigquery/src/query.rs
@@ -71,8 +71,8 @@ pub mod row {
     }
 
     impl Row {
-        pub fn column<'a, T: http::query::value::Decodable<'a> + storage::value::Decodable>(
-            &'a self,
+        pub fn column<T: http::query::value::Decodable + storage::value::Decodable>(
+            &self,
             index: usize,
         ) -> Result<T, Error> {
             Ok(match &self.inner {

--- a/bigquery/src/query.rs
+++ b/bigquery/src/query.rs
@@ -5,7 +5,8 @@ use crate::http::bigquery_job_client::BigqueryJobClient;
 use crate::http::error::Error as HttpError;
 use crate::http::job::get_query_results::GetQueryResultsRequest;
 use crate::http::tabledata::list::Tuple;
-use crate::query::value::StructDecodable;
+use crate::query::row::RowType;
+use crate::{http, storage};
 
 #[derive(Debug, Clone, Default)]
 pub struct QueryOption {
@@ -23,256 +24,77 @@ impl QueryOption {
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    Http(#[from] HttpError),
+    Http(#[from] http::query::Error),
     #[error(transparent)]
-    Value(#[from] value::Error),
+    Storage(#[from] storage::Error),
 }
 
-pub struct Iterator {
-    pub(crate) client: BigqueryJobClient,
-    pub(crate) project_id: String,
-    pub(crate) job_id: String,
-    pub(crate) request: GetQueryResultsRequest,
-    pub(crate) chunk: VecDeque<Tuple>,
-    pub(crate) force_first_fetch: bool,
+pub enum QueryResult<T: http::query::value::StructDecodable + storage::value::StructDecodable> {
+    Http(http::query::Iterator<T>),
+    Storage(storage::Iterator<T>),
+}
+
+pub struct Iterator<T: http::query::value::StructDecodable + storage::value::StructDecodable> {
+    pub(crate) inner: QueryResult<T>,
     pub total_size: i64,
 }
 
-impl Iterator {
-    pub async fn next<T: StructDecodable>(&mut self) -> Result<Option<T>, Error> {
-        loop {
-            if let Some(v) = self.chunk.pop_front() {
-                return Ok(T::decode(v).map(Some)?);
-            }
-            if self.force_first_fetch {
-                self.force_first_fetch = false
-            } else if self.request.page_token.is_none() {
-                return Ok(None);
-            }
-            let response = self
-                .client
-                .get_query_results(self.project_id.as_str(), self.job_id.as_str(), &self.request)
-                .await?;
-            if response.rows.is_none() {
-                return Ok(None);
-            }
-            let v = response.rows.unwrap();
-            self.chunk = VecDeque::from(v);
-            self.request.page_token = response.page_token;
-        }
+impl<T: http::query::value::StructDecodable + storage::value::StructDecodable> Iterator<T> {
+    pub async fn next(&mut self) -> Result<Option<T>, Error> {
+        Ok(match self.inner {
+            QueryResult::Storage(ref mut v) => v.next().await?,
+            QueryResult::Http(ref mut v) => v.next().await?,
+        })
     }
 }
 
 pub mod row {
-
     use crate::http::tabledata::list::{Cell, Tuple};
-    use crate::query::value::StructDecodable;
+    use crate::{http, storage};
+    use arrow::array::ArrayRef;
 
     #[derive(thiserror::Error, Debug)]
     pub enum Error {
-        #[error("no data found: {0}")]
-        UnexpectedColumnIndex(usize),
         #[error(transparent)]
-        Value(#[from] super::value::Error),
+        Http(#[from] http::query::row::Error),
+        #[error(transparent)]
+        Storage(#[from] storage::row::Error),
+    }
+
+    pub enum RowType {
+        Http(http::query::row::Row),
+        Storage(storage::row::Row),
     }
 
     pub struct Row {
-        inner: Vec<Cell>,
+        inner: RowType,
     }
 
     impl Row {
-        pub fn column<'a, T: super::value::Decodable<'a>>(&'a self, index: usize) -> Result<T, Error> {
-            let cell: &Cell = self.inner.get(index).ok_or(Error::UnexpectedColumnIndex(index))?;
-            Ok(T::decode(&cell.v)?)
+        pub fn column<'a, T: http::query::value::Decodable<'a> + storage::value::Decodable>(
+            &'a self,
+            index: usize,
+        ) -> Result<T, Error> {
+            Ok(match &self.inner {
+                RowType::Http(row) => row.column(index)?,
+                RowType::Storage(row) => row.column(index)?,
+            })
         }
     }
 
-    impl StructDecodable for Row {
-        fn decode(value: Tuple) -> Result<Self, crate::query::value::Error> {
-            Ok(Self { inner: value.f })
-        }
-    }
-}
-
-pub mod value {
-    use std::str::FromStr;
-
-    use base64::prelude::BASE64_STANDARD;
-    use base64::Engine;
-    use bigdecimal::BigDecimal;
-    use time::error::ComponentRange;
-    use time::macros::format_description;
-    use time::{Date, OffsetDateTime, Time};
-
-    use crate::http::tabledata::list::{Tuple, Value};
-
-    #[derive(thiserror::Error, Debug)]
-    pub enum Error {
-        #[error("invalid type")]
-        InvalidType,
-        #[error("unexpected null value")]
-        UnexpectedNullValue,
-        #[error(transparent)]
-        Timestamp(#[from] ComponentRange),
-        #[error("invalid number {0}")]
-        FromString(String),
-        #[error(transparent)]
-        Base64(#[from] base64::DecodeError),
-        #[error(transparent)]
-        ParseDateTime(#[from] time::error::Parse),
-        #[error(transparent)]
-        ParseBigDecimal(#[from] bigdecimal::ParseBigDecimalError),
-    }
-
-    pub trait Decodable<'a>: Sized {
-        fn decode(value: &'a Value) -> Result<Self, Error>;
-    }
-
-    pub trait StructDecodable: Sized {
-        fn decode(value: Tuple) -> Result<Self, Error>;
-    }
-
-    impl<'a, T: StructDecodable> Decodable<'a> for T {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::Struct(v) => T::decode(v.clone()),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
+    impl http::query::value::StructDecodable for Row {
+        fn decode(value: Tuple) -> Result<Self, http::query::value::Error> {
+            Ok(Self {
+                inner: RowType::Http(http::query::row::Row::decode(value)?),
+            })
         }
     }
 
-    impl<'a> Decodable<'a> for &'a str {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(v.as_str()),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for String {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(v.to_string()),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for Vec<u8> {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(BASE64_STANDARD.decode(v)?),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for bool {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(v.parse::<bool>().map_err(|_| Error::FromString(v.clone()))?),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for f64 {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(v.parse::<f64>().map_err(|_| Error::FromString(v.clone()))?),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for i64 {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(v.parse::<i64>().map_err(|_| Error::FromString(v.clone()))?),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for BigDecimal {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(BigDecimal::from_str(v)?),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for OffsetDateTime {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            let f = f64::decode(value)?;
-            let sec = f.trunc();
-            // Timestamps in BigQuery have microsecond precision, so we must
-            // return a round number of microseconds.
-            let micro = ((f - sec) * 1000000.0 + 0.5).trunc();
-            Ok(OffsetDateTime::from_unix_timestamp_nanos(
-                sec as i128 * 1_000_000_000 + micro as i128 * 1000,
-            )?)
-        }
-    }
-
-    impl<'a> Decodable<'a> for Date {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(Date::parse(v, format_description!("[year]-[month]-[day]"))?),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a> Decodable<'a> for Time {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::String(v) => Ok(Time::parse(v, format_description!("[hour]:[minute]:[second]"))?),
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a, T> Decodable<'a> for Vec<T>
-    where
-        T: Decodable<'a>,
-    {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::Array(v) => {
-                    let mut result = Vec::with_capacity(v.len());
-                    for element in v {
-                        result.push(T::decode(&element.v)?);
-                    }
-                    Ok(result)
-                }
-                Value::Null => Err(Error::UnexpectedNullValue),
-                _ => Err(Error::InvalidType),
-            }
-        }
-    }
-
-    impl<'a, T> Decodable<'a> for Option<T>
-    where
-        T: Decodable<'a>,
-    {
-        fn decode(value: &'a Value) -> Result<Self, Error> {
-            match value {
-                Value::Null => Ok(None),
-                _ => Ok(Some(T::decode(value)?)),
-            }
+    impl storage::value::StructDecodable for Row {
+        fn decode_arrow(fields: &[ArrayRef], row_no: usize) -> Result<Self, storage::value::Error> {
+            Ok(Self {
+                inner: RowType::Storage(storage::row::Row::decode_arrow(fields, row_no)?),
+            })
         }
     }
 }

--- a/bigquery/src/query.rs
+++ b/bigquery/src/query.rs
@@ -1,11 +1,5 @@
 pub use backon::*;
-use std::collections::VecDeque;
 
-use crate::http::bigquery_job_client::BigqueryJobClient;
-use crate::http::error::Error as HttpError;
-use crate::http::job::get_query_results::GetQueryResultsRequest;
-use crate::http::tabledata::list::Tuple;
-use crate::query::row::RowType;
 use crate::{http, storage};
 
 #[derive(Debug, Clone)]
@@ -64,7 +58,7 @@ impl<T: http::query::value::StructDecodable + storage::value::StructDecodable> I
 }
 
 pub mod row {
-    use crate::http::tabledata::list::{Cell, Tuple};
+    use crate::http::tabledata::list::Tuple;
     use crate::{http, storage};
     use arrow::array::ArrayRef;
 

--- a/bigquery/src/query.rs
+++ b/bigquery/src/query.rs
@@ -19,8 +19,8 @@ pub struct QueryOption {
 impl Default for QueryOption {
     fn default() -> Self {
         Self {
-            enable_storage_read: true,
-            retry: ExponentialBuilder::default()
+            enable_storage_read: false,
+            retry: ExponentialBuilder::default().with_max_times(usize::MAX),
         }
     }
 }

--- a/bigquery/src/query.rs
+++ b/bigquery/src/query.rs
@@ -8,15 +8,30 @@ use crate::http::tabledata::list::Tuple;
 use crate::query::row::RowType;
 use crate::{http, storage};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct QueryOption {
     /// Exponential back off retry setting
     pub(crate) retry: ExponentialBuilder,
+    /// true: use storage api is page token is empty
+    pub(crate) enable_storage_read: bool,
+}
+
+impl Default for QueryOption {
+    fn default() -> Self {
+        Self {
+            enable_storage_read: true,
+            retry: ExponentialBuilder::default()
+        }
+    }
 }
 
 impl QueryOption {
     pub fn with_retry(mut self, builder: ExponentialBuilder) -> Self {
         self.retry = builder;
+        self
+    }
+    pub fn with_enable_storage_read(mut self, value: bool) -> Self {
+        self.enable_storage_read = value;
         self
     }
 }

--- a/bigquery/src/storage.rs
+++ b/bigquery/src/storage.rs
@@ -318,7 +318,15 @@ pub mod value {
             match col.data_type() {
                 DataType::Time64(TimeUnit::Microsecond) => {
                     let micros = downcast::<Time64MicrosecondArray>(col)?.value(row_no);
-                    Ok(Time::from_hms_micro(0, 0, 0, micros as u32)?)
+                    // ex) TIME(15, 30, 01) is 55801000000
+                    // TODO test
+                    let hour = micros / 3600_000000;
+                    let rest_micros = micros % 3600_000000;
+                    let minute = rest_micros/ 60_000000 ;
+                    let rest_micros = rest_micros % 60_000000 ;
+                    let secs = rest_micros / 1_000_000;
+                    let rest_micros= rest_micros % 1_000_000;
+                    Ok(Time::from_hms_micro(hour as u8, minute as u8, secs as u8, rest_micros as u32)?)
                 }
                 _ => Err(Error::InvalidDataType(col.data_type().clone(), "Time")),
             }

--- a/bigquery/src/storage.rs
+++ b/bigquery/src/storage.rs
@@ -319,13 +319,13 @@ pub mod value {
                 DataType::Time64(TimeUnit::Microsecond) => {
                     let micros = downcast::<Time64MicrosecondArray>(col)?.value(row_no);
                     // ex) TIME(15, 30, 01) is 55801000000
-                    // TODO test
+                    // ex) TIME_ADD(TIME(15, 30, 01), INTERVAL 10 MICROSECOND) is 55801000010
                     let hour = micros / 3600_000000;
                     let rest_micros = micros % 3600_000000;
-                    let minute = rest_micros/ 60_000000 ;
-                    let rest_micros = rest_micros % 60_000000 ;
+                    let minute = rest_micros / 60_000000;
+                    let rest_micros = rest_micros % 60_000000;
                     let secs = rest_micros / 1_000_000;
-                    let rest_micros= rest_micros % 1_000_000;
+                    let rest_micros = rest_micros % 1_000_000;
                     Ok(Time::from_hms_micro(hour as u8, minute as u8, secs as u8, rest_micros as u32)?)
                 }
                 _ => Err(Error::InvalidDataType(col.data_type().clone(), "Time")),


### PR DESCRIPTION
`QueryOption::default().with_enable_storage_read(true)` enables storage read API for query.

#177 

```rust
async fn run(client: &Client, project_id: &str) {
    let request = QueryRequest {
             query: "SELECT * FROM dataset.table".to_string(),
            ..Default::default()
    };
    let option = QueryOption::default().with_enable_storage_read(true);
    let mut iter = client.query_with_option::<Row>(project_id, request, option).await.unwrap();
     while let Some(row) = iter.next().await.unwrap() {
         let col1 = row.column::<String>(0);
         let col2 = row.column::<Option<String>>(1);
     }
}
```