### PR TITLE
Handle error responses from the token requests

### DIFF
--- a/foundation/auth/src/error.rs
+++ b/foundation/auth/src/error.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("scopes is required if the audience is none")]
@@ -51,4 +53,17 @@ pub enum Error {
 
     #[error("No target_audience Found in the private claims")]
     NoTargetAudienceFound,
+
+    #[error("Unexpected token response: status={status}, error={error}, description={error_description}")]
+    TokenErrorResponse {
+        status: u16,
+        error: String,
+        error_description: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct TokenErrorResponse {
+    pub(crate) error: String,
+    pub(crate) error_description: String,
 }


### PR DESCRIPTION
Currently, the token source tries to parse a response into a token even if the response was not successful.
This makes it difficult to debug what was the actual error cause, as the token source fails with an error like this:
```
http error: error decoding response body

Caused by:
0: error decoding response body
1: missing field `access_token` at line 1 column 70
```
while the actual response can for example be a HTTP 400 Bad Request with a body like this:
```
{"error":"invalid_grant","error_description":"Invalid JWT Signature."}
```
The full list of possible error codes can be found here: https://developers.google.com/identity/protocols/oauth2/service-account#error-codes

This PR adds a check for the response status, and tries to parse the error response.