### PR TITLE
spanner: fix lint error

### DIFF
--- a/spanner/src/apiv1/mod.rs
+++ b/spanner/src/apiv1/mod.rs
@@ -32,7 +32,7 @@ mod tests {
         )
         .await
         .unwrap();
-        cm.conn().with_metadata(client_metadata(&DATABASE))
+        cm.conn().with_metadata(client_metadata(DATABASE))
     }
 
     async fn create_session(client: &mut Client) -> Session {


### PR DESCRIPTION
Fix lint error introduced in https://github.com/yoshidan/google-cloud-rust/pull/332

```
warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> spanner/src/apiv1/mod.rs:35:49
   |
35 |         cm.conn().with_metadata(client_metadata(&DATABASE))
   |                                                 ^^^^^^^^^ help: change this to: `DATABASE`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default
```

Noting though that this is only in test code. We should perhaps change CI to `cargo clippy --all-targets` to catch lint errors in test code as well.