### PR TITLE
ci: use actively maintained rust toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,35 +26,22 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1
-        name: format check
-        with:
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1
-        name: clippy check
-        with:
-          command: clippy
-          args: -- -D warnings
+      - name: format check
+        run: cargo fmt --all -- --check
+      - name: clippy check
+        run: cargo clippy -- -D warnings
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v0.6.0
         with:
           service_account_key: ${{ secrets.STORAGE_CREDENTIALS }}
           export_default_credentials: true
-      - uses: actions-rs/cargo@v1
-        name: auth-test
-        with:
-          command: test
-          args: --release --all-features --manifest-path foundation/auth/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        name: gax-test
-        with:
-          command: test
-          args: --release --all-features --manifest-path foundation/gax/Cargo.toml
+      - name: auth-test
+        run: cargo test --release --all-features --manifest-path foundation/auth/Cargo.toml
+      - name: gax-test
+        run: cargo test --release --all-features --manifest-path foundation/gax/Cargo.toml
       - name: cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
@@ -81,17 +68,12 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        name: test
-        with:
-          command: test
-          args: --release --all-features --manifest-path pubsub/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - name: test
         env:
           PUBSUB_EMULATOR_HOST: localhost:8681
           RUSTFLAGS: "-A dead_code -A unused"
+        run: cargo test --release --all-features --manifest-path pubsub/Cargo.toml
   spanner:
     name: spanner
     runs-on: ubuntu-latest
@@ -129,30 +111,22 @@ jobs:
           SPANNER_INSTANCE_ID: test-instance
           SPANNER_DATABASE_ID: local-database
           SPANNER_EMULATOR_HOST: 172.17.0.1:9010
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v0.6.0
         with:
           service_account_key: ${{ secrets.STORAGE_CREDENTIALS }}
           export_default_credentials: true
-      - uses: actions-rs/cargo@v1
-        name: test
-        with:
-          command: test
-          args: --release --all-features --manifest-path spanner/Cargo.toml
+      - name: test
         env:
           SPANNER_EMULATOR_HOST: localhost:9010
           RUSTFLAGS: "-A dead_code -A unused"
-      - uses: actions-rs/cargo@v1
-        name: test-derive
-        with:
-          command: test
-          args: --release --all-features --manifest-path spanner-derive/Cargo.toml
+        run: cargo test --release --all-features --manifest-path spanner/Cargo.toml
+      - name: test-derive
         env:
           SPANNER_EMULATOR_HOST: localhost:9010
           RUSTFLAGS: "-A dead_code -A unused"
+        run: cargo test --release --all-features --manifest-path spanner-derive/Cargo.toml
   storage:
     name: storage
     runs-on: ubuntu-latest
@@ -174,16 +148,11 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        name: test
-        with:
-          command: test
-          args: --release --all-features --manifest-path storage/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - name: test
         env:
           RUSTFLAGS: "-A dead_code -A unused"
+        run: cargo test --release --all-features --manifest-path storage/Cargo.toml
   bigquery:
     name: bigquery
     runs-on: ubuntu-latest
@@ -205,13 +174,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        name: test
-        with:
-          command: test
-          args: --release --all-features --manifest-path bigquery/Cargo.toml
+      - uses: dtolnay/rust-toolchain@stable
+      - name: test
         env:
           RUSTFLAGS: "-A dead_code -A unused"
+        run: cargo test --release --all-features --manifest-path bigquery/Cargo.toml


### PR DESCRIPTION
[actions-rs](https://github.com/actions-rs) was marked as archived and will not maintained in the future. (toolchain and cargo have not been maintained for a long time already though.)

So I replaced the GitHub Action with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain). The author of this repository contributes very famous Rust related repositories and the repository is maintained actively.