### PR TITLE
fix(spanner): evict session on 'Session not found' surfaced from the response stream

### DIFF
--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -384,10 +384,18 @@ where
                 Ok(s) => s,
                 Err(e) => {
                     if !self.reader.can_resume() || !self.resumable {
-                        return Err(e);
+                        // A "Session not found" NotFound from a server-expired session
+                        // surfaces here (on the first stream message, not the initial
+                        // call, which Reader::read already guards) — route it through
+                        // invalidate_if_needed so the dead session is evicted instead
+                        // of being recycled into the pool as valid.
+                        return self.session.invalidate_if_needed(Err(e)).await;
                     }
                     tracing::debug!("streaming error: {}. resume reading by resume_token", e);
-                    self.stream_retry.next(e).await?;
+                    if let Err(e) = self.stream_retry.next(e).await {
+                        // Retries exhausted / non-retryable: same eviction requirement.
+                        return self.session.invalidate_if_needed(Err(e)).await;
+                    }
                     let call_option = option.clone();
                     let result = self
                         .reader


### PR DESCRIPTION
## Problem

When Cloud Spanner expires an idle session server-side, the resulting `NotFound` / `Session not found` error for streaming calls (`ExecuteStreamingSql`, `StreamingRead`) surfaces on the **first `streaming.message().await`**, not on the initial RPC. The initial call is wrapped with `invalidate_if_needed` inside `Reader::read`, but `RowIterator::try_recv` returns stream-message errors directly.

As a result the dead session is recycled back into the pool still marked `valid`, and — because the pool reuses hot sessions and `release` refreshes `last_used_at` (so the health-checker keeps trusting it) — the same dead session is handed out again on subsequent requests indefinitely.

We hit this in production on Cloud Run: one instance served `Session not found` 500s for **two hours**, all on the same session name, until the instance was recycled. (On Cloud Run the background health-check task is CPU-throttled while the instance is idle, so idle sessions routinely outlive the ~1h server-side expiry — the pool only finds out on use, which is exactly the path that skipped invalidation.)

## Fix

Route both non-resuming error exits of `try_recv` through `SessionHandle::invalidate_if_needed`, matching what every unary path already does:

- the non-resumable arm (`!can_resume() || !resumable`) — where a dead session's error always lands, since no resume token exists yet;
- `StreamingRetry` exhaustion / non-retryable status.

## Verification

Reproduced against a real Spanner database: warm a session pool, delete the pool's sessions with `gcloud spanner databases sessions delete` (simulating server-side expiry), then issue queries.

- **Before**: the same dead session fails repeatedly and is never evicted.
- **After**: each dead session fails exactly once, is deleted from the pool, and the next request succeeds on a fresh session.

Happy to add an emulator test for this if you'd like — deleting the session via `DeleteSession` then issuing a query through the pool reproduces it deterministically.