### PR TITLE
feat: support both identity and token source for gke metadata server mode

### DIFF
--- a/artifact-registry/src/client.rs
+++ b/artifact-registry/src/client.rs
@@ -49,6 +49,7 @@ impl ClientConfig {
             audience: None,
             scopes: Some(&SCOPES),
             sub: None,
+            ..Default::default()
         }
     }
 }

--- a/bigquery/src/client.rs
+++ b/bigquery/src/client.rs
@@ -132,6 +132,7 @@ impl ClientConfig {
             audience: None,
             scopes: Some(&crate::http::bigquery_client::SCOPES),
             sub: None,
+            ..Default::default()
         }
     }
 
@@ -140,6 +141,7 @@ impl ClientConfig {
             audience: Some(crate::grpc::apiv1::conn_pool::AUDIENCE),
             scopes: Some(&crate::grpc::apiv1::conn_pool::SCOPES),
             sub: None,
+            ..Default::default()
         }
     }
 }

--- a/bigquery/src/http/bigquery_client.rs
+++ b/bigquery/src/http/bigquery_client.rs
@@ -135,6 +135,7 @@ pub(crate) mod test {
             audience: None,
             scopes: Some(&SCOPES),
             sub: None,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/foundation/auth/src/idtoken.rs
+++ b/foundation/auth/src/idtoken.rs
@@ -68,7 +68,7 @@ pub async fn create_id_token_source(
     }
 }
 
-async fn id_token_source_from_credentials(
+pub(crate) async fn id_token_source_from_credentials(
     custom_claims: &HashMap<String, serde_json::Value>,
     credentials: &CredentialsFile,
     audience: &str,

--- a/foundation/auth/src/project.rs
+++ b/foundation/auth/src/project.rs
@@ -107,14 +107,14 @@ pub async fn create_token_source_from_project(
         }
         Project::FromMetadataServer(_) => {
             if config.use_id_token {
-                let ts = ComputeIdentitySource::new(&config.audience.unwrap_or_default())?;
+                let ts = ComputeIdentitySource::new(config.audience.unwrap_or_default())?;
                 let token = ts.token().await?;
                 Ok(Box::new(ReuseTokenSource::new(Box::new(ts), token)))
             } else {
                 if config.scopes.is_none() {
                     return Err(error::Error::ScopeOrAudienceRequired);
                 }
-                let ts = ComputeTokenSource::new(&config.scopes_to_string(","))?;
+                let ts = ComputeTokenSource::new(config.scopes_to_string(",").as_str())?;
                 let token = ts.token().await?;
                 Ok(Box::new(ReuseTokenSource::new(Box::new(ts), token)))
             }

--- a/kms/src/client.rs
+++ b/kms/src/client.rs
@@ -47,6 +47,7 @@ impl ClientConfig {
             audience: None,
             scopes: Some(&SCOPES),
             sub: None,
+            ..Default::default()
         }
     }
 }

--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -81,6 +81,7 @@ impl ClientConfig {
             audience: Some(crate::apiv1::conn_pool::AUDIENCE),
             scopes: Some(&crate::apiv1::conn_pool::SCOPES),
             sub: None,
+            ..Default::default()
         }
     }
 }

--- a/spanner/src/client.rs
+++ b/spanner/src/client.rs
@@ -128,6 +128,7 @@ impl ClientConfig {
             audience: Some(crate::apiv1::conn_pool::AUDIENCE),
             scopes: Some(&crate::apiv1::conn_pool::SCOPES),
             sub: None,
+            ..Default::default()
         }
     }
 }

--- a/spanner/tests/change_stream_test.rs
+++ b/spanner/tests/change_stream_test.rs
@@ -114,6 +114,7 @@ async fn create_environment() -> Environment {
         audience: Some(google_cloud_spanner::apiv1::conn_pool::AUDIENCE),
         scopes: Some(&google_cloud_spanner::apiv1::conn_pool::SCOPES),
         sub: None,
+        ..Default::default()
     })
     .await
     .unwrap();

--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -118,6 +118,7 @@ impl ClientConfig {
             audience: None,
             scopes: Some(&crate::http::storage_client::SCOPES),
             sub: None,
+            ..Default::default()
         }
     }
 }

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -77,6 +77,7 @@ mod test {
             audience: None,
             scopes: Some(&["https://www.googleapis.com/auth/cloud-platform"]),
             sub: None,
+            ..Default::default()
         })
         .await
         .unwrap();

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1421,6 +1421,7 @@ pub(crate) mod test {
             audience: None,
             scopes: Some(&SCOPES),
             sub: None,
+            ..Default::default()
         })
         .await
         .unwrap();


### PR DESCRIPTION
# Description

The changes included in this PR give us the ability to generate different token types when relying on the GKE metadata server.

In the current version, only OAuth 2.0 tokens can be generated.

# What was done

In the exact same way as when using the Credential File mode, we know can:

- generate a JWT identity token when providing an `audience`
- generate a OAuth 2.0 token when providing `scopes`

This is useful when we want to access remote services (across shared VPC, VPC, PSC, whatever) like custom services, cloud run instances that are protected with basic authentication.

# How has it been tested

- No unit tests (no existing ones)
- Tested within a GKE server and against remote (different project location) Vertex AI endpoints: using the usual OAuth 2.0 tokens.
- Tested within a GKE server and against remote (different project location) Cloud Run service: with a Private Service Connect setup in between, using JWT identity tokens with specifying the Cloud Run's URL as audience and granting `cloud.run.invoker` role to the service account used.