### PR TITLE
fix documentation where `tokio::select!` was used with `.await`

### DIFF
--- a/pubsub/README.md
+++ b/pubsub/README.md
@@ -167,13 +167,13 @@ async fn run(config: ClientConfig) -> Result<(), Status> {
     while let Some(message) = tokio::select!{
         v = iter.next() => v,
         _ = ctx.cancelled() => None,
-    }.await {
+    } {
         let _ = message.ack().await;
     }
     // Wait for all the unprocessed messages to be Nack.
     // If you don't call dispose, the unprocessed messages will be Nack when the iterator is dropped.
-    iter.dispose().await;    
-        
+    iter.dispose().await;
+
     // Delete subscription if needed.
     subscription.delete(None).await?;
 

--- a/pubsub/src/lib.rs
+++ b/pubsub/src/lib.rs
@@ -157,7 +157,7 @@
 //!     while let Some(message) = tokio::select!{
 //!         v = iter.next() => v,
 //!         _ = cancel.cancelled() => None,
-//!     }.await {
+//!     } {
 //!         let _ = message.ack().await;
 //!     }
 //!     // Wait for all the unprocessed messages to be Nack.

--- a/pubsub/src/subscription.rs
+++ b/pubsub/src/subscription.rs
@@ -449,7 +449,7 @@ impl Subscription {
     ///     while let Some(message) = tokio::select!{
     ///         v = iter.next() => v,
     ///         _ = ctx.cancelled() => None,
-    ///     }.await {
+    ///     } {
     ///         let _ = message.ack().await;
     ///     }
     ///     // Wait for all the unprocessed messages to be Nack.


### PR DESCRIPTION
First of all, thanks for the usability improvements in the last versions! 

When trying to use some of the example code, I discovered `tokio::select!` is used wrong here, since you don't have to `.await` it. 