### PR TITLE
spanner: add transaction tag support based on Go client inspiration

### DIFF
--- a/spanner/src/transaction_ro.rs
+++ b/spanner/src/transaction_ro.rs
@@ -64,6 +64,7 @@ impl ReadOnlyTransaction {
                         isolation_level: IsolationLevel::Unspecified as i32,
                     })),
                 },
+                transaction_tag: None,
             },
             rts: None,
         })
@@ -82,7 +83,7 @@ impl ReadOnlyTransaction {
                 mode: Some(transaction_options::Mode::ReadOnly(tb.into())),
                 isolation_level: IsolationLevel::Unspecified as i32,
             }),
-            request_options: Transaction::create_request_options(options.priority),
+            request_options: Transaction::create_request_options(options.priority, None),
             mutation_key: None,
         };
 
@@ -99,6 +100,7 @@ impl ReadOnlyTransaction {
                         transaction_selector: TransactionSelector {
                             selector: Some(transaction_selector::Selector::Id(tx.id)),
                         },
+                        transaction_tag: None,
                     },
                     rts: Some(OffsetDateTime::from(st)),
                 })
@@ -207,7 +209,10 @@ impl BatchReadOnlyTransaction {
                             limit: ro.limit,
                             resume_token: vec![],
                             partition_token: x.partition_token,
-                            request_options: Transaction::create_request_options(ro.call_options.priority),
+                            request_options: Transaction::create_request_options(
+                                ro.call_options.priority,
+                                self.base_tx.transaction_tag.clone(),
+                            ),
                             directed_read_options: directed_read_options.clone(),
                             data_boost_enabled,
                             order_by: 0,
@@ -272,7 +277,10 @@ impl BatchReadOnlyTransaction {
                             partition_token: x.partition_token,
                             seqno: 0,
                             query_options: qo.optimizer_options.clone(),
-                            request_options: Transaction::create_request_options(qo.call_options.priority),
+                            request_options: Transaction::create_request_options(
+                                qo.call_options.priority,
+                                self.base_tx.transaction_tag.clone(),
+                            ),
                             data_boost_enabled,
                             directed_read_options: directed_read_options.clone(),
                             last_statement: false,


### PR DESCRIPTION
Inspired by Go client patch that introduced transaction tagging to cloud.google.com/go/spanner.

Refs: https://github.com/googleapis/google-cloud-go/commit/f08c73a75e2d2a8b9a0b184179346cb97c82e9e5

One difference from the golang client is that the golang client supports a client-wide setting of transaction tag, and that is not implemented here.

As implemented, this change technically breaks semver compatibility (as shown with `cargo semver-checks`). I am open to a different implementation, or to doing a follow on PR that refactors all Options APIs to be builder-driven rather than exposing struct members themselves, so that future changes can avoid semver breakages.

```
% cargo public-api diff 1.3.0
 Documenting gcloud-spanner v1.3.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.45s
 Documenting gcloud-spanner v1.4.0 (/Users/cliff/src/yoshidan-google-cloud-rust/spanner)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.95s
Removed items from the public API
=================================
(none)

Changed items in the public API
===============================
-pub async fn gcloud_spanner::transaction_rw::ReadWriteTransaction::begin(
-       session: gcloud_spanner::session::ManagedSession,
-       options: gcloud_spanner::transaction::CallOptions)
-  -> core::result::Result<gcloud_spanner::transaction_rw::ReadWriteTransaction, gcloud_spanner::transaction_rw::BeginError>
+pub async fn gcloud_spanner::transaction_rw::ReadWriteTransaction::begin(
+       session: gcloud_spanner::session::ManagedSession,
+       options: gcloud_spanner::transaction::CallOptions,
+       transaction_tag: core::option::Option<alloc::string::String>)
+  -> core::result::Result<gcloud_spanner::transaction_rw::ReadWriteTransaction, gcloud_spanner::transaction_rw::BeginError>

-pub async fn gcloud_spanner::transaction_rw::ReadWriteTransaction::begin_partitioned_dml(
-       session: gcloud_spanner::session::ManagedSession,
-       options: gcloud_spanner::transaction::CallOptions)
-  -> core::result::Result<gcloud_spanner::transaction_rw::ReadWriteTransaction, gcloud_spanner::transaction_rw::BeginError>
+pub async fn gcloud_spanner::transaction_rw::ReadWriteTransaction::begin_partitioned_dml(
+       session: gcloud_spanner::session::ManagedSession,
+       options: gcloud_spanner::transaction::CallOptions,
+       transaction_tag: core::option::Option<alloc::string::String>)
+  -> core::result::Result<gcloud_spanner::transaction_rw::ReadWriteTransaction, gcloud_spanner::transaction_rw::BeginError>

Added items to the public API
=============================
+pub gcloud_spanner::client::PartitionedUpdateOption::transaction_tag: core::option::Option<alloc::string::String>
+pub gcloud_spanner::client::ReadWriteTransactionOption::transaction_tag: core::option::Option<alloc::string::String>
+pub gcloud_spanner::transaction_rw::CommitOptions::transaction_tag: core::option::Option<alloc::string::String>
```

```
% cargo semver-checks
    Checking gcloud-spanner v1.3.0 -> v1.3.0 (no change)
     Checked [   0.009s] 153 checks: 151 pass, 2 fail, 0 warn, 11 skip

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ReadWriteTransactionOption.transaction_tag in /Users/cliff/src/yoshidan-google-cloud-rust/spanner/src/client.rs:52
  field CommitOptions.transaction_tag in /Users/cliff/src/yoshidan-google-cloud-rust/spanner/src/transaction_rw.rs:28
  field PartitionedUpdateOption.transaction_tag in /Users/cliff/src/yoshidan-google-cloud-rust/spanner/src/client.rs:28

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gcloud_spanner::transaction_rw::ReadWriteTransaction::begin now takes 3 parameters instead of 2, in /Users/cliff/src/yoshidan-google-cloud-rust/spanner/src/transaction_rw.rs:124
  gcloud_spanner::transaction_rw::ReadWriteTransaction::begin_partitioned_dml now takes 3 parameters instead of 2, in /Users/cliff/src/yoshidan-google-cloud-rust/spanner/src/transaction_rw.rs:138

     Summary semver requires new major version: 2 major and 0 minor checks failed
```