### PR TITLE
Fix ComputeIdentitySource::token()

### DIFF
--- a/foundation/auth/src/token_source/compute_identity_source.rs
+++ b/foundation/auth/src/token_source/compute_identity_source.rs
@@ -47,7 +47,7 @@ impl ComputeIdentitySource {
 
         Ok(ComputeIdentitySource {
             token_url: format!(
-                "http://{}/computeMetadata/v1/instance/service-accounts/default/identity?audience={}",
+                "http://{}/computeMetadata/v1/instance/service-accounts/default/identity?audience={}&format=full",
                 host,
                 encode(audience)
             ),

--- a/foundation/auth/src/token_source/compute_identity_source.rs
+++ b/foundation/auth/src/token_source/compute_identity_source.rs
@@ -42,6 +42,7 @@ impl ComputeIdentitySource {
         // Only used to extract the expiry without checking the signature.
         let mut validation = Validation::default();
         validation.insecure_disable_signature_validation();
+        validation.set_audience(&[audience]);
         let decoding_key = jsonwebtoken::DecodingKey::from_secret(b"");
 
         Ok(ComputeIdentitySource {


### PR DESCRIPTION
There are two issues.
## 1. Can't pass JWT validation

This issue is almost the same with [this issue](https://github.com/yoshidan/google-cloud-rust/issues/248).

### Solution
Set audience to pass the validation

## 2. ID Token claims doesn't include email field.

### Solution
Add `format=full` to query parameter.
If this parameter is missing, JWT doesn't include email field. Sorry I can't find the official documentation about this specification.
However, I found [Golang client implementation](https://github.com/googleapis/google-api-go-client/blob/a11ef60f2a28101378ad81d3e553ffb90b43b653/idtoken/compute.go#L41).