### PR TITLE
fix(storage): add audience configuration to auth setup in ClientConfig

### DIFF
--- a/storage/src/client.rs
+++ b/storage/src/client.rs
@@ -114,7 +114,9 @@ impl ClientConfig {
     }
 
     fn auth_config() -> google_cloud_auth::project::Config<'static> {
-        google_cloud_auth::project::Config::default().with_scopes(&crate::http::storage_client::SCOPES)
+        google_cloud_auth::project::Config::default()
+            .with_audience(&crate::http::storage_client::AUDIENCE)
+            .with_scopes(&crate::http::storage_client::SCOPES)
     }
 }
 

--- a/storage/src/http/storage_client.rs
+++ b/storage/src/http/storage_client.rs
@@ -63,6 +63,7 @@ use crate::http::{
     object_access_controls, objects, Error,
 };
 
+pub const AUDIENCE: &str = "https://storage.googleapis.com/";
 pub const SCOPES: [&str; 2] = [
     "https://www.googleapis.com/auth/cloud-platform",
     "https://www.googleapis.com/auth/devstorage.full_control",


### PR DESCRIPTION
This pull request updates the authentication configuration for the storage client to improve compatibility and security. The main change is the introduction of an explicit audience parameter in the authentication process.

Authentication improvements:

* Added a new constant `AUDIENCE` in `storage/src/http/storage_client.rs` to specify the intended audience for authentication tokens.
* Updated the `auth_config` method in `storage/src/client.rs` to use the new `AUDIENCE` constant when building the authentication config, ensuring tokens are scoped for the correct audience.