### PR TITLE
Fix encoding when creating oAuth token via Metadata Server

### DIFF
--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-cloud-auth"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/auth"

--- a/foundation/auth/src/token_source/compute_token_source.rs
+++ b/foundation/auth/src/token_source/compute_token_source.rs
@@ -24,9 +24,9 @@ impl ComputeTokenSource {
 
         Ok(ComputeTokenSource {
             token_url: format!(
-                "http://{}/computeMetadata/v1/instance/service-accounts/default/token?{}",
+                "http://{}/computeMetadata/v1/instance/service-accounts/default/token?scopes={}",
                 host,
-                encode(format!("scopes={scope}").as_str())
+                encode(scope)
             ),
             client: default_http_client(),
         })


### PR DESCRIPTION
Hi @yoshidan , thank you for the crate. 

I faced the problem that I could not generate oAuth token when I use it with google metadata server . 
Looks like it was just a typo in implementation. The `=` sign in `scopes=` does not need to be encoded. 
With the fix in this PR obtaining oAuth token from metadata server works as expected. 