### PR TITLE
[pubsub] Cancellable MessageStream 

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -196,7 +196,7 @@ async fn run(config: ClientConfig, ct: CancellationToken) -> Result<(), Status> 
      let mut stream = subscription.subscribe(Some(config)).await.unwrap();
 
      // None if the CancellationToken is cancelled
-     while let Some(message) = stream.read() {
+     while let Some(message) = stream.read().await {
          message.ack().await.unwrap();
      }
      Ok(())

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -182,27 +182,23 @@ async fn run(config: ClientConfig) -> Result<(), Status> {
 ```rust
 use google_cloud_pubsub::client::{Client, ClientConfig};
 use google_cloud_googleapis::pubsub::v1::PubsubMessage;
-use google_cloud_pubsub::subscription::SubscriptionConfig;
+use google_cloud_pubsub::subscription::{SubscribeConfig, SubscriptionConfig};
 use google_cloud_gax::grpc::Status;
 use tokio_util::sync::CancellationToken;
-use futures_util::StreamExt;
 
-async fn run(config: ClientConfig, cancel: CancellationToken) -> Result<(), Status> {
+async fn run(config: ClientConfig, ct: CancellationToken) -> Result<(), Status> {
      // Creating Client, Topic and Subscription...
      let client = Client::new(config).await.unwrap();
      let subscription = client.subscription("test-subscription");
 
      // Read the messages as a stream
-     let mut stream = subscription.subscribe(None).await.unwrap();
-     while let Some(message) = tokio::select! {
-         msg = stream.next() => msg,
-         _ = cancel.cancelled() => None
-     } {
+     let config = SubscribeConfig::default().with_cancellation_token(ct);
+     let mut stream = subscription.subscribe(Some(config)).await.unwrap();
+
+     // None if the CancellationToken is cancelled
+     while let Some(message) = stream.read() {
          message.ack().await.unwrap();
      }
-     stream.dispose().await;
-
-     // Wait for stream dispose
      Ok(())
 }
 ```

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -197,7 +197,7 @@ async fn run(config: ClientConfig) -> Result<(), Status> {
      let mut stream = subscription.subscribe(None).await.unwrap();
      let cancellable = stream.cancellable();
      let task = tokio::spawn(async move {
-         // None if the CancellationToken is cancelled
+         // None if the stream is cancelled
          while let Some(message) = stream.next().await {
              message.ack().await.unwrap();
          }
@@ -226,7 +226,7 @@ async fn run(config: ClientConfig) -> Result<(), Status> {
      let mut stream = subscription.subscribe(None).await.unwrap();
      let cancellable = stream.cancellable();
      let task = tokio::spawn(async move {
-         // None if the CancellationToken is cancelled
+         // None if the stream is cancelled
          while let Some(message) = stream.read().await {
              message.ack().await.unwrap();
          }

--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -697,9 +697,9 @@ mod tests_in_gcp {
         let sub_task = tokio::spawn(async move {
             tracing::info!("start subscriber");
             // None when the ctx_sub is cancelled
-            while let Some(message) = stream.next().await {
+            while let Some(message) = stream.read().await {
                 tracing::info!("message received {}", &message.message.message_id);
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                tokio::time::sleep(Duration::from_secs(10)).await;
                 message.ack().await.unwrap();
             }
             tracing::info!("finish subscriber");

--- a/pubsub/src/lib.rs
+++ b/pubsub/src/lib.rs
@@ -172,27 +172,23 @@
 //! ```
 //! use google_cloud_pubsub::client::{Client, ClientConfig};
 //! use google_cloud_googleapis::pubsub::v1::PubsubMessage;
-//! use google_cloud_pubsub::subscription::SubscriptionConfig;
+//! use google_cloud_pubsub::subscription::{SubscribeConfig, SubscriptionConfig};
 //! use google_cloud_gax::grpc::Status;
 //! use tokio_util::sync::CancellationToken;
-//! use futures_util::StreamExt;
 //!
-//! async fn run(config: ClientConfig, cancel: CancellationToken) -> Result<(), Status> {
+//! async fn run(config: ClientConfig, ct: CancellationToken) -> Result<(), Status> {
 //!     // Creating Client, Topic and Subscription...
 //!     let client = Client::new(config).await.unwrap();
 //!     let subscription = client.subscription("test-subscription");
 //!
 //!     // Read the messages as a stream
-//!     let mut stream = subscription.subscribe(None).await.unwrap();
-//!     while let Some(message) = tokio::select! {
-//!         msg = stream.next() => msg,
-//!         _ = cancel.cancelled() => None
-//!     } {
+//!     let config = SubscribeConfig::default().with_cancellation_token(ct);
+//!     let mut stream = subscription.subscribe(Some(config)).await.unwrap();
+//!
+//!     // None if the CancellationToken is cancelled
+//!     while let Some(message) = stream.read().await {
 //!         message.ack().await.unwrap();
 //!     }
-//!     stream.dispose().await;
-//!
-//!     // Wait for stream dispose
 //!     Ok(())
 //! }
 //! ```

--- a/pubsub/src/lib.rs
+++ b/pubsub/src/lib.rs
@@ -187,7 +187,7 @@
 //!     let mut stream = subscription.subscribe(None).await.unwrap();
 //!     let cancellable = stream.cancellable();
 //!     let task = tokio::spawn(async move {
-//!         // None if the CancellationToken is cancelled
+//!         // None if the stream is cancelled
 //!         while let Some(message) = stream.next().await {
 //!             message.ack().await.unwrap();
 //!         }
@@ -216,7 +216,7 @@
 //!     let mut stream = subscription.subscribe(None).await.unwrap();
 //!     let cancellable = stream.cancellable();
 //!     let task = tokio::spawn(async move {
-//!         // None if the CancellationToken is cancelled
+//!         // None if the tream is cancelled
 //!         while let Some(message) = stream.read().await {
 //!             message.ack().await.unwrap();
 //!         }

--- a/pubsub/src/lib.rs
+++ b/pubsub/src/lib.rs
@@ -169,26 +169,61 @@
 //!
 //! ### Subscribe Message (Alternative Way)
 //!
+//! After canceling, wait until all pulled messages are processed.
 //! ```
+//! use std::time::Duration;
+//! use futures_util::StreamExt;
 //! use google_cloud_pubsub::client::{Client, ClientConfig};
 //! use google_cloud_googleapis::pubsub::v1::PubsubMessage;
 //! use google_cloud_pubsub::subscription::{SubscribeConfig, SubscriptionConfig};
 //! use google_cloud_gax::grpc::Status;
-//! use tokio_util::sync::CancellationToken;
 //!
-//! async fn run(config: ClientConfig, ct: CancellationToken) -> Result<(), Status> {
+//! async fn run(config: ClientConfig) -> Result<(), Status> {
 //!     // Creating Client, Topic and Subscription...
 //!     let client = Client::new(config).await.unwrap();
 //!     let subscription = client.subscription("test-subscription");
 //!
 //!     // Read the messages as a stream
-//!     let config = SubscribeConfig::default().with_cancellation_token(ct);
-//!     let mut stream = subscription.subscribe(Some(config)).await.unwrap();
+//!     let mut stream = subscription.subscribe(None).await.unwrap();
+//!     let cancellable = stream.cancellable();
+//!     let task = tokio::spawn(async move {
+//!         // None if the CancellationToken is cancelled
+//!         while let Some(message) = stream.next().await {
+//!             message.ack().await.unwrap();
+//!         }
+//!     });
+//!     tokio::time::sleep(Duration::from_secs(60)).await;
+//!     cancellable.cancel();
+//!     let _ = task.await;
+//!     Ok(())
+//! }
+//! ```
 //!
-//!     // None if the CancellationToken is cancelled
-//!     while let Some(message) = stream.read().await {
-//!         message.ack().await.unwrap();
-//!     }
+//! Unprocessed messages are nack after cancellation.
+//! ```
+//! use std::time::Duration;
+//! use google_cloud_pubsub::client::{Client, ClientConfig};
+//! use google_cloud_googleapis::pubsub::v1::PubsubMessage;
+//! use google_cloud_pubsub::subscription::{SubscribeConfig, SubscriptionConfig};
+//! use google_cloud_gax::grpc::Status;
+//!
+//! async fn run(config: ClientConfig) -> Result<(), Status> {
+//!     // Creating Client, Topic and Subscription...
+//!     let client = Client::new(config).await.unwrap();
+//!     let subscription = client.subscription("test-subscription");
+//!
+//!     // Read the messages as a stream
+//!     let mut stream = subscription.subscribe(None).await.unwrap();
+//!     let cancellable = stream.cancellable();
+//!     let task = tokio::spawn(async move {
+//!         // None if the CancellationToken is cancelled
+//!         while let Some(message) = stream.read().await {
+//!             message.ack().await.unwrap();
+//!         }
+//!     });
+//!     tokio::time::sleep(Duration::from_secs(60)).await;
+//!     cancellable.cancel();
+//!     let _ = task.await;
 //!     Ok(())
 //! }
 //! ```

--- a/pubsub/src/subscriber.rs
+++ b/pubsub/src/subscriber.rs
@@ -273,12 +273,12 @@ async fn handle_message(
                 received_message.ack_id.clone(),
                 (received_message.delivery_attempt > 0).then_some(received_message.delivery_attempt as usize),
             );
-            let should_nack =  select! {
+            let should_nack = select! {
                 result = queue.send(msg) => result.is_err(),
                 _ = cancel.cancelled() => true
             };
             if should_nack {
-                tracing::trace!("cancelled -> so nack immediately : msg_id={id}");
+                tracing::info!("cancelled -> so nack immediately : msg_id={id}");
                 nack_targets.push(received_message.ack_id);
             }
         }

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -412,7 +412,6 @@ impl Subscription {
     }
 
     /// subscribe creates a `Stream` of `ReceivedMessage`
-    /// Terminates the underlying `Subscriber` when dropped.
     /// ```
     /// use google_cloud_pubsub::subscription::{SubscribeConfig, Subscription};
     /// use tokio::select;

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -177,7 +177,7 @@ impl MessageStream {
         if message.is_none() {
             self.dispose().await;
         }
-        return message;
+        message
     }
 }
 
@@ -432,7 +432,7 @@ impl Subscription {
     pub async fn subscribe(&self, opt: Option<SubscribeConfig>) -> Result<MessageStream, Status> {
         let opt = opt.unwrap_or_default();
         let (tx, rx) = create_channel(opt.channel_capacity);
-        let cancel = opt.cancellation_token.unwrap_or(CancellationToken::new());
+        let cancel = opt.cancellation_token.unwrap_or_default();
         let sub_opt = self.unwrap_subscribe_config(opt.subscriber_config).await?;
 
         // spawn a separate subscriber task for each connection in the pool


### PR DESCRIPTION
Added `MessageStream#cancellable()` to finish subscribe messages gracefully.

https://github.com/yoshidan/google-cloud-rust/issues/266

```rust
use std::time::Duration;
use futures_util::StreamExt;
use google_cloud_pubsub::client::{Client, ClientConfig};
use google_cloud_googleapis::pubsub::v1::PubsubMessage;
use google_cloud_pubsub::subscription::{SubscribeConfig, SubscriptionConfig};
use google_cloud_gax::grpc::Status;

async fn run(config: ClientConfig) -> Result<(), Status> {
     // Creating Client, Topic and Subscription...
     let client = Client::new(config).await.unwrap();
     let subscription = client.subscription("test-subscription");

     // Read the messages as a stream
     let mut stream = subscription.subscribe(None).await.unwrap();
     let cancellable = stream.cancellable();
     let task = tokio::spawn(async move {
         // None if the stream is cancelled
         while let Some(message) = stream.next().await {
             message.ack().await.unwrap();
         }
     });
     tokio::time::sleep(Duration::from_secs(60)).await;
     cancellable.cancel();
     let _ = task.await;
     Ok(())
}
```