### PR TITLE
fix regional endpoint support for pubsub ordering keys

### DIFF
--- a/foundation/gax/src/conn.rs
+++ b/foundation/gax/src/conn.rs
@@ -123,7 +123,7 @@ impl<'a> ConnectionManager {
     pub async fn new(
         pool_size: usize,
         domain_name: impl Into<String>,
-        audience: &'static str,
+        audience: &str,
         environment: &Environment,
         conn_options: &'a ConnectionOptions,
     ) -> Result<Self, Error> {
@@ -144,7 +144,7 @@ impl<'a> ConnectionManager {
     async fn create_connections(
         pool_size: usize,
         domain_name: impl Into<String>,
-        audience: &'static str,
+        audience: &str,
         ts_provider: &dyn TokenSourceProvider,
         conn_options: &'a ConnectionOptions,
     ) -> Result<Vec<Channel>, Error> {
@@ -156,7 +156,9 @@ impl<'a> ConnectionManager {
         let ts = ts_provider.token_source();
 
         for _i_ in 0..pool_size {
-            let endpoint = TonicChannel::from_static(audience).tls_config(tls_config.clone())?;
+            let endpoint = TonicChannel::from_shared(audience.to_string().into_bytes())
+                .map_err(|e| Error::InvalidEmulatorHOST(e.to_string()))?
+                .tls_config(tls_config.clone())?;
             let endpoint = conn_options.apply(endpoint);
 
             let con = Self::connect(endpoint).await?;

--- a/pubsub/src/apiv1/conn_pool.rs
+++ b/pubsub/src/apiv1/conn_pool.rs
@@ -1,7 +1,9 @@
 use google_cloud_gax::conn::{Channel, Environment};
 use google_cloud_gax::conn::{ConnectionManager as GRPCConnectionManager, ConnectionOptions, Error};
 
+/// OAuth audience for token requests (global, works for all regional endpoints)
 pub const AUDIENCE: &str = "https://pubsub.googleapis.com/";
+/// Default Pub/Sub endpoint domain
 pub const PUBSUB: &str = "pubsub.googleapis.com";
 pub const SCOPES: [&str; 2] = [
     "https://www.googleapis.com/auth/cloud-platform",
@@ -20,8 +22,10 @@ impl ConnectionManager {
         environment: &Environment,
         conn_options: &ConnectionOptions,
     ) -> Result<Self, Error> {
+        // Derive endpoint URL from domain to support regional endpoints
+        let endpoint_url = format!("https://{}/", domain);
         Ok(ConnectionManager {
-            inner: GRPCConnectionManager::new(pool_size, domain, AUDIENCE, environment, conn_options).await?,
+            inner: GRPCConnectionManager::new(pool_size, domain, &endpoint_url, environment, conn_options).await?,
         })
     }
 


### PR DESCRIPTION
When using ordering keys with topics that have message storage policies (e.g., data residency in europe-west4), Pub/Sub requires publishing to a regional endpoint matching the storage policy. Publishing to the global endpoint with ordering keys fails with:

  "Cannot publish messages that contain ordering keys to topic ... due a
  message storage policy on the topic that would require the messages to
  be forwarded to another region."

Changes:
- change `audience` parameter from `&'static str` to `&str` in gax
- use `TonicChannel::from_shared()` instead of `from_static()` for dynamic URLs
- derive endpoint URL from domain in pubsub conn_pool
- keep AUDIENCE constant for OAuth token scope (works globally)