### PR TITLE
[IMPORTANT] Transfer namespace to Google Cloud Official.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Providing a high level API for gRPC API like [Google Cloud Go](https://github.co
 
 ![CI](https://github.com/yoshidan/google-cloud-rust/workflows/CI/badge.svg?branch=main)
 
+## Announcement
+### 2025.02.06:  
+Since the development of [google cloud rust by Google](https://github.com/googleapis/google-cloud-rust) seems to have resumed,
+We have decided to donate the `google-cloud-*` namespace to Google.
+#### Migration from `google-cloud-*` to `gcloud-*`
+
+Library users do not need to modify existing code.
+Use `package` option at [dependency] in Cargo.toml
+```
+google-cloud-spanner = { package="gcloud-spanner", version="1.0.0" }
+```
+
 ## Component 
 
 * [google-cloud-spanner](./spanner)

--- a/artifact-registry/Cargo.toml
+++ b/artifact-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-artifact-registry"
-version = "0.8.0"
+name = "gcloud-artifact-registry"
+version = "1.0.0"
 edition = "2021"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/artifact-registry"
@@ -8,18 +8,18 @@ keywords = ["gcp", "artifacts-registry","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform Artifact Registry client library."
-documentation = "https://docs.rs/google-cloud-artifact-registry/latest/google_cloud_artifact_registry/"
+documentation = "https://docs.rs/gcloud-artifact-registry/latest/gcloud_artifact_registry/"
+
+[lib]
+doctest = false
 
 [dependencies]
-google-cloud-token = { version = "0.1.2", path = "../foundation/token" }
-google-cloud-auth = { optional = true, version = "0.17", path="../foundation/auth", default-features=false }
-google-cloud-googleapis = { version="0.16.0", path = "../googleapis", features=["artifact-registry"]}
-google-cloud-gax = { version = "0.19.2", path = "../foundation/gax"}
-google-cloud-longrunning = { version = "0.21.0", path = "../foundation/longrunning" }
+google-cloud-token = { package = "gcloud-token", version = "1.0.0", path = "../foundation/token" }
+google-cloud-auth = { package = "gcloud-auth", optional = true, version = "1.0.0", path="../foundation/auth", default-features=false }
+google-cloud-googleapis = { package = "gcloud-googleapis", version="1.0.0", path = "../googleapis", features=["artifact-registry"]}
+google-cloud-gax = { package = "gcloud-gax", version = "1.0.0", path = "../foundation/gax"}
+google-cloud-longrunning = { package = "gcloud-longrunning", version = "1.0.0", path = "../foundation/longrunning" }
 tracing = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
 prost-types = "0.13"
 
 [dev-dependencies]
@@ -27,8 +27,7 @@ tokio = { version="1.32", features=["rt-multi-thread"] }
 serial_test = "3.1"
 tracing-subscriber = { version="0.3.17", features=["env-filter"]}
 ctor = "0.1"
-tokio-util =  {version ="0.7", features = ["codec"] }
-google-cloud-auth = { path = "../foundation/auth", default-features=false }
+google-cloud-auth = { package = "gcloud-auth", path = "../foundation/auth", default-features=false }
 
 [features]
 default = ["default-tls", "auth"]

--- a/artifact-registry/README.md
+++ b/artifact-registry/README.md
@@ -2,7 +2,7 @@
 
 Google Cloud Platform Artifact Registry Client library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-artifact-registry.svg)](https://crates.io/crates/google-cloud-artifact-registry)
+[![crates.io](https://img.shields.io/crates/v/gcloud-artifact-registry.svg)](https://crates.io/crates/google-cloud-artifact-registry)
 
 * [About Artifact Registry](https://cloud.google.com/artifact-registry/)
 * [JSON API Documentation](https://cloud.google.com/artifact-registry/docs/reference/rest)
@@ -12,7 +12,7 @@ Google Cloud Platform Artifact Registry Client library.
 
 ```toml
 [dependencies]
-google-cloud-artifact-registry = "version"
+google-cloud-artifact-registry = {package="gcloud-artifact-registry", version="1.0.0" }
 ```
 
 ## Quickstart

--- a/bigquery/Cargo.toml
+++ b/bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-bigquery"
-version = "0.15.0"
+name = "gcloud-bigquery"
+version = "1.0.0"
 edition = "2021"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/bigquery"
@@ -8,13 +8,16 @@ keywords = ["gcp","bigquery","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform bigquery client library."
-documentation = "https://docs.rs/google-cloud-bigquery/latest/google_cloud_bigquery/"
+documentation = "https://docs.rs/gcloud-bigquery/latest/gcloud_bigquery/"
+
+[lib]
+doctest = false
 
 [dependencies]
 async-trait = "0.1"
-google-cloud-token = { version = "0.1.2", path = "../foundation/token" }
-google-cloud-googleapis = { version="0.16.0", path = "../googleapis", features=["bigquery"]}
-google-cloud-gax = { version = "0.19.2", path = "../foundation/gax"}
+google-cloud-token = { package = "gcloud-token", version = "1.0.0", path = "../foundation/token" }
+google-cloud-googleapis = { package = "gcloud-googleapis", version="1.0.0", path = "../googleapis", features=["bigquery"]}
+google-cloud-gax = { package = "gcloud-gax", version = "1.0.0", path = "../foundation/gax"}
 thiserror = "1.0"
 tracing = "0.1"
 reqwest = { version = "0.12.4", features = ["json", "stream", "multipart", "charset"], default-features = false }
@@ -32,15 +35,14 @@ anyhow = "1.0"
 async-stream = "0.3"
 prost-types = "0.13"
 
-google-cloud-auth = { optional = true, version = "0.17", path="../foundation/auth", default-features=false }
+google-cloud-auth = { package = "gcloud-auth", optional = true, version = "1.0.0", path="../foundation/auth", default-features=false }
 
 [dev-dependencies]
 tokio = { version="1.32", features=["rt-multi-thread"] }
 serial_test = "3.1"
 tracing-subscriber = { version="0.3.17", features=["env-filter"] }
 ctor = "0.1.26"
-tokio-util =  {version ="0.7", features = ["codec"] }
-google-cloud-auth = { path = "../foundation/auth", default-features=false }
+google-cloud-auth = { package = "gcloud-auth", path = "../foundation/auth", default-features=false }
 base64-serde = "0.7"
 prost = "0.13"
 futures-util = "0.3"

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -2,13 +2,13 @@
 
 Google Cloud Platform BigQuery Client library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-bigquery.svg)](https://crates.io/crates/google-cloud-bigquery)
+[![crates.io](https://img.shields.io/crates/v/gcloud-bigquery.svg)](https://crates.io/crates/gcloud-bigquery)
 
 ## Installation
 
 ```toml
 [dependencies]
-google-cloud-bigquery = version
+google-cloud-bigquery = { package="gcloud-bigquery", version="1.0.0" }
 ```
 
 ## Quick Start

--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-auth"
-version = "0.17.2"
+name = "gcloud-auth"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/auth"
@@ -8,6 +8,9 @@ keywords = ["gcp", "auth", "googleapis", "google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform server application authentication library."
+
+[lib]
+doctest = false
 
 [dependencies]
 tracing = "0.1"
@@ -20,8 +23,8 @@ async-trait = "0.1"
 home = "0.5"
 urlencoding = "2.1"
 tokio = { version = "1.32", features = ["fs"] }
-google-cloud-metadata = { version = "0.5.0", path = "../metadata" }
-google-cloud-token = { version = "0.1.2", path = "../token" }
+google-cloud-metadata = { package = "gcloud-metadata", version = "1.0.0", path = "../metadata" }
+google-cloud-token = { package = "gcloud-token", version = "1.0.0", path = "../token" }
 base64 = "0.21"
 time = "0.3"
 

--- a/foundation/auth/README.md
+++ b/foundation/auth/README.md
@@ -2,14 +2,14 @@
 
 Google Cloud Platform server application authentication library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-auth.svg)](https://crates.io/crates/google-cloud-auth)
+[![crates.io](https://img.shields.io/crates/v/gloud-auth.svg)](https://crates.io/crates/gcloud-auth)
 
 ## Installation
 
 ```toml
 [dependencies]
-google-cloud-auth = <version>
-google-cloud-token = "0.1.2"
+google-cloud-auth = { package="gcloud-auth", version="1.0.0" }
+google-cloud-token = { package="gcloud-token", version="1.0.0" }
 ```
 
 ## Quickstart

--- a/foundation/gax/Cargo.toml
+++ b/foundation/gax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-gax"
-version = "0.19.2"
+name = "gcloud-gax"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/gax"
@@ -9,6 +9,9 @@ license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform gRPC retry library."
 
+[lib]
+doctest = false
+
 [dependencies]
 tracing = "0.1"
 tokio = { version = "1.32", features = ["macros"] }
@@ -16,5 +19,5 @@ tonic = { version = "0.12", default-features = false, features = ["prost", "tls-
 thiserror = "1.0"
 tower = { version = "0.4", features = ["filter", "util"] }
 http = "1.1"
-google-cloud-token = { version = "0.1.2", path = "../token" }
+google-cloud-token = { package = "gcloud-token", version = "1.0.0", path = "../token" }
 tokio-retry2 = "0.5.3"

--- a/foundation/gax/README.md
+++ b/foundation/gax/README.md
@@ -2,12 +2,12 @@
 
 Google Cloud Platform gRPC retry library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-gax.svg)](https://crates.io/crates/google-cloud-gax)
+[![crates.io](https://img.shields.io/crates/v/gcloud-gax.svg)](https://crates.io/crates/gcloud-gax)
 
 ## Installation
 
 ```toml
 [dependencies]
-google-cloud-gax = <version>
+google-cloud-gax = { package="gcloud-gax", verion="1.0.0" }
 ```
 

--- a/foundation/longrunning/Cargo.toml
+++ b/foundation/longrunning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-longrunning"
-version = "0.21.0"
+name = "gcloud-longrunning"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/longrunning"
@@ -9,8 +9,11 @@ license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform longrunning library."
 
+[lib]
+doctest = false
+
 [dependencies]
-google-cloud-googleapis = { version = "0.16.0", path = "../../googleapis" }
-google-cloud-gax = { version = "0.19.2", path = "../gax" }
+google-cloud-googleapis = { package = "gcloud-googleapis", version = "1.0.0", path = "../../googleapis" }
+google-cloud-gax = { package = "gcloud-gax", version = "1.0.0", path = "../gax" }
 tonic = { version = "0.12", default-features = false }
 prost = "0.13"

--- a/foundation/longrunning/README.md
+++ b/foundation/longrunning/README.md
@@ -2,12 +2,12 @@
 
 Google Cloud Platform long running operation library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-longrunning.svg)](https://crates.io/crates/google-cloud-longrunning)
+[![crates.io](https://img.shields.io/crates/v/gcloud-longrunning.svg)](https://crates.io/crates/gcloud-longrunning)
 
 ## Installation
 
 ```toml
 [dependencies]
-google-cloud-longrunning = <version>
+google-cloud-longrunning = { package="gcloud-longrunning", version="..." }
 ```
 

--- a/foundation/metadata/Cargo.toml
+++ b/foundation/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-metadata"
-version = "0.5.1"
+name = "gcloud-metadata"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/metadata"
@@ -8,6 +8,9 @@ keywords = ["gcp","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform rust client."
+
+[lib]
+doctest = false
 
 [dependencies]
 tokio = { version = "1.32", features = ["sync", "net", "parking_lot"] }

--- a/foundation/metadata/README.md
+++ b/foundation/metadata/README.md
@@ -2,13 +2,13 @@
 
 Google Cloud Platform GCE check library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-metadata.svg)](https://crates.io/crates/google-cloud-metadata)
+[![crates.io](https://img.shields.io/crates/v/gcloud-metadata.svg)](https://crates.io/crates/gcloud-metadata)
 
 ## Installation
 
 ```toml
 [dependencies]
-google-cloud-metadata = <version>
+google-cloud-metadata = { package="gcloud-metadata", version="..." }
 ```
 
 ## Usage 

--- a/foundation/metadata/tests/test.rs
+++ b/foundation/metadata/tests/test.rs
@@ -1,4 +1,4 @@
-use google_cloud_metadata::{email, on_gce, Error};
+use gcloud_metadata::{email, on_gce, Error};
 
 #[tokio::test]
 async fn test_on_gce() {

--- a/foundation/token/Cargo.toml
+++ b/foundation/token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-token"
-version = "0.1.2"
+name = "gcloud-token"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/foundation/token"
@@ -8,6 +8,9 @@ keywords = ["gcp","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform token spec."
+
+[lib]
+doctest = false
 
 [dependencies]
 async-trait = "0.1"

--- a/foundation/token/README.md
+++ b/foundation/token/README.md
@@ -2,11 +2,11 @@
 
 Google Cloud Platform token spec for google-cloud-rust.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-token.svg)](https://crates.io/crates/google-cloud-token)
+[![crates.io](https://img.shields.io/crates/v/gcloud-token.svg)](https://crates.io/crates/gcloud-token)
 
 ## Installation
 
 ```toml
 [dependencies]
-google-cloud-token = <version>
+google-cloud-token = { package="gcloud-token", version="1.0.0" }
 ```

--- a/googleapis/Cargo.toml
+++ b/googleapis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-googleapis"
-version = "0.16.1"
+name = "gcloud-googleapis"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/googleapis"
@@ -9,7 +9,8 @@ license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform rust client."
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+doctest = false
 
 [dependencies]
 tonic = { version = "0.12", default-features = false, features = ["channel", "prost", "codegen", "gzip"] }

--- a/googleapis/README.md
+++ b/googleapis/README.md
@@ -1,6 +1,6 @@
 ## Generate gRPC Client
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-googleapis.svg)](https://crates.io/crates/google-cloud-googleapis)
+[![crates.io](https://img.shields.io/crates/v/gcloud-googleapis.svg)](https://crates.io/crates/gcloud-googleapis)
 
 ```bash
 git submodule update --init --recursive --progress --depth=1

--- a/kms/Cargo.toml
+++ b/kms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-kms"
-version = "0.6.0"
+name = "gcloud-kms"
+version = "1.0.0"
 edition = "2021"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/kms"
@@ -8,16 +8,17 @@ keywords = ["gcp", "kms","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform Key Management Service client library."
-documentation = "https://docs.rs/google-cloud-kms/latest/google_cloud_kms/"
+documentation = "https://docs.rs/gcloud-kms/latest/gcloud_kms/"
+
+[lib]
+doctest = false
 
 [dependencies]
-google-cloud-token = { version = "0.1.2", path = "../foundation/token" }
-google-cloud-auth = { optional = true, version = "0.17", path="../foundation/auth", default-features=false }
-google-cloud-googleapis = { version="0.16.0", path = "../googleapis", features=["kms"]}
-google-cloud-gax = { version = "0.19.2", path = "../foundation/gax"}
+google-cloud-token = { package = "gcloud-token", version = "1.0.0", path = "../foundation/token" }
+google-cloud-auth = { package = "gcloud-auth", optional = true, version = "1.0.0", path="../foundation/auth", default-features=false }
+google-cloud-googleapis = { package = "gcloud-googleapis", version="1.0.0", path = "../googleapis", features=["kms"]}
+google-cloud-gax = { package = "gcloud-gax", version = "1.0.0", path = "../foundation/gax"}
 tracing = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 thiserror = "1.0"
 prost-types = "0.13"
 
@@ -32,8 +33,7 @@ tokio = { version="1.32", features=["rt-multi-thread"] }
 serial_test = "3.1"
 tracing-subscriber = { version="0.3.17", features=["env-filter"]}
 ctor = "0.1"
-tokio-util =  {version ="0.7", features = ["codec"] }
-google-cloud-auth = { path = "../foundation/auth", default-features=false }
+google-cloud-auth = { package = "gcloud-auth", path = "../foundation/auth", default-features=false }
 hex-literal = "0.4"
 ethers = "2.0"
 

--- a/kms/README.md
+++ b/kms/README.md
@@ -2,7 +2,7 @@
 
 Google Cloud Platform Key Management Service Client library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-kms.svg)](https://crates.io/crates/google-cloud-kms)
+[![crates.io](https://img.shields.io/crates/v/gcloud-kms.svg)](https://crates.io/crates/gcloud-kms)
 
 * [About KMS](https://cloud.google.com/kms/)
 * [JSON API Documentation](https://cloud.google.com/kms/docs/reference/rest)
@@ -12,7 +12,7 @@ Google Cloud Platform Key Management Service Client library.
 
 ```toml
 [dependencies]
-google-cloud-kms = "version"
+google-cloud-kms = { package="gcloud-kms", version="1.0.0" }
 ```
 
  ### Authentication

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-pubsub"
-version = "0.30.0"
+name = "gcloud-pubsub"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/pubsub"
@@ -8,7 +8,10 @@ keywords = ["gcp","pubsub","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform pubsub client library."
-documentation = "https://docs.rs/google-cloud-pubsub/latest/google_cloud_pubsub/"
+documentation = "https://docs.rs/gcloud-pubsub/latest/gcloud_pubsub/"
+
+[lib]
+doctest = false
 
 [dependencies]
 tracing = "0.1"
@@ -19,11 +22,11 @@ async-stream = "0.3"
 thiserror = "1.0"
 tokio-util = "0.7"
 
-google-cloud-token = { version = "0.1.2", path = "../foundation/token" }
-google-cloud-gax = { version = "0.19.2", path = "../foundation/gax" }
-google-cloud-googleapis = { version = "0.16.0", path = "../googleapis", features = ["pubsub"]}
+google-cloud-token = { package = "gcloud-token", version = "1.0.0", path = "../foundation/token" }
+google-cloud-gax = { package = "gcloud-gax", version = "1.0.0", path = "../foundation/gax" }
+google-cloud-googleapis = { package = "gcloud-googleapis", version = "1.0.0", path = "../googleapis", features = ["pubsub"]}
 
-google-cloud-auth = { optional = true, version = "0.17", path="../foundation/auth", default-features=false }
+google-cloud-auth = { package = "gcloud-auth", optional = true, version = "1.0.0", path="../foundation/auth", default-features=false }
 
 [dev-dependencies]
 tokio = { version="1.32", features=["rt-multi-thread"] }

--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -2,7 +2,7 @@
 
 Google Cloud Platform pub/sub library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-pubsub.svg)](https://crates.io/crates/google-cloud-pubsub)
+[![crates.io](https://img.shields.io/crates/v/gcloud-pubsub.svg)](https://crates.io/crates/gcloud-pubsub)
 
 
 * [About Cloud Pub/Sub](https://cloud.google.com/pubsub/)
@@ -12,7 +12,7 @@ Google Cloud Platform pub/sub library.
 
 ```toml
 [dependencies]
-google-cloud-pubsub = "version"
+google-cloud-pubsub = { package="gcloud-pubsub", version="1.0.0" }
 ```
 
 ## Quickstart

--- a/spanner-derive/Cargo.toml
+++ b/spanner-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "google-cloud-spanner-derive"
+name = "gcloud-spanner-derive"
 version = "0.2.1"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
@@ -8,9 +8,10 @@ keywords = ["gcp","spanner","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform spanner client library macro derive."
-documentation = "https://docs.rs/google-cloud-spanner/latest/google_cloud_spanner_derive/"
+documentation = "https://docs.rs/gcloud-spanner/latest/gcloud_spanner_derive/"
 
 [lib]
+doctest = false
 proc-macro = true
 
 [dependencies]
@@ -19,7 +20,7 @@ syn = { version="1.0", features=["full"] }
 convert_case = "0.6"
 
 [dev-dependencies]
-google-cloud-spanner = { path = "../spanner"}
+google-cloud-spanner = { package = "gcloud-spanner", path = "../spanner"}
 time = { version = "0.3", features = ["serde"] }
 tokio = { version="1.32", features=["rt-multi-thread"] }
 serial_test = "3.1"

--- a/spanner-derive/README.md
+++ b/spanner-derive/README.md
@@ -2,13 +2,13 @@
 
 Procedural macro for [google-cloud-spanner](../spanner).
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-spanner-derive.svg)](https://crates.io/crates/google-cloud-spanner-derive)
+[![crates.io](https://img.shields.io/crates/v/gcloud-spanner-derive.svg)](https://crates.io/crates/gcloud-spanner-derive)
 
 ## Installation
 
 ```toml
 [dependencies]
-google-cloud-spanner-derive = <version>
+google-cloud-spanner-derive = { package="gcloud-spanner-derive", version="1.0.0" }
 ```
 
 ## Quick Start

--- a/spanner-derive/tests/test.rs
+++ b/spanner-derive/tests/test.rs
@@ -4,6 +4,7 @@ use serial_test::serial;
 use std::str::FromStr;
 use time::{Date, OffsetDateTime};
 
+use gcloud_spanner_derive as google_cloud_spanner_derive;
 use google_cloud_spanner::client::{Client, ClientConfig, Error};
 use google_cloud_spanner::mutation::insert_struct;
 use google_cloud_spanner::statement::Statement;

--- a/spanner/Cargo.toml
+++ b/spanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "google-cloud-spanner"
-version = "0.33.0"
+name = "gcloud-spanner"
+version = "1.0.0"
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/spanner"
@@ -8,7 +8,10 @@ keywords = ["gcp","spanner","googleapis","google-cloud-rust"]
 license = "MIT"
 readme = "README.md"
 description = "Google Cloud Platform spanner client library."
-documentation = "https://docs.rs/google-cloud-spanner/latest/google_cloud_spanner/"
+documentation = "https://docs.rs/gcloud-spanner/latest/gcloud_spanner/"
+
+[lib]
+doctest = false
 
 [dependencies]
 tracing = "0.1"
@@ -22,19 +25,19 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 tokio-util = "0.7"
 bigdecimal = { version="0.4", features=["serde"] }
 
-google-cloud-token = { version = "0.1.2", path = "../foundation/token" }
-google-cloud-longrunning = { version = "0.21.0", path = "../foundation/longrunning" }
-google-cloud-gax = { version = "0.19.2", path = "../foundation/gax" }
-google-cloud-googleapis = { version = "0.16.0", path = "../googleapis", features = ["spanner"]}
+google-cloud-token = { package = "gcloud-token", version = "1.0.0", path = "../foundation/token" }
+google-cloud-longrunning = { package = "gcloud-longrunning", version = "1.0.0", path = "../foundation/longrunning" }
+google-cloud-gax = { package = "gcloud-gax", version = "1.0.0", path = "../foundation/gax" }
+google-cloud-googleapis = { package = "gcloud-googleapis", version = "1.0.0", path = "../googleapis", features = ["spanner"]}
 
-google-cloud-auth = { optional = true, version = "0.17", path="../foundation/auth", default-features=false }
+google-cloud-auth = { package = "gcloud-auth", optional = true, version = "1.0.0", path="../foundation/auth", default-features=false }
 
 [dev-dependencies]
 tokio = { version="1.32", features=["rt-multi-thread"] }
 tracing-subscriber = { version="0.3", features=["env-filter"] }
 serial_test = "3.1"
 ctor = "0.1"
-google-cloud-auth = { path="../foundation/auth", default-features=false, features=["rustls-tls"]}
+google-cloud-auth = { package = "gcloud-auth", path="../foundation/auth", default-features=false, features=["rustls-tls"]}
 
 [features]
 default = ["serde", "auth", "default-tls"]

--- a/spanner/README.md
+++ b/spanner/README.md
@@ -2,7 +2,7 @@
 
 Google Cloud Platform spanner library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-spanner.svg)](https://crates.io/crates/google-cloud-spanner)
+[![crates.io](https://img.shields.io/crates/v/gcloud-spanner.svg)](https://crates.io/crates/gcloud-spanner)
 
 * [About Cloud Spanner](https://cloud.google.com/spanner/)
 * [Spanner API Documentation](https://cloud.google.com/spanner/docs)
@@ -12,7 +12,7 @@ Google Cloud Platform spanner library.
 
 ```toml
 [dependencies]
-google-cloud-spanner = "version"
+google-cloud-spanner = { package="gcloud-spanner", version="1.0.0" }
 ```
 
 ## Quickstart

--- a/spanner/tests/change_stream_test.rs
+++ b/spanner/tests/change_stream_test.rs
@@ -10,6 +10,7 @@ use google_cloud_gax::conn::Environment::GoogleCloud;
 use google_cloud_gax::grpc::Code;
 use google_cloud_googleapis::spanner::admin::database::v1::UpdateDatabaseDdlRequest;
 
+use common::*;
 use google_cloud_spanner::admin;
 use google_cloud_spanner::admin::AdminClientConfig;
 use google_cloud_spanner::client::{Client, ClientConfig};

--- a/spanner/tests/common.rs
+++ b/spanner/tests/common.rs
@@ -16,6 +16,7 @@ use google_cloud_spanner::value::CommitTimestamp;
 
 use google_cloud_spanner::bigdecimal::BigDecimal;
 
+pub use gcloud_spanner as google_cloud_spanner;
 pub const DATABASE: &str = "projects/local-project/instances/test-instance/databases/local-database";
 
 #[allow(dead_code)]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
 authors = ["yoshidan <naohiro.y@gmail.com>"]
 description = "Google Cloud Platform storage client library."
-documentation = "https://docs.rs/google-cloud-storage/latest/google_cloud_storage/"
+documentation = "https://docs.rs/gcloud-storage/latest/gcloud_storage/"
 edition = "2021"
 keywords = ["gcp", "gcs", "storage", "googleapis", "google-cloud-rust"]
 license = "MIT"
-name = "google-cloud-storage"
+name = "gcloud-storage"
 readme = "README.md"
 repository = "https://github.com/yoshidan/google-cloud-rust/tree/main/storage"
-version = "0.24.0"
+version = "1.0.0"
+
+[lib]
+doctest = false
 
 [dependencies]
 anyhow = "1.0"
-async-stream = "0.3"
-async-trait = "0.1"
 base64 = "0.21"
 bytes = "1.5"
 futures-util = "0.3"
-google-cloud-token = {version = "0.1.2", path = "../foundation/token"}
+google-cloud-token = {package = "gcloud-token", version = "1.0.0", path = "../foundation/token"}
 hex = "0.4"
 once_cell = "1.18"
 percent-encoding = "2.3"
@@ -45,17 +46,16 @@ tokio = {version = "1.32", features = ["macros"]}
 tracing = "0.1"
 url = "2.4"
 
-google-cloud-auth = {optional = true, version = "0.17", path = "../foundation/auth", default-features = false}
-google-cloud-metadata = {optional = true, version = "0.5", path = "../foundation/metadata"}
+google-cloud-auth = {package = "gcloud-auth", optional = true, version = "1.0.0", path = "../foundation/auth", default-features = false}
+google-cloud-metadata = {package = "gcloud-metadata", optional = true, version = "1.0.0", path = "../foundation/metadata"}
 
 [dev-dependencies]
 ctor = "0.1.26"
-google-cloud-auth = {path = "../foundation/auth", default-features = false}
+google-cloud-auth = { package = "gcloud-auth", path = "../foundation/auth", default-features = false}
 reqwest-retry = "0.7.0"
 retry-policies = "0.4.0"
 serial_test = "3.1"
 tokio = {version = "1.32", features = ["rt-multi-thread"]}
-tokio-util = {version = "0.7", features = ["codec"]}
 tracing-subscriber = {version = "0.3.17", features = ["env-filter"]}
 
 [features]

--- a/storage/README.md
+++ b/storage/README.md
@@ -2,7 +2,7 @@
 
 Google Cloud Platform Storage Client library.
 
-[![crates.io](https://img.shields.io/crates/v/google-cloud-storage.svg)](https://crates.io/crates/google-cloud-storage)
+[![crates.io](https://img.shields.io/crates/v/gcloud-storage.svg)](https://crates.io/crates/gcloud-storage)
 
 * [About Cloud Storage](https://cloud.google.com/storage/)
 * [JSON API Documentation](https://cloud.google.com/storage/docs/json_api/v1)
@@ -11,7 +11,7 @@ Google Cloud Platform Storage Client library.
 
 ```toml
 [dependencies]
-google-cloud-storage = "version"
+google-cloud-storage = { package="gcloud-storage", version="1.0.0" }
 ```
 
 ## Quickstart


### PR DESCRIPTION
Since the development of [google cloud rust by Google](https://github.com/googleapis/google-cloud-rust) seems to have resumed,
I have decided to donate the `google-cloud-*` namespace to Google.

https://github.com/yoshidan/google-cloud-rust/issues/343

## New Crate Name
The prefix will be changed from `google-cloud` to `gcloud`.


gcloud-bigquery
gcloud-pubsub
gcloud-spanner

## Migration
Specify package when specifying Crate's dependency so that there is no code for the library user

Before
```toml
google-cloud-pubsub = { version="0.21.0" } 
```

After this PR
```toml
oogle-cloud-pubsub = { package="gcloud-pubsub", version="1.0.0" } 
```