### PR TITLE
Change default subscriber config

### DIFF
--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -325,10 +325,10 @@ mod tests {
         let config = ReceiveConfig {
             worker_count: 2,
             channel_capacity: None,
-            subscriber_config: SubscriberConfig {
+            subscriber_config: Some(SubscriberConfig {
                 ping_interval: Duration::from_secs(1),
                 ..Default::default()
-            },
+            }),
         };
         let cancel_receiver = cancellation_token.clone();
         let (s, mut r) = tokio::sync::mpsc::channel(100);
@@ -631,6 +631,8 @@ mod tests_in_gcp {
                     break;
                 }
                 let msg_id = &message.message.message_id;
+                // heavy task
+                tokio::time::sleep(Duration::from_secs(1)).await;
                 *msgs.entry(msg_id.clone()).or_insert(0) += 1;
                 message.ack().await.unwrap();
             }
@@ -638,7 +640,7 @@ mod tests_in_gcp {
             msgs
         });
 
-        tokio::time::sleep(Duration::from_secs(30)).await;
+        tokio::time::sleep(Duration::from_secs(60)).await;
 
         // check redelivered messages
         ctx.cancel();

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -1,3 +1,4 @@
+use std::cmp::{max, min};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -605,7 +606,7 @@ impl Subscription {
         }
         let cfg = self.config(None).await?;
         let mut default_cfg = SubscriberConfig {
-            stream_ack_deadline_seconds: cfg.1.ack_deadline_seconds,
+            stream_ack_deadline_seconds: max(min(cfg.1.ack_deadline_seconds, 600), 10),
             ..Default::default()
         };
         if cfg.1.enable_exactly_once_delivery {

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -213,7 +213,7 @@ where
         })
     }
 
-    pub(crate) fn set_call_options(&mut self, option: CallOptions) {
+    pub fn set_call_options(&mut self, option: CallOptions) {
         self.reader_option = Some(option);
     }
 


### PR DESCRIPTION
Use server `ack_deadline_seconds` setting for subscribe to be able to ack even if it takes a long time in exactly once delivery.
#236