### PR TITLE
Updated the error when application credentials aren't found

### DIFF
--- a/foundation/auth/src/credentials.rs
+++ b/foundation/auth/src/credentials.rs
@@ -138,7 +138,7 @@ impl CredentialsFile {
             }
         }?;
 
-        let credentials_json = fs::read(path).await?;
+        let credentials_json = fs::read(path).await.map_err(Error::CredentialsIOError)?;
 
         Ok(credentials_json)
     }


### PR DESCRIPTION
Hi!

I on boarded a new developer today, and we couldn't get PubSub working in our backend. The error message that we received was that the file was not found (Not specifying the file name). We debugged and figured we should submit this.

Thanks for the awesome crate, we use it in production here and have had no issues.

Isaac