### PR TITLE
fix(spanner): `ResultSet::merge` panic for chunked nested `ListValue`s

### DIFF
--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -197,7 +197,7 @@ impl ResultSet {
                 )),
             },
             Kind::ListValue(mut last) => match current_first.kind.unwrap() {
-                Kind::ListValue(mut first) => {
+                Kind::ListValue(first) => {
                     if first.values.is_empty() {
                         return Ok(Value {
                             kind: Some(Kind::ListValue(last)),
@@ -213,7 +213,8 @@ impl ResultSet {
                     // first element of `first` must be of a chunkable kind
                     // (StringValue or ListValue). Otherwise the boundary fell
                     // between complete elements and we just concatenate.
-                    let first_value_of_current = first.values.remove(0);
+                    let mut iter = first.values.into_iter();
+                    let first_value_of_current = iter.next().unwrap();
                     let last_value_of_previous = last.values.pop().unwrap();
                     let mergeable = matches!(
                         (&last_value_of_previous.kind, &first_value_of_current.kind),
@@ -228,7 +229,7 @@ impl ResultSet {
                         last.values.push(last_value_of_previous);
                         last.values.push(first_value_of_current);
                     }
-                    last.values.extend(first.values);
+                    last.values.extend(iter);
                     Ok(Value {
                         kind: Some(Kind::ListValue(last)),
                     })
@@ -659,7 +660,7 @@ mod tests {
     // mismatch ...`. After the fix it must concatenate without merging.
     #[test]
     fn test_rs_merge_list_value_with_non_mergeable_tail() {
-        let null = || Value { kind: Some(Kind::NullValue(0)) };
+        let null = || Value { kind: Some(Kind::NullValue(prost_types::NullValue::NullValue.into())) };
         let bool_v = |b: bool| Value { kind: Some(Kind::BoolValue(b)) };
         let num_v = |n: f64| Value { kind: Some(Kind::NumberValue(n)) };
 

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -222,8 +222,7 @@ impl ResultSet {
                             | (Some(Kind::ListValue(_)), Some(Kind::ListValue(_)))
                     );
                     if mergeable {
-                        let merged =
-                            ResultSet::merge(last_value_of_previous, first_value_of_current)?;
+                        let merged = ResultSet::merge(last_value_of_previous, first_value_of_current)?;
                         last.values.push(merged);
                     } else {
                         last.values.push(last_value_of_previous);
@@ -660,9 +659,15 @@ mod tests {
     // mismatch ...`. After the fix it must concatenate without merging.
     #[test]
     fn test_rs_merge_list_value_with_non_mergeable_tail() {
-        let null = || Value { kind: Some(Kind::NullValue(prost_types::NullValue::NullValue.into())) };
-        let bool_v = |b: bool| Value { kind: Some(Kind::BoolValue(b)) };
-        let num_v = |n: f64| Value { kind: Some(Kind::NumberValue(n)) };
+        let null = || Value {
+            kind: Some(Kind::NullValue(prost_types::NullValue::NullValue.into())),
+        };
+        let bool_v = |b: bool| Value {
+            kind: Some(Kind::BoolValue(b)),
+        };
+        let num_v = |n: f64| Value {
+            kind: Some(Kind::NumberValue(n)),
+        };
 
         // previous tail = NullValue, source first = StringValue: must NOT merge.
         let previous_last = Value {

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -198,15 +198,38 @@ impl ResultSet {
             },
             Kind::ListValue(mut last) => match current_first.kind.unwrap() {
                 Kind::ListValue(mut first) => {
+                    if first.values.is_empty() {
+                        return Ok(Value {
+                            kind: Some(Kind::ListValue(last)),
+                        });
+                    }
+                    if last.values.is_empty() {
+                        return Ok(Value {
+                            kind: Some(Kind::ListValue(first)),
+                        });
+                    }
+                    // Only recurse when the chunk boundary actually splits a
+                    // single value: both the last element of `last` and the
+                    // first element of `first` must be of a chunkable kind
+                    // (StringValue or ListValue). Otherwise the boundary fell
+                    // between complete elements and we just concatenate.
+                    // Mirrors the Go SDK (read.go: isMergeable / merge) and
+                    // the official Rust SDK (result_set.rs: merge_values).
                     let first_value_of_current = first.values.remove(0);
-                    let merged = match last.values.pop() {
-                        Some(last_value_of_previous) => {
-                            ResultSet::merge(last_value_of_previous, first_value_of_current)?
-                        }
-                        // last record can be empty
-                        None => first_value_of_current,
-                    };
-                    last.values.push(merged);
+                    let last_value_of_previous = last.values.pop().unwrap();
+                    let mergeable = matches!(
+                        (&last_value_of_previous.kind, &first_value_of_current.kind),
+                        (Some(Kind::StringValue(_)), Some(Kind::StringValue(_)))
+                            | (Some(Kind::ListValue(_)), Some(Kind::ListValue(_)))
+                    );
+                    if mergeable {
+                        let merged =
+                            ResultSet::merge(last_value_of_previous, first_value_of_current)?;
+                        last.values.push(merged);
+                    } else {
+                        last.values.push(last_value_of_previous);
+                        last.values.push(first_value_of_current);
+                    }
                     last.values.extend(first.values);
                     Ok(Value {
                         kind: Some(Kind::ListValue(last)),
@@ -629,6 +652,95 @@ mod tests {
                 }
             }
             _ => unreachable!("must be string value"),
+        }
+    }
+
+    // Regression: chunk boundary falls between complete inner elements where
+    // the last element of the previous list is not a chunkable kind (here
+    // NullValue). Previously this returned `Internal: previous_last kind
+    // mismatch ...`. After the fix it must concatenate without merging.
+    #[test]
+    fn test_rs_merge_list_value_with_non_mergeable_tail() {
+        let null = || Value { kind: Some(Kind::NullValue(0)) };
+        let bool_v = |b: bool| Value { kind: Some(Kind::BoolValue(b)) };
+        let num_v = |n: f64| Value { kind: Some(Kind::NumberValue(n)) };
+
+        // previous tail = NullValue, source first = StringValue: must NOT merge.
+        let previous_last = Value {
+            kind: Some(Kind::ListValue(prost_types::ListValue {
+                values: vec![value("a"), null()],
+            })),
+        };
+        let current_first = Value {
+            kind: Some(Kind::ListValue(prost_types::ListValue {
+                values: vec![value("b"), bool_v(true)],
+            })),
+        };
+        let merged = ResultSet::merge(previous_last, current_first).expect("must concatenate");
+        match merged.kind.unwrap() {
+            Kind::ListValue(v) => {
+                assert_eq!(v.values.len(), 4);
+                assert!(matches!(v.values[0].kind, Some(Kind::StringValue(ref s)) if s == "a"));
+                assert!(matches!(v.values[1].kind, Some(Kind::NullValue(_))));
+                assert!(matches!(v.values[2].kind, Some(Kind::StringValue(ref s)) if s == "b"));
+                assert!(matches!(v.values[3].kind, Some(Kind::BoolValue(true))));
+            }
+            _ => unreachable!("must be list value"),
+        }
+
+        // previous tail = BoolValue, source first = NumberValue: still ok.
+        let previous_last = Value {
+            kind: Some(Kind::ListValue(prost_types::ListValue {
+                values: vec![bool_v(false)],
+            })),
+        };
+        let current_first = Value {
+            kind: Some(Kind::ListValue(prost_types::ListValue {
+                values: vec![num_v(1.5), value("tail")],
+            })),
+        };
+        let merged = ResultSet::merge(previous_last, current_first).expect("must concatenate");
+        match merged.kind.unwrap() {
+            Kind::ListValue(v) => {
+                assert_eq!(v.values.len(), 3);
+                assert!(matches!(v.values[0].kind, Some(Kind::BoolValue(false))));
+                assert!(matches!(v.values[1].kind, Some(Kind::NumberValue(n)) if n == 1.5));
+                assert!(matches!(v.values[2].kind, Some(Kind::StringValue(ref s)) if s == "tail"));
+            }
+            _ => unreachable!("must be list value"),
+        }
+    }
+
+    // Empty list edge cases — a chunk may carry no inner values.
+    #[test]
+    fn test_rs_merge_list_value_empty_sides() {
+        let empty_list = || Value {
+            kind: Some(Kind::ListValue(prost_types::ListValue { values: vec![] })),
+        };
+        let with_one = || Value {
+            kind: Some(Kind::ListValue(prost_types::ListValue {
+                values: vec![value("only")],
+            })),
+        };
+
+        // previous empty + current with one => result is current.
+        let merged = ResultSet::merge(empty_list(), with_one()).unwrap();
+        match merged.kind.unwrap() {
+            Kind::ListValue(v) => {
+                assert_eq!(v.values.len(), 1);
+                assert!(matches!(v.values[0].kind, Some(Kind::StringValue(ref s)) if s == "only"));
+            }
+            _ => unreachable!(),
+        }
+
+        // previous with one + current empty => result is previous.
+        let merged = ResultSet::merge(with_one(), empty_list()).unwrap();
+        match merged.kind.unwrap() {
+            Kind::ListValue(v) => {
+                assert_eq!(v.values.len(), 1);
+                assert!(matches!(v.values[0].kind, Some(Kind::StringValue(ref s)) if s == "only"));
+            }
+            _ => unreachable!(),
         }
     }
 

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -213,8 +213,6 @@ impl ResultSet {
                     // first element of `first` must be of a chunkable kind
                     // (StringValue or ListValue). Otherwise the boundary fell
                     // between complete elements and we just concatenate.
-                    // Mirrors the Go SDK (read.go: isMergeable / merge) and
-                    // the official Rust SDK (result_set.rs: merge_values).
                     let first_value_of_current = first.values.remove(0);
                     let last_value_of_previous = last.values.pop().unwrap();
                     let mergeable = matches!(


### PR DESCRIPTION
### Problem

When `ExecuteStreamingSql` streams a large nested `ARRAY<STRUCT<...>>` value split across multiple `PartialResultSet`s with `chunked_value=true`, `ResultSet::merge` fails with:

```
Internal: previous_last kind mismatch: only StringValue and ListValue can be chunked
```

The root cause is in `spanner/src/reader.rs`: when merging two `ListValue`s, the code unconditionally popped the last element of the previous chunk and recursed into `ResultSet::merge` with the first element of the current chunk. If the boundary fell between two complete elements whose kinds are not chunkable (`NullValue`, `BoolValue`, `NumberValue`), the recursive call hit the catch-all arm and returned an error.

Additionally, the code did not handle the case where either inner list was empty.

### Fix

Mirrors the reference SDKs:

- **[Go SDK](https://github.com/googleapis/google-cloud-go/blob/8cc6e9741e44a2a2ed282330be96c90d76628c49/spanner/read.go#L868-L940)** — `isMergeable` + `merge`
- **[Official Rust SDK](https://github.com/googleapis/google-cloud-rust/blob/6f9388a93f1e3c42839cee1866089f84a52fa9b1/src/spanner/src/result_set.rs#L574-L614)** — `merge_values`

Changes:

1. **Mergeability gate**: only recurse when both the tail of the previous list and the head of the current list are `StringValue` or `ListValue`. Otherwise push both elements as-is and concatenate the remaining values.
2. **Empty list short-circuits**: if either inner list is empty, return the other unchanged without attempting any pop/push.

### Impact

Any caller streaming `ARRAY<STRUCT<...>>` columns large enough to trigger chunking can hit this. Spanner change-stream readers (`SELECT ChangeRecord FROM READ_<stream>(...)`) are particularly exposed because the column type mixes strings, lists, bools, nulls, and numerics.