### PR TITLE
fix(gax): apply configured factor in RetrySetting::strategy

### DIFF
--- a/foundation/gax/src/retry.rs
+++ b/foundation/gax/src/retry.rs
@@ -61,7 +61,7 @@ pub struct RetrySetting {
 
 impl Retry<Status, CodeCondition> for RetrySetting {
     fn strategy(&self) -> Take<ExponentialBackoff> {
-        let mut st = ExponentialBackoff::from_millis(self.from_millis);
+        let mut st = ExponentialBackoff::from_millis(self.from_millis).factor(self.factor);
         if let Some(max_delay) = self.max_delay {
             st = st.max_delay(max_delay);
         }


### PR DESCRIPTION
This makes use of the factor field to the backoff strategy.