### PR TITLE
auth: Support URL type external account source

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "rust-analyzer.linkedProjects": [
+    "./foundation/auth/Cargo.toml"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "rust-analyzer.linkedProjects": [
-    "./foundation/auth/Cargo.toml"
-  ]
-}

--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -4,40 +4,40 @@ version = "0.13.1"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/auth"
-keywords = ["gcp","auth","googleapis","google-cloud-rust"]
+keywords = ["gcp", "auth", "googleapis", "google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform server application authentication library."
 
 [dependencies]
 tracing = "0.1"
-reqwest = { version="0.11", features = ["json"], default-features = false }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = {  version = "1.0" }
+serde_json = { version = "1.0" }
 jsonwebtoken = { version = "9.2.0" }
 thiserror = "1.0"
 async-trait = "0.1"
 home = "0.5"
 urlencoding = "2.1"
-tokio = { version = "1.32", features = ["fs"]}
+tokio = { version = "1.32", features = ["fs"] }
 google-cloud-metadata = { version = "0.4.0", path = "../metadata" }
 google-cloud-token = { version = "0.1.1", path = "../token" }
 base64 = "0.21"
 time = "0.3"
 
-url = { version="2.4", optional = true }
-path-clean = { version="1.0", optional = true }
-sha2 = {version = "0.10", optional = true}
-percent-encoding = { version="2.3", optional = true }
+url = { version = "2.4", optional = true }
+path-clean = { version = "1.0", optional = true }
+sha2 = { version = "0.10", optional = true }
+percent-encoding = { version = "2.3", optional = true }
 hmac = { version = "0.12", optional = true }
 hex = { version = "0.4", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.32", features = ["test-util", "rt-multi-thread", "macros"]}
-tracing-subscriber = {version="0.3", features=["env-filter","std"]}
+tokio = { version = "1.32", features = ["test-util", "rt-multi-thread", "macros"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "std"] }
 ctor = "0.1"
 tempfile = "3.8.0"
-temp-env = {version="0.3.6", features = ["async_closure",]}
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [features]
 default = ["default-tls"]

--- a/foundation/auth/src/token_source/external_account_source/error.rs
+++ b/foundation/auth/src/token_source/external_account_source/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("Unsupported Subject Token Source")]
     UnsupportedSubjectTokenSource,
 
+    #[error("Unsupported Format Type")]
+    UnsupportedFormatType,
+
     #[error(transparent)]
     HttpError(#[from] reqwest::Error),
 
@@ -46,6 +49,15 @@ pub enum Error {
 
     #[error("Missing Subject Token Type")]
     MissingSubjectTokenType,
+
+    #[error("Missing Headers")]
+    MissingHeaders,
+
+    #[error("Missing Format")]
+    MissingFormat,
+
+    #[error("Missing Subject Token Field Name")]
+    MissingSubjectTokenFieldName,
 
     #[error(transparent)]
     InvalidHashLength(#[from] sha2::digest::InvalidLength),

--- a/foundation/auth/src/token_source/external_account_source/url_subject_token_source.rs
+++ b/foundation/auth/src/token_source/external_account_source/url_subject_token_source.rs
@@ -39,19 +39,19 @@ impl UrlSubjectTokenSource {
         }
 
         let body = response.text_with_charset("utf-8").await?;
-        let limit = body.chars().take(1 << 20).collect::<String>(); // Limiting the response body to 1MB
+        let body = body.chars().take(1 << 20).collect::<String>(); // Limiting the response body to 1MB
 
         let format_type = self.format.tp.as_str();
         match format_type {
             "json" => {
-                let data: Value = serde_json::from_str(&limit).map_err(Error::JsonError)?;
+                let data: Value = serde_json::from_str(&body).map_err(Error::JsonError)?;
                 if let Some(token) = data[&self.format.subject_token_field_name].as_str() {
                     Ok(token.to_string())
                 } else {
                     Err(Error::MissingSubjectTokenFieldName)
                 }
             }
-            "text" | "" => Ok(limit),
+            "text" | "" => Ok(body),
             _ => Err(Error::UnsupportedFormatType),
         }
     }

--- a/foundation/auth/src/token_source/external_account_source/url_subject_token_source.rs
+++ b/foundation/auth/src/token_source/external_account_source/url_subject_token_source.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use reqwest::Client;
 use serde_json::Value;
 use std::collections::HashMap;
 use url::Url;
@@ -26,7 +25,7 @@ impl UrlSubjectTokenSource {
     }
 
     async fn create_subject_token(&self) -> Result<String, Error> {
-        let client = Client::new();
+        let client = default_http_client();
         let mut request = client.get(self.url.clone());
 
         for (key, val) in &self.headers {
@@ -43,7 +42,6 @@ impl UrlSubjectTokenSource {
         let limit = body.chars().take(1 << 20).collect::<String>(); // Limiting the response body to 1MB
 
         let format_type = self.format.tp.as_str();
-
         match format_type {
             "json" => {
                 let data: Value = serde_json::from_str(&limit).map_err(Error::JsonError)?;

--- a/foundation/auth/src/token_source/external_account_source/url_subject_token_source.rs
+++ b/foundation/auth/src/token_source/external_account_source/url_subject_token_source.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::Value;
+use std::collections::HashMap;
+use url::Url;
+
+use crate::credentials::{CredentialSource, Format};
+use crate::token_source::default_http_client;
+use crate::token_source::external_account_source::error::Error;
+use crate::token_source::external_account_source::subject_token_source::SubjectTokenSource;
+
+pub struct UrlSubjectTokenSource {
+    url: Url,
+    headers: HashMap<String, String>,
+    format: Format,
+}
+
+impl UrlSubjectTokenSource {
+    pub async fn new(value: CredentialSource) -> Result<Self, Error> {
+        let url = value.url.ok_or(Error::MissingTokenURL)?;
+        let url = Url::parse(&url).map_err(Error::URLError)?;
+        let headers = value.headers.ok_or(Error::MissingHeaders)?;
+        let format = value.format.ok_or(Error::MissingFormat)?;
+
+        Ok(Self { url, headers, format })
+    }
+
+    async fn create_subject_token(&self) -> Result<String, Error> {
+        let client = Client::new();
+        let mut request = client.get(self.url.clone());
+
+        for (key, val) in &self.headers {
+            request = request.header(key, val);
+        }
+
+        let response = request.send().await.map_err(Error::HttpError)?;
+
+        if !response.status().is_success() {
+            return Err(Error::UnexpectedStatusOnGetSessionToken(response.status().as_u16()));
+        }
+
+        let body = response.text_with_charset("utf-8").await?;
+        let limit = body.chars().take(1 << 20).collect::<String>(); // Limiting the response body to 1MB
+
+        let format_type = self.format.tp.as_str();
+
+        match format_type {
+            "json" => {
+                let data: Value = serde_json::from_str(&limit).map_err(Error::JsonError)?;
+                if let Some(token) = data[&self.format.subject_token_field_name].as_str() {
+                    Ok(token.to_string())
+                } else {
+                    Err(Error::MissingSubjectTokenFieldName)
+                }
+            }
+            "text" | "" => Ok(limit),
+            _ => Err(Error::UnsupportedFormatType),
+        }
+    }
+}
+
+#[async_trait]
+impl SubjectTokenSource for UrlSubjectTokenSource {
+    async fn subject_token(&self) -> Result<String, Error> {
+        self.create_subject_token().await
+    }
+}


### PR DESCRIPTION
This PR updates `google-cloud-auth` to support URL type external account source. By this update, Workload Identity Federation for Github Actions can be enabled.

From: https://github.com/yoshidan/google-cloud-rust/issues/233