### PR TITLE
clippy --all-targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: format check
         run: cargo fmt --all -- --check
       - name: clippy check
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
   check-deps:
     name: check-deps
     runs-on: ubuntu-latest

--- a/spanner/tests/change_stream_test.rs
+++ b/spanner/tests/change_stream_test.rs
@@ -29,6 +29,7 @@ fn init() {
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct ChangeRecord {
     pub data_change_record: Vec<DataChangeRecord>,
@@ -44,6 +45,7 @@ impl TryFromStruct for ChangeRecord {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct ChildPartitionsRecord {
     pub start_timestamp: OffsetDateTime,
@@ -61,6 +63,7 @@ impl TryFromStruct for ChildPartitionsRecord {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct ChildPartition {
     pub token: String,
@@ -76,6 +79,7 @@ impl TryFromStruct for ChildPartition {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct DataChangeRecord {
     pub commit_timestamp: OffsetDateTime,

--- a/spanner/tests/common.rs
+++ b/spanner/tests/common.rs
@@ -18,6 +18,7 @@ use google_cloud_spanner::bigdecimal::BigDecimal;
 
 pub const DATABASE: &str = "projects/local-project/instances/test-instance/databases/local-database";
 
+#[allow(dead_code)]
 pub struct UserCharacter {
     pub user_id: String,
     pub character_id: i64,
@@ -36,6 +37,7 @@ impl TryFromStruct for UserCharacter {
     }
 }
 
+#[allow(dead_code)]
 pub struct UserItem {
     pub user_id: String,
     pub item_id: i64,
@@ -54,6 +56,7 @@ impl TryFromStruct for UserItem {
     }
 }
 
+#[allow(dead_code)]
 pub struct UserItemWithHistory {
     pub user_id: String,
     pub item_id: i64,
@@ -74,6 +77,7 @@ impl TryFromStruct for UserItemWithHistory {
     }
 }
 
+#[allow(dead_code)]
 pub struct UserItemHistory {
     pub user_id: String,
     pub item_id: i64,


### PR DESCRIPTION
Continuation of https://github.com/yoshidan/google-cloud-rust/pull/334 to address all test code lint errors and clippy all targets in CI.

```
$ cargo clippy --all-targets
warning: fields `user_id`, `item_id`, `quantity`, `updated_at`, and `user_item_history` are never read
  --> spanner/tests/common.rs:58:9
   |
57 | pub struct UserItemWithHistory {
   |            ------------------- fields in this struct
58 |     pub user_id: String,
   |         ^^^^^^^
59 |     pub item_id: i64,
   |         ^^^^^^^
60 |     pub quantity: i64,
   |         ^^^^^^^^
61 |     pub updated_at: CommitTimestamp,
   |         ^^^^^^^^^^
62 |     pub user_item_history: Vec<UserItemHistory>,
   |         ^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: fields `user_id`, `item_id`, and `used_at` are never read
  --> spanner/tests/common.rs:78:9
   |
77 | pub struct UserItemHistory {
   |            --------------- fields in this struct
78 |     pub user_id: String,
   |         ^^^^^^^
79 |     pub item_id: i64,
   |         ^^^^^^^
80 |     pub used_at: CommitTimestamp,
   |         ^^^^^^^

warning: field `data_change_record` is never read
  --> spanner/tests/change_stream_test.rs:34:9
   |
33 | struct ChangeRecord {
   |        ------------ field in this struct
34 |     pub data_change_record: Vec<DataChangeRecord>,
   |         ^^^^^^^^^^^^^^^^^^
   |
   = note: `ChangeRecord` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default

warning: fields `start_timestamp` and `record_sequence` are never read
  --> spanner/tests/change_stream_test.rs:49:9
   |
48 | struct ChildPartitionsRecord {
   |        --------------------- fields in this struct
49 |     pub start_timestamp: OffsetDateTime,
   |         ^^^^^^^^^^^^^^^
50 |     pub record_sequence: String,
   |         ^^^^^^^^^^^^^^^
   |
   = note: `ChildPartitionsRecord` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: field `parent_partition_tokens` is never read
  --> spanner/tests/change_stream_test.rs:67:9
   |
65 | struct ChildPartition {
   |        -------------- field in this struct
66 |     pub token: String,
67 |     pub parent_partition_tokens: Vec<String>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `ChildPartition` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: multiple fields are never read
  --> spanner/tests/change_stream_test.rs:81:9
   |
80 | struct DataChangeRecord {
   |        ---------------- fields in this struct
81 |     pub commit_timestamp: OffsetDateTime,
   |         ^^^^^^^^^^^^^^^^
82 |     pub record_sequence: String,
   |         ^^^^^^^^^^^^^^^
83 |     pub server_transaction_id: String,
   |         ^^^^^^^^^^^^^^^^^^^^^
84 |     pub is_last_record_in_transaction_in_partition: bool,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
85 |     pub table_name: String,
   |         ^^^^^^^^^^
86 |     pub mod_type: String,
   |         ^^^^^^^^
87 |     pub value_capture_type: String,
   |         ^^^^^^^^^^^^^^^^^^
88 |     pub number_of_records_in_transaction: i64,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
89 |     pub number_of_partitions_in_transaction: i64,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
90 |     pub transaction_tag: String,
   |         ^^^^^^^^^^^^^^^
91 |     pub is_system_transaction: bool,
   |         ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `DataChangeRecord` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: fields `user_id`, `character_id`, `level`, and `updated_at` are never read
  --> spanner/tests/common.rs:22:9
   |
21 | pub struct UserCharacter {
   |            ------------- fields in this struct
22 |     pub user_id: String,
   |         ^^^^^^^
23 |     pub character_id: i64,
   |         ^^^^^^^^^^^^
24 |     pub level: i64,
   |         ^^^^^
25 |     pub updated_at: CommitTimestamp,
   |         ^^^^^^^^^^

warning: fields `user_id`, `item_id`, `quantity`, and `updated_at` are never read
  --> spanner/tests/common.rs:40:9
   |
39 | pub struct UserItem {
   |            -------- fields in this struct
40 |     pub user_id: String,
   |         ^^^^^^^
41 |     pub item_id: i64,
   |         ^^^^^^^
42 |     pub quantity: i64,
   |         ^^^^^^^^
43 |     pub updated_at: CommitTimestamp,
   |         ^^^^^^^^^^

warning: fields `user_id`, `item_id`, `quantity`, `updated_at`, and `user_item_history` are never read
  --> spanner/tests/common.rs:58:9
   |
57 | pub struct UserItemWithHistory {
   |            ------------------- fields in this struct
58 |     pub user_id: String,
   |         ^^^^^^^
59 |     pub item_id: i64,
   |         ^^^^^^^
60 |     pub quantity: i64,
   |         ^^^^^^^^
61 |     pub updated_at: CommitTimestamp,
   |         ^^^^^^^^^^
62 |     pub user_item_history: Vec<UserItemHistory>,
   |         ^^^^^^^^^^^^^^^^^

warning: fields `user_id`, `item_id`, `quantity`, and `updated_at` are never read
  --> spanner/tests/common.rs:40:9
   |
39 | pub struct UserItem {
   |            -------- fields in this struct
40 |     pub user_id: String,
   |         ^^^^^^^
41 |     pub item_id: i64,
   |         ^^^^^^^
42 |     pub quantity: i64,
   |         ^^^^^^^^
43 |     pub updated_at: CommitTimestamp,
   |         ^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: fields `user_id`, `character_id`, `level`, and `updated_at` are never read
  --> spanner/tests/common.rs:22:9
   |
21 | pub struct UserCharacter {
   |            ------------- fields in this struct
22 |     pub user_id: String,
   |         ^^^^^^^
23 |     pub character_id: i64,
   |         ^^^^^^^^^^^^
24 |     pub level: i64,
   |         ^^^^^
25 |     pub updated_at: CommitTimestamp,
   |         ^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> spanner/src/apiv1/mod.rs:35:49
   |
35 |         cm.conn().with_metadata(client_metadata(&DATABASE))
   |                                                 ^^^^^^^^^ help: change this to: `DATABASE`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: `google-cloud-spanner` (test "transaction_rw_test") generated 2 warnings
warning: `google-cloud-spanner` (test "change_stream_test") generated 8 warnings (1 duplicate)
warning: `google-cloud-spanner` (test "transaction_ro_test") generated 1 warning
warning: `google-cloud-spanner` (test "client_test") generated 4 warnings (3 duplicates)
warning: `google-cloud-spanner` (lib test) generated 1 warning (run `cargo clippy --fix --lib -p google-cloud-spanner --tests` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
```