### PR TITLE
spanner: set google-cloud-resource-prefix metadata

### DIFF
--- a/spanner/src/apiv1/mod.rs
+++ b/spanner/src/apiv1/mod.rs
@@ -19,6 +19,7 @@ mod tests {
 
     use crate::apiv1::conn_pool::ConnectionManager;
     use crate::apiv1::spanner_client::Client;
+    use crate::session::client_metadata;
 
     const DATABASE: &str = "projects/local-project/instances/test-instance/databases/local-database";
 
@@ -31,7 +32,7 @@ mod tests {
         )
         .await
         .unwrap();
-        cm.conn()
+        cm.conn().with_metadata(client_metadata(&DATABASE))
     }
 
     async fn create_session(client: &mut Client) -> Session {


### PR DESCRIPTION
Set `google-cloud-resource-prefix` metadata to speed up spanner data RPCs. 

It seems that data RPCs still work without this, albeit with surprisingly reduced performance. I have not found anything in the spanner RPC API docs to indicate which RPCs should have this metadata set but the golang spanner client seems to be setting it for all session creation and data RPCs.

Not sure what is the preferred way to implement this. This PR adds a `metadata` field on `crate::apiv1::spanner_client::Client` to avoid having to pass it in to the public methods on the impl.

Other approaches could be to instead explicitly pass in the metadata from call sites, and/or infer it from already available information like `database` fields on the request types when available.

https://github.com/yoshidan/google-cloud-rust/issues/323#issuecomment-2558133420

See: 
*  https://github.com/googleapis/google-cloud-go/blob/7cbffad749a0f8917658406dae73c7fb7151b55d/spanner/client.go#L478
* https://github.com/googleapis/google-cloud-ruby/issues/1237
