### PR TITLE
Fix job statistics deserialization for cached queries

### DIFF
--- a/bigquery/src/http/job/mod.rs
+++ b/bigquery/src/http/job/mod.rs
@@ -839,6 +839,8 @@ pub enum IndexUnusedCode {
     BaseTableTooSmall,
     BaseTableTooLarge,
     EstimatedPerformanceGainTooLow,
+    QueryCacheHit,
+    StaleIndex,
     InternalError,
     OtherReason,
 }


### PR DESCRIPTION
The `QUERY_CACHE_HIT` variant was missing from the IndexUnusedCode enum. This caused deserialization to fail when requesting job details for a query that's been cached by Google Cloud. 

Additionally, this commit also adds a second variant that was missing from this enum, `STALE_INDEX`. See the Google Cloud docs for reference:
https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#Code_1

---

**Note**: Adding new enum variants is a [**breaking change** in Rust](https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new), but I suspect that Google does not see adding enum variants to their API as such. To mitigate this in the future, I would recommend: 

* mark all enums used in deserialization as `#[non_exhaustive]`,
* introduce a fallback "Other" variant to enums used for deserialization with [`#[serde(other)]`](https://serde.rs/variant-attrs.html#other), so that a change in the Google Cloud API does not break existing code.

Let me know if you'd like me to help out with that. Ideally these changes should be done all at once as a part of v2.0 to minimize breakage (as tagging a public enum as `#[non_exhaustive]` is a breaking change in itself), and to avoid having to release multiple major versions.