### PR TITLE
Emulator does not return `kind`

### DIFF
--- a/bigquery/src/http/job/query.rs
+++ b/bigquery/src/http/job/query.rs
@@ -106,6 +106,7 @@ pub struct QueryRequest {
 #[serde(rename_all = "camelCase")]
 pub struct QueryResponse {
     /// The resource type.
+    #[serde(default)]
     pub kind: String,
     /// The schema of the results. Present only when the query completes successfully.
     pub schema: Option<TableSchema>,


### PR DESCRIPTION
This is a follow up from https://github.com/yoshidan/google-cloud-rust/pull/336/files

The emulator seems to not return `kind` on any of the responses. In the original PR this was fixed by adding a `serde(default)` to those fields on the responses. While testing the library with `client.query::<Row>(&project_id, request).await?` I discovered there was a missing place.