### PR TITLE
Switch from reqwest::Client to reqwest_middleware::Client

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.15.0"
 edition = "2021"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/storage"
-keywords = ["gcp","gcs","storage","googleapis","google-cloud-rust"]
+keywords = ["gcp", "gcs", "storage", "googleapis", "google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform storage client library."
@@ -12,20 +12,32 @@ documentation = "https://docs.rs/google-cloud-storage/latest/google_cloud_storag
 
 [dependencies]
 google-cloud-token = { version = "0.1.1", path = "../foundation/token" }
-pkcs8 = {version="0.10", features=["pem"]}
+pkcs8 = { version = "0.10", features = ["pem"] }
 thiserror = "1.0"
-time = { version = "0.3", features = ["std", "macros", "formatting", "parsing", "serde"] }
+time = { version = "0.3", features = [
+    "std",
+    "macros",
+    "formatting",
+    "parsing",
+    "serde",
+] }
 base64 = "0.21"
 regex = "1.9"
 sha2 = "0.10"
 ring = "0.17"
-tokio = { version="1.32", features=["macros"] }
+tokio = { version = "1.32", features = ["macros"] }
 async-stream = "0.3"
 once_cell = "1.18"
 hex = "0.4"
 url = "2.4"
 tracing = "0.1"
-reqwest = { version = "0.11", features = ["json", "stream", "multipart"], default-features = false }
+reqwest = { version = "0.11", features = [
+    "json",
+    "stream",
+    "multipart",
+], default-features = false }
+reqwest-middleware = "0.2"
+anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 percent-encoding = "2.3"
@@ -34,20 +46,20 @@ bytes = "1.5"
 async-trait = "0.1"
 
 google-cloud-metadata = { optional = true, version = "0.4", path = "../foundation/metadata" }
-google-cloud-auth = { optional = true, version = "0.13", path="../foundation/auth", default-features=false }
+google-cloud-auth = { optional = true, version = "0.13", path = "../foundation/auth", default-features = false }
 
 [dev-dependencies]
-tokio = { version="1.32", features=["rt-multi-thread"] }
+tokio = { version = "1.32", features = ["rt-multi-thread"] }
 serial_test = "0.9"
-tracing-subscriber = { version="0.3.17", features=["env-filter"]}
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 ctor = "0.1.26"
-tokio-util =  {version ="0.7", features = ["codec"] }
-google-cloud-auth = { path = "../foundation/auth", default-features=false }
+tokio-util = { version = "0.7", features = ["codec"] }
+google-cloud-auth = { path = "../foundation/auth", default-features = false }
 
 [features]
 default = ["default-tls", "auth"]
-default-tls = ["reqwest/default-tls","google-cloud-auth?/default-tls"]
-rustls-tls = ["reqwest/rustls-tls","google-cloud-auth?/rustls-tls"]
+default-tls = ["reqwest/default-tls", "google-cloud-auth?/default-tls"]
+rustls-tls = ["reqwest/rustls-tls", "google-cloud-auth?/rustls-tls"]
 trace = []
 auth = ["google-cloud-auth", "google-cloud-metadata"]
 external-account = ["google-cloud-auth?/external-account"]

--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -11,7 +11,7 @@ use crate::sign::{create_signed_buffer, RsaKeyPair, SignBy, SignedURLError, Sign
 
 #[derive(Debug)]
 pub struct ClientConfig {
-    pub http: Option<reqwest::Client>,
+    pub http: Option<reqwest_middleware::ClientWithMiddleware>,
     pub storage_endpoint: String,
     pub service_account_endpoint: String,
     pub token_source_provider: Option<Box<dyn TokenSourceProvider>>,
@@ -125,7 +125,9 @@ impl Client {
                 None
             }
         };
-        let http = config.http.unwrap_or_default();
+        let http = config
+            .http
+            .unwrap_or_else(|| reqwest_middleware::ClientBuilder::new(reqwest::Client::default()).build());
 
         let service_account_client =
             ServiceAccountClient::new(ts.clone(), config.service_account_endpoint.as_str(), http.clone());

--- a/storage/src/http/bucket_access_controls/delete.rs
+++ b/storage/src/http/bucket_access_controls/delete.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/bucket_access_controls/get.rs
+++ b/storage/src/http/bucket_access_controls/get.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/bucket_access_controls/insert.rs
+++ b/storage/src/http/bucket_access_controls/insert.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::bucket_access_controls::BucketACLRole;
 use crate::http::Escape;

--- a/storage/src/http/bucket_access_controls/list.rs
+++ b/storage/src/http/bucket_access_controls/list.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::bucket_access_controls::BucketAccessControl;
 use crate::http::Escape;

--- a/storage/src/http/bucket_access_controls/patch.rs
+++ b/storage/src/http/bucket_access_controls/patch.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::bucket_access_controls::BucketAccessControl;
 use crate::http::Escape;

--- a/storage/src/http/buckets/delete.rs
+++ b/storage/src/http/buckets/delete.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/buckets/get.rs
+++ b/storage/src/http/buckets/get.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::Projection;
 use crate::http::Escape;

--- a/storage/src/http/buckets/get_iam_policy.rs
+++ b/storage/src/http/buckets/get_iam_policy.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/buckets/insert.rs
+++ b/storage/src/http/buckets/insert.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::bucket_access_controls::{BucketAccessControl, PredefinedBucketAcl};
 use crate::http::buckets::{Billing, Cors, Encryption, IamConfiguration, Lifecycle, Logging, Versioning, Website};

--- a/storage/src/http/buckets/list.rs
+++ b/storage/src/http/buckets/list.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::buckets::Bucket;
 use crate::http::object_access_controls::Projection;

--- a/storage/src/http/buckets/list_channels.rs
+++ b/storage/src/http/buckets/list_channels.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::channels::Channel;
 use crate::http::Escape;

--- a/storage/src/http/buckets/lock_retention_policy.rs
+++ b/storage/src/http/buckets/lock_retention_policy.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/buckets/patch.rs
+++ b/storage/src/http/buckets/patch.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::bucket_access_controls::{BucketAccessControl, PredefinedBucketAcl};
 use crate::http::buckets::insert::RetentionPolicyCreationConfig;

--- a/storage/src/http/buckets/set_iam_policy.rs
+++ b/storage/src/http/buckets/set_iam_policy.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::buckets::Policy;
 use crate::http::Escape;

--- a/storage/src/http/buckets/test_iam_permissions.rs
+++ b/storage/src/http/buckets/test_iam_permissions.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/channels/stop.rs
+++ b/storage/src/http/channels/stop.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::channels::WatchableChannel;
 

--- a/storage/src/http/default_object_access_controls/delete.rs
+++ b/storage/src/http/default_object_access_controls/delete.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/default_object_access_controls/get.rs
+++ b/storage/src/http/default_object_access_controls/get.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/default_object_access_controls/insert.rs
+++ b/storage/src/http/default_object_access_controls/insert.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::insert::ObjectAccessControlCreationConfig;
 use crate::http::Escape;

--- a/storage/src/http/default_object_access_controls/list.rs
+++ b/storage/src/http/default_object_access_controls/list.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::ObjectAccessControl;
 use crate::http::Escape;

--- a/storage/src/http/default_object_access_controls/patch.rs
+++ b/storage/src/http/default_object_access_controls/patch.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::ObjectAccessControl;
 use crate::http::Escape;

--- a/storage/src/http/hmac_keys/create.rs
+++ b/storage/src/http/hmac_keys/create.rs
@@ -1,5 +1,5 @@
 use reqwest::header::CONTENT_LENGTH;
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::hmac_keys::HmacKeyMetadata;
 use crate::http::Escape;

--- a/storage/src/http/hmac_keys/delete.rs
+++ b/storage/src/http/hmac_keys/delete.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/hmac_keys/get.rs
+++ b/storage/src/http/hmac_keys/get.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/hmac_keys/list.rs
+++ b/storage/src/http/hmac_keys/list.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::hmac_keys::HmacKeyMetadata;
 use crate::http::Escape;

--- a/storage/src/http/hmac_keys/update.rs
+++ b/storage/src/http/hmac_keys/update.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::hmac_keys::HmacKeyMetadata;
 use crate::http::Escape;

--- a/storage/src/http/notifications/delete.rs
+++ b/storage/src/http/notifications/delete.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/notifications/get.rs
+++ b/storage/src/http/notifications/get.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/notifications/insert.rs
+++ b/storage/src/http/notifications/insert.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::notifications::{EventType, PayloadFormat};
 use crate::http::Escape;

--- a/storage/src/http/notifications/list.rs
+++ b/storage/src/http/notifications/list.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::notifications::Notification;
 use crate::http::Escape;

--- a/storage/src/http/object_access_controls/delete.rs
+++ b/storage/src/http/object_access_controls/delete.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 /// Request message for GetObjectAccessControl.
 #[derive(Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, Debug, Default)]

--- a/storage/src/http/object_access_controls/get.rs
+++ b/storage/src/http/object_access_controls/get.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 /// Request message for GetObjectAccessControl.
 #[derive(Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, Debug, Default)]

--- a/storage/src/http/object_access_controls/insert.rs
+++ b/storage/src/http/object_access_controls/insert.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::ObjectACLRole;
 

--- a/storage/src/http/object_access_controls/list.rs
+++ b/storage/src/http/object_access_controls/list.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 /// Request message for GetObjectAccessControl.
 #[derive(Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, Debug, Default)]

--- a/storage/src/http/object_access_controls/patch.rs
+++ b/storage/src/http/object_access_controls/patch.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::ObjectAccessControl;
 

--- a/storage/src/http/objects/compose.rs
+++ b/storage/src/http/objects/compose.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::PredefinedObjectAcl;
 use crate::http::objects::{Encryption, Object, SourceObjects};

--- a/storage/src/http/objects/copy.rs
+++ b/storage/src/http/objects/copy.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::objects::{Encryption, Object};
 use crate::http::{object_access_controls::Projection, Escape};

--- a/storage/src/http/objects/delete.rs
+++ b/storage/src/http/objects/delete.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::Escape;
 

--- a/storage/src/http/objects/download.rs
+++ b/storage/src/http/objects/download.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::objects::get::GetObjectRequest;
 use crate::http::Escape;

--- a/storage/src/http/objects/get.rs
+++ b/storage/src/http/objects/get.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::Projection;
 use crate::http::objects::Encryption;

--- a/storage/src/http/objects/list.rs
+++ b/storage/src/http/objects/list.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::Projection;
 use crate::http::objects::Object;

--- a/storage/src/http/objects/mod.rs
+++ b/storage/src/http/objects/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use reqwest::RequestBuilder;
+use reqwest_middleware::RequestBuilder;
+
 use time::OffsetDateTime;
 
 use crate::http::object_access_controls::ObjectAccessControl;

--- a/storage/src/http/objects/patch.rs
+++ b/storage/src/http/objects/patch.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::bucket_access_controls::PredefinedBucketAcl;
 use crate::http::object_access_controls::Projection;

--- a/storage/src/http/objects/rewrite.rs
+++ b/storage/src/http/objects/rewrite.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::{PredefinedObjectAcl, Projection};
 use crate::http::objects::{Encryption, Object};

--- a/storage/src/http/objects/upload.rs
+++ b/storage/src/http/objects/upload.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use reqwest::multipart::{Form, Part};
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::object_access_controls::{PredefinedObjectAcl, Projection};
 use crate::http::objects::{Encryption, Object};

--- a/storage/src/http/objects/watch_all.rs
+++ b/storage/src/http/objects/watch_all.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, RequestBuilder};
+use reqwest_middleware::{ClientWithMiddleware as Client, RequestBuilder};
 
 use crate::http::channels::WatchableChannel;
 use crate::http::object_access_controls::Projection;

--- a/storage/src/http/resumable_upload_client.rs
+++ b/storage/src/http/resumable_upload_client.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
 use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE};
-use reqwest::{Body, Client, Response};
+use reqwest::{Body, Response};
+use reqwest_middleware::ClientWithMiddleware as Client;
 
 use crate::http::{check_response_status, objects::Object, Error};
 

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -8,11 +8,15 @@ use crate::http::{check_response_status, Error};
 pub struct ServiceAccountClient {
     ts: Option<Arc<dyn TokenSource>>,
     v1_endpoint: String,
-    http: reqwest::Client,
+    http: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl ServiceAccountClient {
-    pub(crate) fn new(ts: Option<Arc<dyn TokenSource>>, endpoint: &str, http: reqwest::Client) -> Self {
+    pub(crate) fn new(
+        ts: Option<Arc<dyn TokenSource>>,
+        endpoint: &str,
+        http: reqwest_middleware::ClientWithMiddleware,
+    ) -> Self {
         Self {
             ts,
             v1_endpoint: format!("{endpoint}/v1"),
@@ -59,6 +63,7 @@ struct SignBlobResponse {
 #[cfg(test)]
 mod test {
     use reqwest::Client;
+    use reqwest_middleware::ClientBuilder;
     use serial_test::serial;
 
     use google_cloud_auth::project::Config;
@@ -78,7 +83,11 @@ mod test {
         let email = tsp.source_credentials.clone().unwrap().client_email.unwrap();
         let ts = tsp.token_source();
         (
-            ServiceAccountClient::new(Some(ts), "https://iamcredentials.googleapis.com", Client::default()),
+            ServiceAccountClient::new(
+                Some(ts),
+                "https://iamcredentials.googleapis.com",
+                ClientBuilder::new(Client::default()).build(),
+            ),
             email,
         )
     }


### PR DESCRIPTION

This PR replace the use of `reqwest::Client` by `reqwest_middleware`.

The change will allow users to pass their custom middleware client to add custom logic around GCS requests.
Such custom logic can be anything, but in particular (my personal need) a custom retry policy and strategy.