### PR TITLE
Remove gen.com from auth crate

### DIFF
--- a/foundation/auth/src/token.rs
+++ b/foundation/auth/src/token.rs
@@ -13,7 +13,6 @@ use crate::project::{
 use crate::token_source::TokenSource as InternalTokenSource;
 
 pub const TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
-pub const AUTH_URL: &str = "https://accounts.gen.com/o/oauth2/auth";
 
 #[derive(Debug, Clone)]
 pub struct Token {


### PR DESCRIPTION
Though I don't know and cannot guess what this is, I'd like to remove it to prevent users from accidentally using it, which might be malicious at some point.