### PR TITLE
default token source: avoid double boxing error

### DIFF
--- a/foundation/auth/src/token.rs
+++ b/foundation/auth/src/token.rs
@@ -105,7 +105,7 @@ pub struct DefaultTokenSource {
 #[async_trait]
 impl TokenSource for DefaultTokenSource {
     async fn token(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let token = self.inner.token().await.map_err(Box::new)?;
+        let token = self.inner.token().await?;
         Ok(format!("Bearer {0}", token.access_token))
     }
 }


### PR DESCRIPTION
The double boxing interferes with downcasting the error properly.