### PR TITLE
Add setter to auth Config

### DIFF
--- a/artifact-registry/src/client.rs
+++ b/artifact-registry/src/client.rs
@@ -45,12 +45,7 @@ impl ClientConfig {
     }
 
     fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config {
-            audience: None,
-            scopes: Some(&SCOPES),
-            sub: None,
-            ..Default::default()
-        }
+        google_cloud_auth::project::Config::default().with_scopes(&SCOPES)
     }
 }
 

--- a/bigquery/src/client.rs
+++ b/bigquery/src/client.rs
@@ -128,14 +128,13 @@ impl ClientConfig {
     }
 
     fn bigquery_http_auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config::default().with_scopes(&crate::http::bigquery_client::SCOPES)
+        google_cloud_auth::project::Config::default().with_scopes(&http::bigquery_client::SCOPES)
     }
 
     fn bigquery_grpc_auth_config() -> google_cloud_auth::project::Config<'static> {
         google_cloud_auth::project::Config::default()
             .with_audience(crate::grpc::apiv1::conn_pool::AUDIENCE)
             .with_scopes(&crate::grpc::apiv1::conn_pool::SCOPES)
-        }
     }
 }
 

--- a/bigquery/src/client.rs
+++ b/bigquery/src/client.rs
@@ -128,20 +128,13 @@ impl ClientConfig {
     }
 
     fn bigquery_http_auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config {
-            audience: None,
-            scopes: Some(&crate::http::bigquery_client::SCOPES),
-            sub: None,
-            ..Default::default()
-        }
+        google_cloud_auth::project::Config::default().with_scopes(&crate::http::bigquery_client::SCOPES)
     }
 
     fn bigquery_grpc_auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config {
-            audience: Some(crate::grpc::apiv1::conn_pool::AUDIENCE),
-            scopes: Some(&crate::grpc::apiv1::conn_pool::SCOPES),
-            sub: None,
-            ..Default::default()
+        google_cloud_auth::project::Config::default()
+            .with_audience(crate::grpc::apiv1::conn_pool::AUDIENCE)
+            .with_scopes(&crate::grpc::apiv1::conn_pool::SCOPES)
         }
     }
 }

--- a/bigquery/src/http/bigquery_client.rs
+++ b/bigquery/src/http/bigquery_client.rs
@@ -131,7 +131,9 @@ pub(crate) mod test {
     }
 
     pub async fn create_client() -> (BigqueryClient, String) {
-        let tsp = DefaultTokenSourceProvider::new(Config::default().with_scopes(&SCOPES)).await.unwrap();
+        let tsp = DefaultTokenSourceProvider::new(Config::default().with_scopes(&SCOPES))
+            .await
+            .unwrap();
         let cred = tsp.source_credentials.clone();
         let ts = tsp.token_source();
         let client = BigqueryClient::new(

--- a/bigquery/src/http/bigquery_client.rs
+++ b/bigquery/src/http/bigquery_client.rs
@@ -131,14 +131,7 @@ pub(crate) mod test {
     }
 
     pub async fn create_client() -> (BigqueryClient, String) {
-        let tsp = DefaultTokenSourceProvider::new(Config {
-            audience: None,
-            scopes: Some(&SCOPES),
-            sub: None,
-            ..Default::default()
-        })
-        .await
-        .unwrap();
+        let tsp = DefaultTokenSourceProvider::new(Config::default().with_scopes(&SCOPES)).await.unwrap();
         let cred = tsp.source_credentials.clone();
         let ts = tsp.token_source();
         let client = BigqueryClient::new(

--- a/foundation/auth/src/project.rs
+++ b/foundation/auth/src/project.rs
@@ -19,18 +19,38 @@ const EXTERNAL_ACCOUNT_KEY: &str = "external_account";
 
 #[derive(Debug, Clone, Default)]
 pub struct Config<'a> {
-    pub audience: Option<&'a str>,
-    pub scopes: Option<&'a [&'a str]>,
-    pub sub: Option<&'a str>,
-    pub use_id_token: bool,
+    audience: Option<&'a str>,
+    scopes: Option<&'a [&'a str]>,
+    sub: Option<&'a str>,
+    use_id_token: bool,
 }
 
-impl Config<'_> {
+impl <'a> Config<'a> {
     pub fn scopes_to_string(&self, sep: &str) -> String {
         match self.scopes {
             Some(s) => s.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(sep),
             None => EMPTY.to_string(),
         }
+    }
+
+    pub fn with_audience(mut self, value: &'a str) -> Self {
+        self.audience = Some(value);
+        self
+    }
+
+    pub fn with_scopes(mut self, value: &'a [&'a str]) -> Self {
+        self.scopes = Some(value);
+        self
+    }
+
+    pub fn with_sub(mut self, value: &'a str) -> Self {
+        self.sub = Some(value);
+        self
+    }
+
+    pub fn with_use_id_token(mut self, value: bool) -> Self {
+        self.use_id_token = value;
+        self
     }
 }
 

--- a/foundation/auth/src/project.rs
+++ b/foundation/auth/src/project.rs
@@ -25,7 +25,7 @@ pub struct Config<'a> {
     use_id_token: bool,
 }
 
-impl <'a> Config<'a> {
+impl<'a> Config<'a> {
     pub fn scopes_to_string(&self, sep: &str) -> String {
         match self.scopes {
             Some(s) => s.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(sep),

--- a/kms/src/client.rs
+++ b/kms/src/client.rs
@@ -43,12 +43,7 @@ impl ClientConfig {
     }
 
     fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config {
-            audience: None,
-            scopes: Some(&SCOPES),
-            sub: None,
-            ..Default::default()
-        }
+        google_cloud_auth::project::Config::default().with_scopes(&SCOPES)
     }
 }
 

--- a/pubsub/src/client.rs
+++ b/pubsub/src/client.rs
@@ -77,12 +77,9 @@ impl ClientConfig {
     }
 
     fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config {
-            audience: Some(crate::apiv1::conn_pool::AUDIENCE),
-            scopes: Some(&crate::apiv1::conn_pool::SCOPES),
-            sub: None,
-            ..Default::default()
-        }
+        google_cloud_auth::project::Config::default()
+            .with_audience(crate::apiv1::conn_pool::AUDIENCE)
+            .with_scopes(&crate::apiv1::conn_pool::SCOPES)
     }
 }
 

--- a/spanner/src/client.rs
+++ b/spanner/src/client.rs
@@ -124,12 +124,9 @@ impl ClientConfig {
     }
 
     fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config {
-            audience: Some(crate::apiv1::conn_pool::AUDIENCE),
-            scopes: Some(&crate::apiv1::conn_pool::SCOPES),
-            sub: None,
-            ..Default::default()
-        }
+        google_cloud_auth::project::Config::default()
+            .with_audience(crate::apiv1::conn_pool::AUDIENCE)
+            .with_scopes(&crate::apiv1::conn_pool::SCOPES)
     }
 }
 

--- a/spanner/tests/change_stream_test.rs
+++ b/spanner/tests/change_stream_test.rs
@@ -110,12 +110,11 @@ impl TryFromStruct for DataChangeRecord {
 }
 
 async fn create_environment() -> Environment {
-    let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(google_cloud_auth::project::Config {
-        audience: Some(google_cloud_spanner::apiv1::conn_pool::AUDIENCE),
-        scopes: Some(&google_cloud_spanner::apiv1::conn_pool::SCOPES),
-        sub: None,
-        ..Default::default()
-    })
+    let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(
+        google_cloud_auth::project::Config::default()
+            .with_audience(&google_cloud_spanner::apiv1::conn_pool::AUDIENCE)
+            .with_scopes(&google_cloud_spanner::apiv1::conn_pool::SCOPES)
+    )
     .await
     .unwrap();
     GoogleCloud(Box::new(ts))

--- a/spanner/tests/change_stream_test.rs
+++ b/spanner/tests/change_stream_test.rs
@@ -112,8 +112,8 @@ impl TryFromStruct for DataChangeRecord {
 async fn create_environment() -> Environment {
     let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(
         google_cloud_auth::project::Config::default()
-            .with_audience(&google_cloud_spanner::apiv1::conn_pool::AUDIENCE)
-            .with_scopes(&google_cloud_spanner::apiv1::conn_pool::SCOPES)
+            .with_audience(google_cloud_spanner::apiv1::conn_pool::AUDIENCE)
+            .with_scopes(&google_cloud_spanner::apiv1::conn_pool::SCOPES),
     )
     .await
     .unwrap();

--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -114,12 +114,7 @@ impl ClientConfig {
     }
 
     fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config {
-            audience: None,
-            scopes: Some(&crate::http::storage_client::SCOPES),
-            sub: None,
-            ..Default::default()
-        }
+        google_cloud_auth::project::Config::default().with_scopes(&crate::http::storage_client::SCOPES)
     }
 }
 

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -73,7 +73,9 @@ mod test {
     use crate::http::service_account_client::ServiceAccountClient;
 
     async fn client() -> (ServiceAccountClient, String) {
-        let tsp = DefaultTokenSourceProvider::new(Config::default().with_scopes(&["https://www.googleapis.com/auth/cloud-platform"]))
+        let tsp = DefaultTokenSourceProvider::new(
+            Config::default().with_scopes(&["https://www.googleapis.com/auth/cloud-platform"]),
+        )
         .await
         .unwrap();
         let email = tsp.source_credentials.clone().unwrap().client_email.unwrap();

--- a/storage/src/http/service_account_client.rs
+++ b/storage/src/http/service_account_client.rs
@@ -73,12 +73,7 @@ mod test {
     use crate::http::service_account_client::ServiceAccountClient;
 
     async fn client() -> (ServiceAccountClient, String) {
-        let tsp = DefaultTokenSourceProvider::new(Config {
-            audience: None,
-            scopes: Some(&["https://www.googleapis.com/auth/cloud-platform"]),
-            sub: None,
-            ..Default::default()
-        })
+        let tsp = DefaultTokenSourceProvider::new(Config::default().with_scopes(&["https://www.googleapis.com/auth/cloud-platform"]))
         .await
         .unwrap();
         let email = tsp.source_credentials.clone().unwrap().client_email.unwrap();

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1448,8 +1448,8 @@ pub(crate) mod test {
 
     async fn client() -> (StorageClient, String, String) {
         let tsp = DefaultTokenSourceProvider::new(Config::default().with_scopes(&SCOPES))
-        .await
-        .unwrap();
+            .await
+            .unwrap();
         let cred = tsp.source_credentials.clone();
         let ts = tsp.token_source();
         let client = StorageClient::new(

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -1447,12 +1447,7 @@ pub(crate) mod test {
     }
 
     async fn client() -> (StorageClient, String, String) {
-        let tsp = DefaultTokenSourceProvider::new(Config {
-            audience: None,
-            scopes: Some(&SCOPES),
-            sub: None,
-            ..Default::default()
-        })
+        let tsp = DefaultTokenSourceProvider::new(Config::default().with_scopes(&SCOPES))
         .await
         .unwrap();
         let cred = tsp.source_credentials.clone();


### PR DESCRIPTION
### Before
```rust
 let config = google_cloud_auth::project::Config {
      audience: Some(crate::apiv1::conn_pool::AUDIENCE),
      scopes: Some(&crate::apiv1::conn_pool::SCOPES),
      sub: None,
      ..Default::default()
  }
```

### After
```rust
   let config = google_cloud_auth::project::Config::default()
            .with_audience(crate::apiv1::conn_pool::AUDIENCE)
            .with_scopes(&crate::apiv1::conn_pool::SCOPES);
```