### PR TITLE
bigquery: Upgrade arrow, backon dependencies

### DIFF
--- a/bigquery/Cargo.toml
+++ b/bigquery/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version="1.32", features=["macros"] }
 time = { version = "0.3", features = ["std", "macros", "formatting", "parsing", "serde"] }
-arrow = { version="50.0", default-features = false, features = ["ipc"] }
+arrow = { version = "53.1", default-features = false, features = ["ipc"] }
 base64 = "0.21"
 bigdecimal = { version="0.4", features=["serde"] }
 num-bigint = "0.4"

--- a/bigquery/Cargo.toml
+++ b/bigquery/Cargo.toml
@@ -26,7 +26,7 @@ arrow = { version = "53.1", default-features = false, features = ["ipc"] }
 base64 = "0.21"
 bigdecimal = { version="0.4", features=["serde"] }
 num-bigint = "0.4"
-backon = "0.4"
+backon = { version = "1.2", default-features = false, features = ["tokio-sleep"] }
 reqwest-middleware = { version = "0.3", features = ["json", "multipart"] }
 anyhow = "1.0"
 

--- a/bigquery/src/client.rs
+++ b/bigquery/src/client.rs
@@ -304,7 +304,7 @@ impl Client {
             )
         } else {
             (
-                self.wait_for_query(&result.job_reference, &option.retry, &request.timeout_ms)
+                self.wait_for_query(&result.job_reference, option.retry, &request.timeout_ms)
                     .await?,
                 None,
                 vec![],
@@ -410,7 +410,7 @@ impl Client {
     async fn wait_for_query(
         &self,
         job: &JobReference,
-        builder: &ExponentialBuilder,
+        builder: ExponentialBuilder,
         timeout_ms: &Option<i64>,
     ) -> Result<i64, query::run::Error> {
         // Use get_query_results only to wait for completion, not to read results.

--- a/bigquery/src/storage.rs
+++ b/bigquery/src/storage.rs
@@ -123,7 +123,7 @@ where
             let mut rows_with_schema = schema.serialized_schema;
             rows_with_schema.extend_from_slice(&rows.serialized_record_batch);
             let rows = Cursor::new(rows_with_schema);
-            let rows: StreamReader<BufReader<Cursor<Vec<u8>>>> = StreamReader::try_new(rows, None)?;
+            let rows: StreamReader<BufReader<Cursor<Vec<u8>>>> = StreamReader::try_new(BufReader::new(rows), None)?;
             let mut chunk: VecDeque<T> = VecDeque::new();
             for row in rows {
                 let row = row?;


### PR DESCRIPTION
The arrow upgrade indirectly upgrades `lexical-core`. The previously-used version of it has a couple of soundness issues: https://rustsec.org/advisories/RUSTSEC-2023-0086.html