### PR TITLE
Update arrow to fix compatibility with chrono

### DIFF
--- a/bigquery/Cargo.toml
+++ b/bigquery/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version="1.32", features=["macros"] }
 time = { version = "0.3", features = ["std", "macros", "formatting", "parsing", "serde"] }
-arrow = { version = "53.1", default-features = false, features = ["ipc"] }
+arrow = { version = "54.2.1", default-features = false, features = ["ipc"] }
 base64 = "0.21"
 bigdecimal = { version="0.4", features=["serde"] }
 num-bigint = "0.4"


### PR DESCRIPTION
latest chrono is currenlty not available with any older arrow version: https://github.com/apache/arrow-rs/issues/7196

Update here to arrow 54 so compatibility with chrono is guaranteed.