### PR TITLE
Directly authenticate Spanner Admin Client

### DIFF
--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -248,6 +248,11 @@ where
         }
     }
 
+    /// Return metadata for all columns
+    pub fn columns_metadata(&self) -> &Arc<Vec<Field>> {
+        &self.rs.fields
+    }
+
     pub fn column_metadata(&self, column_name: &str) -> Option<(usize, Field)> {
         for (i, val) in self.rs.fields.iter().enumerate() {
             if val.name == column_name {


### PR DESCRIPTION
- Support direct authentication for the Spanner Admin Client when being independently created
- Support returning metadata about all columns in a query
  - This is required when performing activities such as exporting results to CSV when the structure of the result set is not known in advance.