### PR TITLE
[auth] Slightly better error message

### DIFF
--- a/foundation/auth/src/error.rs
+++ b/foundation/auth/src/error.rs
@@ -17,8 +17,8 @@ pub enum Error {
     #[error("jwt error: {0}")]
     JwtError(#[from] jsonwebtoken::errors::Error),
 
-    #[error("http error: {0}")]
-    HttpError(#[from] reqwest::Error),
+    #[error("http error on {0}: {1}")]
+    HttpError(String, reqwest::Error),
 
     #[error("GOOGLE_APPLICATION_CREDENTIALS or default credentials is required: {0}")]
     CredentialsIOError(#[from] std::io::Error),

--- a/foundation/auth/src/token_source/authorized_user_token_source.rs
+++ b/foundation/auth/src/token_source/authorized_user_token_source.rs
@@ -63,9 +63,11 @@ impl TokenSource for UserAccountTokenSource {
             .post(self.token_url.to_string())
             .json(&data)
             .send()
-            .await?
+            .await
+            .map_err(|e| Error::HttpError(self.token_url.clone(), e))?
             .json::<InternalToken>()
-            .await?;
+            .await
+            .map_err(|e| Error::HttpError(self.token_url.clone(), e))?;
 
         return Ok(it.to_token(time::OffsetDateTime::now_utc()));
     }

--- a/foundation/auth/src/token_source/compute_identity_source.rs
+++ b/foundation/auth/src/token_source/compute_identity_source.rs
@@ -71,9 +71,11 @@ impl TokenSource for ComputeIdentitySource {
             .get(self.token_url.to_string())
             .header(METADATA_FLAVOR_KEY, METADATA_GOOGLE)
             .send()
-            .await?
+            .await
+            .map_err(|e| Error::HttpError(self.token_url.clone(), e))?
             .text()
-            .await?;
+            .await
+            .map_err(|e| Error::HttpError(self.token_url.clone(), e))?;
 
         let exp = jsonwebtoken::decode::<ExpClaim>(&jwt, &self.decoding_key, &self.validation)?
             .claims

--- a/foundation/auth/src/token_source/compute_token_source.rs
+++ b/foundation/auth/src/token_source/compute_token_source.rs
@@ -41,9 +41,11 @@ impl TokenSource for ComputeTokenSource {
             .get(self.token_url.to_string())
             .header(METADATA_FLAVOR_KEY, METADATA_GOOGLE)
             .send()
-            .await?
+            .await
+            .map_err(|e| Error::HttpError(self.token_url.clone(), e))?
             .json::<InternalToken>()
-            .await?;
+            .await
+            .map_err(|e| Error::HttpError(self.token_url.clone(), e))?;
         return Ok(it.to_token(time::OffsetDateTime::now_utc()));
     }
 }


### PR DESCRIPTION
I wrote very simple code:

```
            google_cloud_storage::client::ClientConfig::default()
                .with_auth()
                .await
                .unwrap();
```

and error message is not helpful:

```
called `Result::unwrap()` on an `Err` value: HttpError(reqwest::Error { kind: Decode, source: Error("missing field `access_token`", line: 6, column: 1) })
```

at least add what server we are talking to the error message to help a bit with reverse engineering what it is trying to do:

```
called `Result::unwrap()` on an `Err` value: HttpError("https://oauth2.googleapis.com/token", reqwest::Error { kind: Decode, source: Error("missing field `access_token`", line: 6, column: 1) })
```