### PR TITLE
feat: allow consumers of crate to choose their own crypto backend for jsonwebtoken

### DIFF
--- a/foundation/auth/Cargo.toml
+++ b/foundation/auth/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1"
 reqwest = { version = "0.12.4", features = ["json", "charset"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-jsonwebtoken = { version = "10.2", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "10.2", features = ["use_pem"], default-features = false }
 thiserror = "2.0"
 async-trait = "0.1"
 home = "0.5"
@@ -43,8 +43,10 @@ tempfile = "3.8.0"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "jwt-aws-lc-rs"]
 default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 hickory-dns = ["reqwest/hickory-dns"]
 external-account = ["sha2", "path-clean", "url", "percent-encoding", "hmac", "hex"]
+jwt-aws-lc-rs = ["jsonwebtoken/aws_lc_rs"]
+jwt-rust-crypto = ["jsonwebtoken/rust_crypto"]

--- a/foundation/auth/src/lib.rs
+++ b/foundation/auth/src/lib.rs
@@ -5,3 +5,9 @@ mod misc;
 pub mod project;
 pub mod token;
 pub mod token_source;
+
+#[cfg(all(feature = "jwt-aws-lc-rs", feature = "jwt-rust-crypto"))]
+compile_error!("Enable only one feature: `jwt-aws-lc-rs` OR `jwt-rust-crypto`.");
+
+#[cfg(not(any(feature = "jwt-aws-lc-rs", feature = "jwt-rust-crypto")))]
+compile_error!("Enable one feature: `jwt-aws-lc-rs` OR `jwt-rust-crypto`.");

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -46,12 +46,12 @@ tokio = {version = "1.32", features = ["macros"]}
 tracing = "0.1"
 url = "2.4"
 
-google-cloud-auth = {package = "gcloud-auth", optional = true, version = "1.1.3", path = "../foundation/auth", default-features = false}
+google-cloud-auth = {package = "gcloud-auth", optional = true, version = "1.1.3", path = "../foundation/auth", features = ["jwt-aws-lc-rs"], default-features = false}
 google-cloud-metadata = {package = "gcloud-metadata", optional = true, version = "1.0.1", path = "../foundation/metadata"}
 
 [dev-dependencies]
 ctor = "0.5"
-google-cloud-auth = { package = "gcloud-auth", path = "../foundation/auth", default-features = false}
+google-cloud-auth = { package = "gcloud-auth", path = "../foundation/auth", features = ["jwt-aws-lc-rs"], default-features = false}
 serial_test = "3.1"
 tokio = {version = "1.32", features = ["rt-multi-thread"]}
 tracing-subscriber = {version = "0.3.17", features = ["env-filter"]}


### PR DESCRIPTION
# The problem
User's of `jsonwebtoken` with `rust_crypto` backend enabled can't use the gcloud-auth crate.

# Solution
This PR toggles `jsonwebtoken` features flags with `gcloud-auth` feature flags.

# Note
This will need a new major release, probably, just so callers are unaffected in their Cargo.toml`s. 

Merging this means that callers must explicitly choose their jsonwebtoken backends.