### PR TITLE
Impl ToKind for slices

### DIFF
--- a/spanner/src/statement.rs
+++ b/spanner/src/statement.rs
@@ -254,6 +254,21 @@ impl<T> ToKind for Vec<T>
 where
     T: ToKind,
 {
+    #[inline]
+    fn to_kind(&self) -> Kind {
+        self.as_slice().to_kind()
+    }
+
+    #[inline]
+    fn get_type() -> Type {
+        <&[T] as ToKind>::get_type()
+    }
+}
+
+impl<'a, T> ToKind for &'a [T]
+where
+    T: ToKind,
+{
     fn to_kind(&self) -> Kind {
         value::Kind::ListValue(ListValue {
             values: self
@@ -264,6 +279,7 @@ where
                 .collect(),
         })
     }
+
     fn get_type() -> Type {
         Type {
             code: TypeCode::Array.into(),


### PR DESCRIPTION
# Why?

Since Slices are always foreign types `ToKind` isn't implementable for `&[MyStruct]`, even if `MyStruct` implements `ToKind` [error reference](https://doc.rust-lang.org/error_codes/E0117.html).

An implementation exists for `Vec<T>`, but that would require a triple-allocation in some cases, first the upstream to create the collection, then the api which gets a slice, then the downstream implementation (this one)  which creates a new vector by invoking `to_kind`, it would be nice to not have to do that.

# Solution

Implement `ToKind` for slices of type `T`. 

Just copies the vec implementation which doesn't need ownership of the vector since it invokes `to_kind` from references. The implementation then inlines a proxy call to the slice implementation in the vec implementation, because they're identical.

# Notes 

The Vec<T> impl isn't really necessary since it doesn't require ownership and could be removed in a later major version, then a user could just do a `my_vec.as_ref().to_kind()`, or pass `&my_vec` into any function that takes a `ToKind`