### PR TITLE
feat(spanner): support Private Service Connect (PSC) endpoint override

### DIFF
--- a/spanner/src/apiv1/conn_pool.rs
+++ b/spanner/src/apiv1/conn_pool.rs
@@ -21,8 +21,23 @@ impl ConnectionManager {
         domain: &str,
         conn_options: &ConnectionOptions,
     ) -> Result<Self, Error> {
+        // Support Private Service Connect (PSC) endpoints for Spanner.
+        //
+        // When `domain` is a full HTTPS URL (e.g. "https://spanner-nonprod.p.googleapis.com")
+        // we use it as both the TLS SNI hostname and the gRPC connection target, mirroring
+        // the Java SDK's `SpannerOptions.setHost("https://...")` behaviour.
+        //
+        // When `domain` is a plain hostname (default: "spanner.googleapis.com") the existing
+        // behaviour is preserved: the public AUDIENCE constant is used as the target.
+        let (sni_domain, audience): (String, &str) = if domain.starts_with("https://") {
+            let host = domain.trim_start_matches("https://").trim_end_matches('/');
+            (host.to_string(), domain)
+        } else {
+            (domain.to_string(), AUDIENCE)
+        };
+
         Ok(ConnectionManager {
-            inner: GRPCConnectionManager::new(pool_size, domain, AUDIENCE, environment, conn_options).await?,
+            inner: GRPCConnectionManager::new(pool_size, sni_domain, audience, environment, conn_options).await?,
         })
     }
 


### PR DESCRIPTION
## Summary

When `ClientConfig.endpoint` is set to a full HTTPS URL (e.g. `https://spanner-nonprod.p.googleapis.com`), the existing code only used it for TLS SNI but still dialled the hardcoded public `AUDIENCE` (`https://spanner.googleapis.com/`) as the actual gRPC connection target. Private Service Connect (PSC) connections silently fell back to the public endpoint.

This PR mirrors the Java SDK's `SpannerOptions.setHost("https://...")` behaviour: when the configured endpoint starts with `https://`, extract the hostname for TLS SNI and use the full URL as the gRPC dial target.

## Change

`spanner/src/apiv1/conn_pool.rs` — 16 lines added, 1 line changed, fully backwards-compatible:
- **Plain hostname** (default `spanner.googleapis.com`): behaviour unchanged, `AUDIENCE` used as gRPC target
- **`https://` URL**: hostname used for TLS SNI, full URL used as gRPC dial target

## Reference
- [GCP Private Service Connect for Spanner](https://cloud.google.com/spanner/docs/private-service-connect)
- Java SDK equivalent: `SpannerOptions.setHost()`

## Testing

Battle-tested in production connecting from Azure AKS to non-prod Google Cloud Spanner via a Walmart PSC endpoint (`https://spanner-nonprod.p.googleapis.com`).