### PR TITLE
Improve documentation for subscribing with exactly-once delivery

### DIFF
--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -341,6 +341,8 @@ impl Subscription {
 
     /// pull get message synchronously.
     /// It blocks until at least one message is available.
+    ///
+    /// NOTE: this is the recommended function to use when receiving messages from a subscription with exactly-once delivery.
     pub async fn pull(&self, max_messages: i32, retry: Option<RetrySetting>) -> Result<Vec<ReceivedMessage>, Status> {
         #[allow(deprecated)]
         let req = PullRequest {
@@ -366,6 +368,9 @@ impl Subscription {
 
     /// subscribe creates a `Stream` of `ReceivedMessage`
     /// Terminates the underlying `Subscriber` when dropped.
+    ///
+    /// NOTE: for subscriptions with exactly-once delivery,
+    /// use `pull` instead.
     /// ```no_test
     /// use google_cloud_pubsub::client::Client;
     /// use google_cloud_pubsub::subscription::Subscription;


### PR DESCRIPTION
I just spent a week troubleshooting, because I was using `subscribe()` to receive messages from my Pub/Sub subscription, and strangely, most acked messages were getting redelivered.

At first I thought that my Pub/Sub monitoring was broken. I was calling `message.ack()`, but the metrics in Cloud Console showed that the number of unacked messages wasn't decreasing.

The problem was that calling `subscribe()` on a subscription with exactly-once delivery only allows the first received message to be acked. The rest of the messages delivered, but calling `message.ack()` returned an error status, and then the subscription would redeliver them. 

Once I started to using `pull()` instead, everything started working as expected.

This PR adds a note in the documentation that `pull()` is recommended over `subscribe()` for subscriptions with exactly-once delivery. And hopefully prevents someone else from another long week of debugging.
