### PR TITLE
Remove server feature from tonic

### DIFF
--- a/googleapis/Cargo.toml
+++ b/googleapis/Cargo.toml
@@ -12,7 +12,7 @@ description = "Google Cloud Platform rust client."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = { version = "0.12", default-features = false, features = ["transport", "prost", "codegen", "gzip"] }
+tonic = { version = "0.12", default-features = false, features = ["channel", "prost", "codegen", "gzip"] }
 prost = "0.13"
 prost-types = "0.13"
 


### PR DESCRIPTION
The server feature is unneeded, and pulls in extra dependencies (e.g. axum).