### PR TITLE
Add way to initialize client configs with existing default token provider

### DIFF
--- a/artifact-registry/src/client.rs
+++ b/artifact-registry/src/client.rs
@@ -22,30 +22,31 @@ pub use google_cloud_auth;
 
 #[cfg(feature = "auth")]
 impl ClientConfig {
-    pub async fn with_auth(self) -> Result<Self, google_cloud_auth::error::Error> {
-        let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
-        Ok(self.with_token_source(ts).await)
+    pub async fn with_auth(self) -> Result<Self, crate::auth::error::Error> {
+        let ts = crate::auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
+        Ok(self.with_token_source(ts))
     }
 
     pub async fn with_credentials(
         self,
-        credentials: google_cloud_auth::credentials::CredentialsFile,
-    ) -> Result<Self, google_cloud_auth::error::Error> {
-        let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new_with_credentials(
+        credentials: crate::auth::credentials::CredentialsFile,
+    ) -> Result<Self, crate::auth::error::Error> {
+        let ts = crate::auth::token::DefaultTokenSourceProvider::new_with_credentials(
             Self::auth_config(),
             Box::new(credentials),
         )
         .await?;
-        Ok(self.with_token_source(ts).await)
+        Ok(self.with_token_source(ts))
     }
 
-    async fn with_token_source(mut self, ts: google_cloud_auth::token::DefaultTokenSourceProvider) -> Self {
+    ///Initializes token source using default source provider
+    pub fn with_token_source(mut self, ts: crate::auth::token::DefaultTokenSourceProvider) -> Self {
         self.token_source_provider = Box::new(ts);
         self
     }
 
-    fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config::default().with_scopes(&SCOPES)
+    fn auth_config() -> crate::auth::project::Config<'static> {
+        crate::auth::project::Config::default().with_scopes(&SCOPES)
     }
 }
 
@@ -116,7 +117,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     async fn new_client() -> (Client, String) {
-        let cred = google_cloud_auth::credentials::CredentialsFile::new().await.unwrap();
+        let cred = crate::auth::credentials::CredentialsFile::new().await.unwrap();
         let project = cred.project_id.clone().unwrap();
         let config = ClientConfig::default().with_credentials(cred).await.unwrap();
         (Client::new(config).await.unwrap(), project)

--- a/artifact-registry/src/lib.rs
+++ b/artifact-registry/src/lib.rs
@@ -273,5 +273,7 @@
 //!     }
 //! }
 //! ```
+#[cfg(feature = "auth")]
+pub use google_cloud_auth as auth;
 pub mod client;
 pub mod grpc;

--- a/foundation/auth/src/token.rs
+++ b/foundation/auth/src/token.rs
@@ -42,6 +42,7 @@ impl Token {
     }
 }
 
+#[derive(Clone)]
 pub struct DefaultTokenSourceProvider {
     ts: Arc<DefaultTokenSource>,
     pub project_id: Option<String>,

--- a/kms/src/client.rs
+++ b/kms/src/client.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 #[cfg(feature = "auth")]
-pub use google_cloud_auth;
+pub use crate::auth;
 use google_cloud_gax::conn::{ConnectionOptions, Environment, Error};
 
 use google_cloud_token::{NopeTokenSourceProvider, TokenSourceProvider};
@@ -20,30 +20,31 @@ pub struct ClientConfig {
 
 #[cfg(feature = "auth")]
 impl ClientConfig {
-    pub async fn with_auth(self) -> Result<Self, google_cloud_auth::error::Error> {
-        let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
-        Ok(self.with_token_source(ts).await)
+    pub async fn with_auth(self) -> Result<Self, crate::auth::error::Error> {
+        let ts = crate::auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
+        Ok(self.with_token_source(ts))
     }
 
     pub async fn with_credentials(
         self,
-        credentials: google_cloud_auth::credentials::CredentialsFile,
-    ) -> Result<Self, google_cloud_auth::error::Error> {
-        let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new_with_credentials(
+        credentials: crate::auth::credentials::CredentialsFile,
+    ) -> Result<Self, crate::auth::error::Error> {
+        let ts = crate::auth::token::DefaultTokenSourceProvider::new_with_credentials(
             Self::auth_config(),
             Box::new(credentials),
         )
         .await?;
-        Ok(self.with_token_source(ts).await)
+        Ok(self.with_token_source(ts))
     }
 
-    async fn with_token_source(mut self, ts: google_cloud_auth::token::DefaultTokenSourceProvider) -> Self {
+    ///Initializes token source using default source provider
+    pub fn with_token_source(mut self, ts: crate::auth::token::DefaultTokenSourceProvider) -> Self {
         self.token_source_provider = Box::new(ts);
         self
     }
 
-    fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config::default().with_scopes(&SCOPES)
+    fn auth_config() -> crate::auth::project::Config<'static> {
+        crate::auth::project::Config::default().with_scopes(&SCOPES)
     }
 }
 
@@ -99,7 +100,7 @@ mod tests {
     use crate::client::{Client, ClientConfig};
 
     async fn new_client() -> (Client, String) {
-        let cred = google_cloud_auth::credentials::CredentialsFile::new().await.unwrap();
+        let cred = crate::auth::credentials::CredentialsFile::new().await.unwrap();
         let project = cred.project_id.clone().unwrap();
         let config = ClientConfig::default().with_credentials(cred).await.unwrap();
         (Client::new(config).await.unwrap(), project)

--- a/kms/src/lib.rs
+++ b/kms/src/lib.rs
@@ -148,6 +148,8 @@
 //!     let receipt: TransactionReceipt = res.confirmations(3).await.unwrap().unwrap();
 //! }
 //! ```
+#[cfg(feature = "auth")]
+pub use google_cloud_auth as auth;
 pub mod client;
 pub mod grpc;
 pub mod signer;

--- a/pubsub/src/lib.rs
+++ b/pubsub/src/lib.rs
@@ -227,6 +227,8 @@
 //!     Ok(())
 //! }
 //! ```
+#[cfg(feature = "auth")]
+pub use google_cloud_auth as auth;
 pub mod apiv1;
 pub mod client;
 pub mod publisher;

--- a/spanner/src/admin/mod.rs
+++ b/spanner/src/admin/mod.rs
@@ -59,6 +59,14 @@ impl AdminClientConfig {
         Ok(self)
     }
 
+    ///Initializes environment using default source provider when using real cloud environment
+    pub async fn with_token_source(mut self, ts: crate::auth::token::DefaultTokenSourceProvider) -> Self {
+        if let Environment::GoogleCloud(_) = self.environment {
+            self.environment = Environment::GoogleCloud(Box::new(ts))
+        }
+        self
+    }
+
     fn auth_config() -> google_cloud_auth::project::Config<'static> {
         google_cloud_auth::project::Config::default()
             .with_audience(crate::apiv1::conn_pool::AUDIENCE)

--- a/spanner/src/client.rs
+++ b/spanner/src/client.rs
@@ -100,9 +100,9 @@ pub use google_cloud_auth;
 
 #[cfg(feature = "auth")]
 impl ClientConfig {
-    pub async fn with_auth(mut self) -> Result<Self, google_cloud_auth::error::Error> {
+    pub async fn with_auth(mut self) -> Result<Self, crate::auth::error::Error> {
         if let Environment::GoogleCloud(_) = self.environment {
-            let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
+            let ts = crate::auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
             self.environment = Environment::GoogleCloud(Box::new(ts))
         }
         Ok(self)
@@ -110,10 +110,10 @@ impl ClientConfig {
 
     pub async fn with_credentials(
         mut self,
-        credentials: google_cloud_auth::credentials::CredentialsFile,
-    ) -> Result<Self, google_cloud_auth::error::Error> {
+        credentials: crate::auth::credentials::CredentialsFile,
+    ) -> Result<Self, crate::auth::error::Error> {
         if let Environment::GoogleCloud(_) = self.environment {
-            let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new_with_credentials(
+            let ts = crate::auth::token::DefaultTokenSourceProvider::new_with_credentials(
                 Self::auth_config(),
                 Box::new(credentials),
             )
@@ -123,8 +123,16 @@ impl ClientConfig {
         Ok(self)
     }
 
-    fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config::default()
+    ///Initializes environment using default source provider when using real cloud environment
+    pub fn with_token_source(mut self, ts: crate::auth::token::DefaultTokenSourceProvider) -> Self {
+        if let Environment::GoogleCloud(_) = self.environment {
+            self.environment = Environment::GoogleCloud(Box::new(ts))
+        }
+        self
+    }
+
+    fn auth_config() -> crate::auth::project::Config<'static> {
+        crate::auth::project::Config::default()
             .with_audience(crate::apiv1::conn_pool::AUDIENCE)
             .with_scopes(&crate::apiv1::conn_pool::SCOPES)
     }

--- a/spanner/src/lib.rs
+++ b/spanner/src/lib.rs
@@ -631,6 +631,8 @@
 //!     Ok(())
 //! }
 //! ```
+#[cfg(feature = "auth")]
+pub use google_cloud_auth as auth;
 pub mod admin;
 pub mod apiv1;
 pub mod client;

--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -75,16 +75,16 @@ pub use google_cloud_auth;
 
 #[cfg(feature = "auth")]
 impl ClientConfig {
-    pub async fn with_auth(self) -> Result<Self, google_cloud_auth::error::Error> {
-        let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
+    pub async fn with_auth(self) -> Result<Self, crate::auth::error::Error> {
+        let ts = crate::auth::token::DefaultTokenSourceProvider::new(Self::auth_config()).await?;
         Ok(self.with_token_source(ts).await)
     }
 
     pub async fn with_credentials(
         self,
-        credentials: google_cloud_auth::credentials::CredentialsFile,
-    ) -> Result<Self, google_cloud_auth::error::Error> {
-        let ts = google_cloud_auth::token::DefaultTokenSourceProvider::new_with_credentials(
+        credentials: crate::auth::credentials::CredentialsFile,
+    ) -> Result<Self, crate::auth::error::Error> {
+        let ts = crate::auth::token::DefaultTokenSourceProvider::new_with_credentials(
             Self::auth_config(),
             Box::new(credentials),
         )
@@ -92,7 +92,8 @@ impl ClientConfig {
         Ok(self.with_token_source(ts).await)
     }
 
-    async fn with_token_source(mut self, ts: google_cloud_auth::token::DefaultTokenSourceProvider) -> Self {
+    ///Initializes project configuration and auth method using default source provider.
+    pub async fn with_token_source(mut self, ts: crate::auth::token::DefaultTokenSourceProvider) -> Self {
         match &ts.source_credentials {
             // Credential file is used.
             Some(cred) => {
@@ -113,8 +114,8 @@ impl ClientConfig {
         self
     }
 
-    fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config::default().with_scopes(&crate::http::storage_client::SCOPES)
+    fn auth_config() -> crate::auth::project::Config<'static> {
+        crate::auth::project::Config::default().with_scopes(&crate::http::storage_client::SCOPES)
     }
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -103,6 +103,8 @@
 
 extern crate core;
 
+#[cfg(feature = "auth")]
+pub use google_cloud_auth as auth;
 pub mod client;
 pub mod http;
 pub mod sign;


### PR DESCRIPTION
This allows user to create config himself once and share it among all clients. As using `with_auth()` pose risk of metadata server starting to reject connections when there is burst of requests

As a background I recently noticed that our cron jobs in GKE can error out with metadata server rejecting new connections temporarily
I'm not 100% sure, but I suspect google has some sort of burst protection to avoid metadata server being overwhlemed.
While `with_auth` method is convenient, it encourages to create multiple providers connecting to the same server, which might not be ideal for GKE

As result I made it public method to provider token source or added it when it wasn't existing

I also made it non-async because there is no reason to use async for it, but if you have concerns let me know, and I will make async again

I also exposed google_cloud_auth at root of every create with auth feature for convenience sake (instead of needing to access it via `client::google_cloud_auth`)