### PR TITLE
feat(spanner): support multiplexed sessions (Spanner Omni)

### DIFF
--- a/spanner/docker-compose.omni.yml
+++ b/spanner/docker-compose.omni.yml
@@ -1,0 +1,74 @@
+# Spanner Omni: a full Spanner server in one container. It accepts only multiplexed
+# sessions, so the client needs `SessionConfig::multiplexed = true`.
+#
+#   docker compose -f docker-compose.omni.yml up -d --wait
+#   docker wait gcloud-spanner-omni-spanner-omni-init-1   # returns 0 once the schema exists
+#   cargo test -p gcloud-spanner --test omni_test -- --ignored
+#
+# Both waits are needed: `up --wait` returns as soon as the init container is running,
+# which is before it has applied the schema.
+
+name: gcloud-spanner-omni
+
+services:
+  spanner-omni:
+    image: ${SPANNER_OMNI_IMAGE:-us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r2.1-beta}
+    command: start-single-server
+    ports:
+      # Omni serves gRPC on 15000 inside the container.
+      - "${SPANNER_OMNI_PORT:-9011}:15000"
+    volumes:
+      - omni-data:/spanner
+    healthcheck:
+      # Absolute path: `CMD` does not run a shell, so PATH does not apply.
+      test: ["CMD", "/google/spanner/bin/spanner", "databases", "list"]
+      interval: 5s
+      timeout: 30s
+      retries: 40
+      start_period: 15s
+
+  # Omni does not create databases on demand, so one has to be made before use. The
+  # image ships its own CLI, which saves pulling a second image.
+  spanner-omni-init:
+    image: ${SPANNER_OMNI_IMAGE:-us-docker.pkg.dev/spanner-omni/images/spanner-omni:2026.r2.1-beta}
+    depends_on:
+      spanner-omni:
+        condition: service_healthy
+    volumes:
+      - ./tests/ddl:/ddl:ro
+    environment:
+      SPANNER_DATABASE_ID: ${SPANNER_DATABASE_ID:-local-database}
+    # The image has no bash and a toybox /bin/sh with no `set -e`, so every failure is
+    # checked explicitly.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        SPANNER=/google/spanner/bin/spanner
+        ENDPOINT=dns:///spanner-omni:15000
+        DB="$${SPANNER_DATABASE_ID}"
+
+        # `databases list` pads and indents its rows, so match on the exit code of
+        # `describe` rather than trying to find the name in the table.
+        if $$SPANNER databases describe "$$DB" --deployment-endpoint="$$ENDPOINT" >/dev/null 2>&1; then
+          echo "database $$DB already exists"
+          exit 0
+        fi
+
+        echo "creating database $$DB"
+        $$SPANNER databases create "$$DB" --deployment-endpoint="$$ENDPOINT" --timeout 5m
+        if [ $$? -ne 0 ]; then
+          echo "failed to create database $$DB"
+          exit 1
+        fi
+
+        echo "applying /ddl/schema.sql"
+        $$SPANNER databases ddl update "$$DB" --ddl-file=/ddl/schema.sql --deployment-endpoint="$$ENDPOINT"
+        if [ $$? -ne 0 ]; then
+          echo "failed to apply schema to $$DB"
+          exit 1
+        fi
+
+        echo "database $$DB is ready"
+
+volumes:
+  omni-data:

--- a/spanner/src/client.rs
+++ b/spanner/src/client.rs
@@ -80,6 +80,7 @@ impl Default for ChannelConfig {
 #[derive(Debug)]
 pub struct ClientConfig {
     /// SessionPoolConfig is the configuration for session pool.
+    /// For Spanner Omni, set `session_config.multiplexed = true`.
     pub session_config: SessionConfig,
     /// ChannelConfig is the configuration for gRPC connection.
     pub channel_config: ChannelConfig,
@@ -108,6 +109,11 @@ impl Default for ClientConfig {
         };
         config.session_config.min_opened = config.channel_config.num_channels * 4;
         config.session_config.max_opened = config.channel_config.num_channels * 100;
+        // Spanner Omni accepts only multiplexed sessions. Reading the switch from the
+        // environment, the same way SPANNER_EMULATOR_HOST already is, lets an application
+        // point at Omni without any code change.
+        config.session_config.multiplexed =
+            matches!(var("SPANNER_MULTIPLEXED_SESSIONS").as_deref(), Ok("true") | Ok("1"));
         config
     }
 }
@@ -423,7 +429,9 @@ impl Client {
                     mode: Some(transaction_options::Mode::ReadWrite(transaction_options::ReadWrite::default())),
                     isolation_level: IsolationLevel::Unspecified as i32,
                 });
-                match commit(session, ms.clone(), tx, options.clone(), self.disable_route_to_leader).await {
+                // A single-use transaction is begun and committed by the same request, so
+                // there is no earlier response that could have carried a precommit token.
+                match commit(session, ms.clone(), tx, options.clone(), self.disable_route_to_leader, None).await {
                     Ok(s) => Ok(Some(s.into())),
                     Err(e) => Err((Error::GRPC(e), session)),
                 }

--- a/spanner/src/reader.rs
+++ b/spanner/src/reader.rs
@@ -13,7 +13,7 @@ use google_cloud_googleapis::spanner::v1::{
 use crate::retry::StreamingRetry;
 use crate::row::Row;
 use crate::session::SessionHandle;
-use crate::transaction::CallOptions;
+use crate::transaction::{observe_precommit_token, CallOptions, PrecommitTokenSink};
 
 pub trait Reader: Send + Sync {
     fn read(
@@ -308,6 +308,10 @@ where
     resumable: bool,
     end_of_stream: bool,
     stream_retry: StreamingRetry,
+    /// Precommit tokens ride on the `PartialResultSet`s of a read-write transaction running
+    /// on a multiplexed session. The iterator holds the session borrow, so it reports them
+    /// through the owning transaction's shared slot rather than returning them.
+    precommit_token: PrecommitTokenSink,
 }
 
 impl<'a, T> RowIterator<'a, T>
@@ -319,6 +323,7 @@ where
         reader: T,
         option: Option<CallOptions>,
         disable_route_to_leader: bool,
+        precommit_token: PrecommitTokenSink,
     ) -> Result<RowIterator<'a, T>, Status> {
         let streaming = reader
             .read(session, option, disable_route_to_leader)
@@ -342,6 +347,7 @@ where
             resumable: true,
             end_of_stream: false,
             stream_retry: StreamingRetry::new(),
+            precommit_token,
         })
     }
 
@@ -400,10 +406,14 @@ where
             };
 
             match received {
-                Some(result_set) => {
+                Some(mut result_set) => {
                     if result_set.last {
                         self.end_of_stream = true;
                     }
+                    // Record the token as soon as it arrives rather than when the row is
+                    // delivered, so it survives an iterator that is dropped before the
+                    // buffer is drained.
+                    observe_precommit_token(&self.precommit_token, result_set.precommit_token.take());
                     self.prs_buffer.push(result_set);
                     if self.prs_buffer.unretryable {
                         self.resumable = false;

--- a/spanner/src/session.rs
+++ b/spanner/src/session.rs
@@ -18,7 +18,9 @@ use tracing::{Instrument, Span};
 use google_cloud_gax::grpc::metadata::MetadataMap;
 use google_cloud_gax::grpc::{Code, Status};
 use google_cloud_gax::retry::TryAs;
-use google_cloud_googleapis::spanner::v1::{BatchCreateSessionsRequest, DeleteSessionRequest, Session};
+use google_cloud_googleapis::spanner::v1::{
+    BatchCreateSessionsRequest, CreateSessionRequest, DeleteSessionRequest, Session,
+};
 
 use crate::apiv1::conn_pool::ConnectionManager;
 use crate::apiv1::spanner_client::{ping_query_request, Client};
@@ -73,6 +75,7 @@ impl SessionHandle {
         };
         match self.spanner_client.delete_session(request, true, None).await {
             Ok(_) => self.deleted = true,
+            // Multiplexed sessions cannot be deleted and will fail here.
             Err(e) => tracing::warn!("failed to delete session {}, {:?}", session_name, e),
         };
     }
@@ -239,8 +242,15 @@ impl SessionPool {
         disable_route_to_leader: bool,
         metrics: Arc<MetricsRecorder>,
     ) -> Result<Self, Status> {
-        let available_sessions =
-            Self::init_pool(database, conn_pool, config.min_opened, disable_route_to_leader, metrics.clone()).await?;
+        let available_sessions = Self::init_pool(
+            database,
+            conn_pool,
+            config.min_opened,
+            disable_route_to_leader,
+            config.multiplexed,
+            metrics.clone(),
+        )
+        .await?;
         let pool = SessionPool {
             inner: Arc::new(RwLock::new(Sessions {
                 available_sessions,
@@ -264,6 +274,7 @@ impl SessionPool {
         conn_pool: &ConnectionManager,
         min_opened: usize,
         disable_route_to_leader: bool,
+        multiplexed: bool,
         metrics: Arc<MetricsRecorder>,
     ) -> Result<VecDeque<SessionHandle>, Status> {
         let channel_num = conn_pool.num();
@@ -284,9 +295,13 @@ impl SessionPool {
                 .with_metrics(metrics.clone())
                 .with_metadata(client_metadata(&database));
             let database = database.clone();
-            tasks.spawn(async move {
-                batch_create_sessions(next_client, &database, creation_count, disable_route_to_leader).await
-            }.instrument(Span::current()));
+            tasks.spawn(
+                async move {
+                    batch_create_sessions(next_client, &database, creation_count, disable_route_to_leader, multiplexed)
+                        .await
+                }
+                .instrument(Span::current()),
+            );
         }
         while let Some(r) = tasks.join_next().await {
             let new_sessions = r.map_err(|e| Status::from_error(e.into()))??;
@@ -417,6 +432,7 @@ impl SessionPool {
     fn snapshot_fn(&self) -> SessionPoolStatsFn {
         let inner = self.inner.clone();
         let max_allowed = self.config.max_opened;
+        let has_multiplexed = self.config.multiplexed;
         Arc::new(move || {
             let sessions = inner.read();
             SessionPoolSnapshot {
@@ -425,7 +441,7 @@ impl SessionPool {
                 idle_sessions: sessions.available_sessions.len(),
                 max_allowed_sessions: max_allowed,
                 max_in_use_last_window: sessions.max_inuse_window,
-                has_multiplexed_session: false,
+                has_multiplexed_session: has_multiplexed,
             }
         })
     }
@@ -475,6 +491,18 @@ pub struct SessionConfig {
     /// incStep is the number of sessions to create in one batch when at least
     /// one more session is needed.
     inc_step: usize,
+
+    /// multiplexed creates multiplexed sessions instead of regular ones.
+    ///
+    /// A multiplexed session is a single shared session that cannot be deleted and does
+    /// not idle out, so most of the pool's sizing, eviction and health-check logic stops
+    /// being meaningful — but it is left in place and simply becomes redundant.
+    ///
+    /// Required by Spanner Omni, which rejects regular sessions with
+    /// `InvalidArgument: Please use multiplexed sessions.` Real Cloud Spanner and the
+    /// Cloud Spanner emulator both still accept regular sessions, so this defaults to
+    /// `false` and the existing behaviour is unchanged unless it is opted into.
+    pub multiplexed: bool,
 }
 
 impl Default for SessionConfig {
@@ -488,6 +516,7 @@ impl Default for SessionConfig {
             session_alive_trust_duration: Duration::from_secs(55 * 60),
             session_get_timeout: Duration::from_secs(1),
             refresh_interval: Duration::from_secs(5 * 60),
+            multiplexed: false,
         }
     }
 }
@@ -538,7 +567,7 @@ impl SessionManager {
         .await?;
 
         let cancel = CancellationToken::new();
-        let task_session_cleaner = Self::spawn_health_check_task(config, session_pool.clone(), cancel.clone());
+        let task_session_cleaner = Self::spawn_health_check_task(config.clone(), session_pool.clone(), cancel.clone());
         let task_session_creator = Self::spawn_session_creation_task(
             session_pool.clone(),
             database,
@@ -546,6 +575,7 @@ impl SessionManager {
             receiver,
             cancel.clone(),
             disable_route_to_leader,
+            config.multiplexed,
         );
 
         let sm = SessionManager {
@@ -583,6 +613,7 @@ impl SessionManager {
         mut rx: UnboundedReceiver<usize>,
         cancel: CancellationToken,
         disable_route_to_leader: bool,
+        multiplexed: bool,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut tasks = JoinSet::default();
@@ -600,7 +631,7 @@ impl SessionManager {
                                 .with_metrics(session_pool.metrics.clone())
                                 .with_metadata(client_metadata(&database));
                             let database = database.clone();
-                            tasks.spawn(async move { (session_count, batch_create_sessions(client, &database, session_count, disable_route_to_leader).await) });
+                            tasks.spawn(async move { (session_count, batch_create_sessions(client, &database, session_count, disable_route_to_leader, multiplexed).await) });
                         },
                         None => continue
                     },
@@ -699,6 +730,7 @@ async fn batch_create_sessions(
     database: &str,
     mut remaining_create_count: usize,
     disable_route_to_leader: bool,
+    multiplexed: bool,
 ) -> Result<Vec<SessionHandle>, Status> {
     let mut created = Vec::with_capacity(remaining_create_count);
     while remaining_create_count > 0 {
@@ -707,6 +739,7 @@ async fn batch_create_sessions(
             database,
             remaining_create_count,
             disable_route_to_leader,
+            multiplexed,
         )
         .await?;
         // Spanner could return less sessions than requested.
@@ -723,25 +756,49 @@ async fn batch_create_session(
     database: &str,
     session_count: usize,
     disable_route_to_leader: bool,
+    multiplexed: bool,
 ) -> Result<Vec<SessionHandle>, Status> {
-    let request = BatchCreateSessionsRequest {
-        database: database.to_string(),
-        session_template: None,
-        session_count: session_count as i32,
-    };
-
-    tracing::debug!("spawn session creation request : session_count = {}", session_count);
-    let response = spanner_client
-        .batch_create_sessions(request, disable_route_to_leader, None)
-        .await?
-        .into_inner();
-
     let now = Instant::now();
-    Ok(response
-        .session
-        .into_iter()
-        .map(|s| SessionHandle::new(s, spanner_client.clone(), now))
-        .collect::<Vec<SessionHandle>>())
+
+    if multiplexed {
+        // Multiplexed sessions must be created one at a time using create_session.
+        tracing::debug!("spawn multiplexed session creation request : session_count = {}", session_count);
+        let mut sessions = Vec::with_capacity(session_count);
+        for _ in 0..session_count {
+            let request = CreateSessionRequest {
+                database: database.to_string(),
+                session: Some(Session {
+                    multiplexed: true,
+                    ..Default::default()
+                }),
+            };
+            let response = spanner_client
+                .create_session(request, disable_route_to_leader, None)
+                .await?
+                .into_inner();
+            sessions.push(SessionHandle::new(response, spanner_client.clone(), now));
+        }
+        Ok(sessions)
+    } else {
+        // Regular sessions use batch creation.
+        let request = BatchCreateSessionsRequest {
+            database: database.to_string(),
+            session_template: None,
+            session_count: session_count as i32,
+        };
+
+        tracing::debug!("spawn session creation request : session_count = {}", session_count);
+        let response = spanner_client
+            .batch_create_sessions(request, disable_route_to_leader, None)
+            .await?
+            .into_inner();
+
+        Ok(response
+            .session
+            .into_iter()
+            .map(|s| SessionHandle::new(s, spanner_client.clone(), now))
+            .collect::<Vec<SessionHandle>>())
+    }
 }
 
 pub(crate) fn client_metadata(database: &str) -> MetadataMap {
@@ -1223,7 +1280,7 @@ mod tests {
             .with_metrics(Arc::new(MetricsRecorder::default()))
             .with_metadata(client_metadata(DATABASE));
         let session_count = 125;
-        let result = batch_create_sessions(client.clone(), DATABASE, session_count, false).await;
+        let result = batch_create_sessions(client.clone(), DATABASE, session_count, false, false).await;
         match result {
             Ok(created) => {
                 assert_eq!(session_count, created.len());

--- a/spanner/src/transaction.rs
+++ b/spanner/src/transaction.rs
@@ -1,6 +1,8 @@
 use std::ops::DerefMut;
 use std::sync::atomic::AtomicI64;
+use std::sync::Arc;
 
+use parking_lot::Mutex;
 use prost_types::Struct;
 
 use google_cloud_gax::grpc::Status;
@@ -8,7 +10,7 @@ use google_cloud_gax::retry::RetrySetting;
 use google_cloud_googleapis::spanner::v1::request_options::Priority;
 use google_cloud_googleapis::spanner::v1::{
     execute_sql_request::QueryMode, execute_sql_request::QueryOptions as ExecuteQueryOptions, ExecuteSqlRequest,
-    ReadRequest, RequestOptions, TransactionSelector,
+    MultiplexedSessionPrecommitToken, ReadRequest, RequestOptions, TransactionSelector,
 };
 
 use crate::key::{Key, KeySet};
@@ -98,6 +100,28 @@ impl Default for QueryOptions {
     }
 }
 
+/// Shared slot holding the highest-sequence precommit token seen during a transaction.
+///
+/// Spanner rejects a read-write commit on a multiplexed session unless the request carries
+/// the most recent precommit token, and tokens arrive on several different responses --
+/// including the `PartialResultSet`s that a [`RowIterator`] consumes while it holds the
+/// session borrow. A shared slot lets the iterator record tokens without having to hand
+/// anything back to the transaction that owns it.
+///
+/// Regular sessions never receive tokens, so the slot simply stays empty for them.
+pub(crate) type PrecommitTokenSink = Arc<Mutex<Option<MultiplexedSessionPrecommitToken>>>;
+
+/// Records `token` if it is newer than whatever the sink already holds.
+pub(crate) fn observe_precommit_token(sink: &PrecommitTokenSink, token: Option<MultiplexedSessionPrecommitToken>) {
+    let Some(token) = token else {
+        return;
+    };
+    let mut current = sink.lock();
+    if current.as_ref().is_none_or(|held| token.seq_num > held.seq_num) {
+        *current = Some(token);
+    }
+}
+
 pub struct Transaction {
     pub(crate) session: Option<ManagedSession>,
     // for returning ownership of session on before destroy
@@ -108,9 +132,18 @@ pub struct Transaction {
     /// disableRouteToLeader specifies if all the requests of type read-write and PDML
     /// need to be routed to the leader region.
     pub(crate) disable_route_to_leader: bool,
+    /// Highest-sequence precommit token observed so far. Only ever populated when the
+    /// transaction runs on a multiplexed session.
+    pub(crate) precommit_token: PrecommitTokenSink,
 }
 
 impl Transaction {
+    /// Whether this transaction runs on a multiplexed session, which is what makes the
+    /// precommit token and `mutation_key` plumbing necessary.
+    pub(crate) fn uses_multiplexed_session(&self) -> bool {
+        self.session.as_ref().is_some_and(|s| s.session.multiplexed)
+    }
+
     pub(crate) fn create_request_options(
         priority: Option<Priority>,
         transaction_tag: Option<String>,
@@ -161,12 +194,20 @@ impl Transaction {
             directed_read_options: None,
             last_statement: false,
         };
+        let precommit_token = self.precommit_token.clone();
         let session = self.session.as_mut().unwrap().deref_mut();
         let reader = StatementReader {
             enable_resume: options.enable_resume,
             request,
         };
-        RowIterator::new(session, reader, Some(options.call_options), self.disable_route_to_leader).await
+        RowIterator::new(
+            session,
+            reader,
+            Some(options.call_options),
+            self.disable_route_to_leader,
+            precommit_token,
+        )
+        .await
     }
 
     /// read returns a RowIterator for reading multiple rows from the database.
@@ -228,9 +269,17 @@ impl Transaction {
         };
 
         let disable_route_to_leader = self.disable_route_to_leader;
+        let precommit_token = self.precommit_token.clone();
         let session = self.as_mut_session();
         let reader = TableReader { request };
-        RowIterator::new(session, reader, Some(options.call_options), disable_route_to_leader).await
+        RowIterator::new(
+            session,
+            reader,
+            Some(options.call_options),
+            disable_route_to_leader,
+            precommit_token,
+        )
+        .await
     }
 
     /// read returns a RowIterator for reading multiple rows from the database.
@@ -278,5 +327,40 @@ impl Transaction {
     /// must drop destroy after this method.
     pub(crate) fn take_session(&mut self) -> Option<ManagedSession> {
         self.session.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use google_cloud_googleapis::spanner::v1::MultiplexedSessionPrecommitToken;
+
+    use crate::transaction::{observe_precommit_token, PrecommitTokenSink};
+
+    fn token(seq_num: i32) -> Option<MultiplexedSessionPrecommitToken> {
+        Some(MultiplexedSessionPrecommitToken {
+            precommit_token: vec![seq_num as u8],
+            seq_num,
+        })
+    }
+
+    #[test]
+    fn test_observe_precommit_token_keeps_highest_seq_num() {
+        let sink = PrecommitTokenSink::default();
+        assert!(sink.lock().is_none());
+
+        observe_precommit_token(&sink, token(2));
+        assert_eq!(sink.lock().as_ref().unwrap().seq_num, 2);
+
+        // An older token must not displace the one already held.
+        observe_precommit_token(&sink, token(1));
+        assert_eq!(sink.lock().as_ref().unwrap().seq_num, 2);
+
+        observe_precommit_token(&sink, token(3));
+        assert_eq!(sink.lock().as_ref().unwrap().seq_num, 3);
+
+        // Responses without a token leave the sink alone, which is the only thing that
+        // ever happens on a regular session.
+        observe_precommit_token(&sink, None);
+        assert_eq!(sink.lock().as_ref().unwrap().seq_num, 3);
     }
 }

--- a/spanner/src/transaction_ro.rs
+++ b/spanner/src/transaction_ro.rs
@@ -66,6 +66,7 @@ impl ReadOnlyTransaction {
                 },
                 transaction_tag: None,
                 disable_route_to_leader: true,
+                precommit_token: Default::default(),
             },
             rts: None,
         })
@@ -106,6 +107,7 @@ impl ReadOnlyTransaction {
                         },
                         transaction_tag: None,
                         disable_route_to_leader: true,
+                        precommit_token: Default::default(),
                     },
                     rts: Some(OffsetDateTime::from(st)),
                 })
@@ -307,7 +309,8 @@ impl BatchReadOnlyTransaction {
         option: Option<CallOptions>,
     ) -> Result<RowIterator<'_, T>, Status> {
         let disable_route_to_leader = self.disable_route_to_leader;
+        let precommit_token = self.precommit_token.clone();
         let session = self.as_mut_session();
-        RowIterator::new(session, partition.reader, option, disable_route_to_leader).await
+        RowIterator::new(session, partition.reader, option, disable_route_to_leader, precommit_token).await
     }
 }

--- a/spanner/src/transaction_rw.rs
+++ b/spanner/src/transaction_rw.rs
@@ -7,17 +7,23 @@ use prost_types::Struct;
 
 use crate::session::ManagedSession;
 use crate::statement::Statement;
-use crate::transaction::{CallOptions, QueryOptions, Transaction};
+use crate::transaction::{observe_precommit_token, CallOptions, PrecommitTokenSink, QueryOptions, Transaction};
 use crate::value::Timestamp;
 use google_cloud_gax::grpc::{Code, Status};
 use google_cloud_gax::retry::{RetrySetting, TryAs};
 use google_cloud_googleapis::spanner::v1::commit_request::Transaction::TransactionId;
 use google_cloud_googleapis::spanner::v1::transaction_options::IsolationLevel;
 use google_cloud_googleapis::spanner::v1::{
-    commit_request, execute_batch_dml_request, result_set_stats, transaction_options, transaction_selector,
-    BeginTransactionRequest, CommitRequest, CommitResponse, ExecuteBatchDmlRequest, ExecuteSqlRequest, Mutation,
-    ResultSetStats, RollbackRequest, TransactionOptions, TransactionSelector,
+    commit_request, commit_response, execute_batch_dml_request, result_set_stats, transaction_options,
+    transaction_selector, BeginTransactionRequest, CommitRequest, CommitResponse, ExecuteBatchDmlRequest,
+    ExecuteSqlRequest, MultiplexedSessionPrecommitToken, Mutation, ResultSetStats, RollbackRequest, TransactionOptions,
+    TransactionSelector,
 };
+
+/// A commit on a multiplexed session can succeed at the RPC level without having committed,
+/// returning a fresh precommit token and asking to be retried with it. Bound how often that
+/// exchange may repeat so a misbehaving backend cannot loop forever.
+const MAX_PRECOMMIT_TOKEN_RETRIES: usize = 3;
 
 #[derive(Clone, Default)]
 pub struct CommitOptions {
@@ -181,6 +187,11 @@ impl ReadWriteTransaction {
             }
         };
         let tx = response.into_inner();
+        let precommit_token = PrecommitTokenSink::default();
+        // BeginTransaction only returns a token when a mutation_key was supplied, which it
+        // never is here -- see begin_with_mutation_key. Observe it anyway so the source is
+        // handled uniformly with the others.
+        observe_precommit_token(&precommit_token, tx.precommit_token);
         Ok(ReadWriteTransaction {
             base_tx: Transaction {
                 session: Some(session),
@@ -190,10 +201,57 @@ impl ReadWriteTransaction {
                 },
                 transaction_tag,
                 disable_route_to_leader,
+                precommit_token,
             },
             tx_id: tx.id,
             wb: vec![],
         })
+    }
+
+    /// Re-issues BeginTransaction with a `mutation_key` so that Spanner hands back a
+    /// precommit token.
+    ///
+    /// A read-write transaction on a multiplexed session must commit with a precommit
+    /// token. Tokens normally ride on statement responses, but a transaction that only
+    /// buffers mutations never runs a statement, so its only possible source is
+    /// BeginTransaction -- and BeginTransaction only returns one when a `mutation_key` was
+    /// supplied. Mutations are buffered after the transaction begins, so the key is not
+    /// known until commit time and the transaction has to be begun a second time.
+    ///
+    /// The transaction being replaced has run no statements, which is exactly what "no
+    /// token yet" means here, so nothing is lost by starting a new one. Any buffered
+    /// mutation serves as the key; Spanner only uses it to route the transaction.
+    async fn begin_with_mutation_key(&mut self, options: &CommitOptions) -> Result<(), Status> {
+        let Some(mutation_key) = self.wb.first().cloned() else {
+            return Ok(());
+        };
+        let request = BeginTransactionRequest {
+            session: self.get_session_name(),
+            options: Some(TransactionOptions {
+                exclude_txn_from_change_streams: false,
+                mode: Some(transaction_options::Mode::ReadWrite(transaction_options::ReadWrite::default())),
+                isolation_level: IsolationLevel::Unspecified as i32,
+            }),
+            request_options: Transaction::create_request_options(
+                options.call_options.priority,
+                self.base_tx.transaction_tag.clone(),
+            ),
+            mutation_key: Some(mutation_key),
+        };
+        let disable_route_to_leader = self.disable_route_to_leader;
+        let precommit_token = self.base_tx.precommit_token.clone();
+        let session = self.as_mut_session();
+        let result = session
+            .spanner_client
+            .begin_transaction(request, disable_route_to_leader, options.call_options.retry.clone())
+            .await;
+        let tx = session.invalidate_if_needed(result).await?.into_inner();
+        observe_precommit_token(&precommit_token, tx.precommit_token);
+        self.tx_id = tx.id.clone();
+        self.base_tx.transaction_selector = TransactionSelector {
+            selector: Some(transaction_selector::Selector::Id(tx.id)),
+        };
+        Ok(())
     }
 
     pub fn buffer_write(&mut self, ms: Vec<Mutation>) {
@@ -225,13 +283,15 @@ impl ReadWriteTransaction {
             last_statement: false,
         };
         let disable_route_to_leader = self.disable_route_to_leader;
+        let precommit_token = self.base_tx.precommit_token.clone();
         let session = self.as_mut_session();
         let result = session
             .spanner_client
             .execute_sql(request, disable_route_to_leader, options.call_options.retry)
             .await;
-        let response = session.invalidate_if_needed(result).await?;
-        Ok(extract_row_count(response.into_inner().stats))
+        let response = session.invalidate_if_needed(result).await?.into_inner();
+        observe_precommit_token(&precommit_token, response.precommit_token);
+        Ok(extract_row_count(response.stats))
     }
 
     pub async fn batch_update(&mut self, stmt: Vec<Statement>) -> Result<Vec<i64>, Status> {
@@ -263,14 +323,15 @@ impl ReadWriteTransaction {
         };
 
         let disable_route_to_leader = self.disable_route_to_leader;
+        let precommit_token = self.base_tx.precommit_token.clone();
         let session = self.as_mut_session();
         let result = session
             .spanner_client
             .execute_batch_dml(request, disable_route_to_leader, options.call_options.retry)
             .await;
-        let response = session.invalidate_if_needed(result).await?;
+        let response = session.invalidate_if_needed(result).await?.into_inner();
+        observe_precommit_token(&precommit_token, response.precommit_token);
         Ok(response
-            .into_inner()
             .result_sets
             .into_iter()
             .map(|x| extract_row_count(x.stats))
@@ -349,11 +410,25 @@ impl ReadWriteTransaction {
     }
 
     pub(crate) async fn commit(&mut self, options: CommitOptions) -> Result<CommitResponse, Status> {
+        // On a multiplexed session a mutation-only transaction has no statement response to
+        // take a precommit token from, and Spanner will not commit without one.
+        if self.uses_multiplexed_session() && !self.wb.is_empty() && self.base_tx.precommit_token.lock().is_none() {
+            self.begin_with_mutation_key(&options).await?;
+        }
         let tx_id = self.tx_id.clone();
         let mutations = self.wb.to_vec();
         let disable_route_to_leader = self.disable_route_to_leader;
+        let precommit_token = self.base_tx.precommit_token.lock().clone();
         let session = self.as_mut_session();
-        commit(session, mutations, TransactionId(tx_id), options, disable_route_to_leader).await
+        commit(
+            session,
+            mutations,
+            TransactionId(tx_id),
+            options,
+            disable_route_to_leader,
+            precommit_token,
+        )
+        .await
     }
 
     pub(crate) async fn rollback(&mut self, retry: Option<RetrySetting>) -> Result<(), Status> {
@@ -378,28 +453,54 @@ pub(crate) async fn commit(
     tx: commit_request::Transaction,
     commit_options: CommitOptions,
     disable_route_to_leader: bool,
+    precommit_token: Option<MultiplexedSessionPrecommitToken>,
 ) -> Result<CommitResponse, Status> {
-    let request = CommitRequest {
-        session: session.session.name.to_string(),
-        mutations: ms,
-        transaction: Some(tx),
-        request_options: Transaction::create_request_options(
-            commit_options.call_options.priority,
-            commit_options.transaction_tag.clone(),
-        ),
-        return_commit_stats: commit_options.return_commit_stats,
-        max_commit_delay: commit_options.max_commit_delay.map(|d| d.try_into().unwrap()),
-        precommit_token: None,
+    // Only a multiplexed session can answer a commit with "not committed, try again with
+    // this token", so the regular path stays a single request and never has to keep a copy
+    // of the mutations around.
+    let attempts = if session.session.multiplexed {
+        MAX_PRECOMMIT_TOKEN_RETRIES
+    } else {
+        1
     };
-    let result = session
-        .spanner_client
-        .commit(request, disable_route_to_leader, commit_options.call_options.retry)
-        .await;
-    let response = session.invalidate_if_needed(result).await;
-    match response {
-        Ok(r) => Ok(r.into_inner()),
-        Err(s) => Err(s),
+    let mut precommit_token = precommit_token;
+    let mut mutations = ms;
+
+    for attempt in 1..=attempts {
+        let request = CommitRequest {
+            session: session.session.name.to_string(),
+            mutations: if attempt == attempts {
+                std::mem::take(&mut mutations)
+            } else {
+                mutations.clone()
+            },
+            transaction: Some(tx.clone()),
+            request_options: Transaction::create_request_options(
+                commit_options.call_options.priority,
+                commit_options.transaction_tag.clone(),
+            ),
+            return_commit_stats: commit_options.return_commit_stats,
+            max_commit_delay: commit_options.max_commit_delay.map(|d| d.try_into().unwrap()),
+            precommit_token: precommit_token.take(),
+        };
+        let result = session
+            .spanner_client
+            .commit(request, disable_route_to_leader, commit_options.call_options.retry.clone())
+            .await;
+        let response = session.invalidate_if_needed(result).await?.into_inner();
+        match response.multiplexed_session_retry {
+            Some(commit_response::MultiplexedSessionRetry::PrecommitToken(token)) => {
+                tracing::debug!("commit was not applied, retrying with the returned precommit token");
+                precommit_token = Some(token);
+            }
+            None => return Ok(response),
+        }
     }
+
+    Err(Status::new(
+        Code::Aborted,
+        "commit did not complete after retrying with the precommit tokens returned by Spanner",
+    ))
 }
 
 fn extract_row_count(rs: Option<ResultSetStats>) -> i64 {

--- a/spanner/tests/client_test.rs
+++ b/spanner/tests/client_test.rs
@@ -22,7 +22,10 @@ fn init() {
     let filter = tracing_subscriber::filter::EnvFilter::from_default_env()
         .add_directive("google_cloud_spanner=trace".parse().unwrap());
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
-    std::env::set_var("SPANNER_EMULATOR_HOST", "localhost:9010");
+    // Leave an explicitly configured host alone so the suite can be pointed at Spanner Omni.
+    if std::env::var("SPANNER_EMULATOR_HOST").is_err() {
+        std::env::set_var("SPANNER_EMULATOR_HOST", "localhost:9010");
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -195,7 +198,9 @@ async fn test_batch_read_only_transaction() {
         .map(|x| create_user_mutation(&format!("user_partition_{}_{}", now.unix_timestamp(), x), &now))
         .collect();
     let data_client = create_data_client().await;
-    data_client.apply(many).await.unwrap();
+    // Too many mutations for a single transaction; only the row count is asserted below,
+    // so the per-chunk commit timestamps do not matter here.
+    apply_in_chunks(&data_client, many, USER_ROWS_PER_COMMIT).await;
 
     // test
     let client = Client::new(DATABASE, ClientConfig::default()).await.unwrap();

--- a/spanner/tests/common.rs
+++ b/spanner/tests/common.rs
@@ -12,6 +12,7 @@ use google_cloud_spanner::row::{Error as RowError, Row, Struct, TryFromStruct};
 use google_cloud_spanner::session::SessionConfig;
 use google_cloud_spanner::statement::Statement;
 use google_cloud_spanner::transaction_ro::BatchReadOnlyTransaction;
+use google_cloud_spanner::transaction_rw::CommitResult;
 use google_cloud_spanner::value::CommitTimestamp;
 
 use google_cloud_spanner::bigdecimal::BigDecimal;
@@ -120,17 +121,65 @@ pub fn user_columns() -> Vec<&'static str> {
     ]
 }
 
+/// The backend the tests run against.
+///
+/// Defaults to the Cloud Spanner emulator on its usual port. Set `SPANNER_EMULATOR_HOST` to
+/// point somewhere else, and `SPANNER_MULTIPLEXED_SESSIONS=true` to use multiplexed
+/// sessions, which is the only kind Spanner Omni accepts.
+#[allow(dead_code)]
+pub fn emulator_host() -> String {
+    std::env::var("SPANNER_EMULATOR_HOST").unwrap_or_else(|_| "localhost:9010".to_string())
+}
+
+#[allow(dead_code)]
+pub fn multiplexed_sessions() -> bool {
+    matches!(std::env::var("SPANNER_MULTIPLEXED_SESSIONS").as_deref(), Ok("true" | "1"))
+}
+
+/// Rows per commit for bulk `User` fixtures: 19 columns x 5,000 rows = 95,000 mutations.
+#[allow(dead_code)]
+pub const USER_ROWS_PER_COMMIT: usize = 5_000;
+
+/// Applies `mutations` in chunks, returning one [`CommitResult`] per chunk, in order.
+///
+/// Spanner refuses a commit carrying more than 120,000 mutations, counted once per column
+/// affected, so a fixture of tens of thousands of `User` rows cannot go in one transaction.
+/// The Cloud Spanner emulator does not enforce that limit, but real Cloud Spanner and
+/// Spanner Omni both do.
+///
+/// Each chunk commits separately and so gets its own commit timestamp; the rows written by
+/// chunk `i` carry the timestamp of `results[i]`. Use [`chunk_timestamp`] to recover it.
+#[allow(dead_code)]
+pub async fn apply_in_chunks(client: &Client, mutations: Vec<Mutation>, rows_per_commit: usize) -> Vec<CommitResult> {
+    let mut results = Vec::new();
+    for chunk in mutations.chunks(rows_per_commit) {
+        results.push(client.apply(chunk.to_vec()).await.unwrap());
+    }
+    results
+}
+
+/// The commit timestamp of the chunk that the mutation at `index` was written in.
+#[allow(dead_code)]
+pub fn chunk_timestamp(results: &[CommitResult], index: usize, rows_per_commit: usize) -> OffsetDateTime {
+    let ts = results[index / rows_per_commit].timestamp.clone().unwrap();
+    OffsetDateTime::from_unix_timestamp(ts.seconds)
+        .unwrap()
+        .replace_nanosecond(ts.nanos as u32)
+        .unwrap()
+}
+
 #[allow(dead_code)]
 pub async fn create_data_client() -> Client {
     let mut session_config = SessionConfig::default();
     session_config.min_opened = 1;
     session_config.max_opened = 1;
+    session_config.multiplexed = multiplexed_sessions();
 
     Client::new(
         DATABASE,
         ClientConfig {
             session_config,
-            environment: Environment::Emulator("localhost:9010".to_string()),
+            environment: Environment::Emulator(emulator_host()),
             channel_config: ChannelConfig {
                 num_channels: 1,
                 ..Default::default()

--- a/spanner/tests/omni_test.rs
+++ b/spanner/tests/omni_test.rs
@@ -1,0 +1,187 @@
+//! Integration tests against a local **Spanner Omni** container.
+//!
+//! Omni is a full Spanner server in a single container. Unlike the Cloud Spanner emulator
+//! it accepts **only multiplexed sessions**, so a client that creates regular sessions
+//! fails at startup with:
+//!
+//! ```text
+//! InvalidArgument: Please use multiplexed sessions.
+//! Only Multiplexed sessions are supported in this environment.
+//! ```
+//!
+//! [`regular_sessions_are_rejected_by_omni`] pins that failure, and
+//! [`multiplexed_sessions_work`] walks every code path multiplexed sessions change:
+//!
+//! 1. session creation (`CreateSession { multiplexed: true }`)
+//! 2. a DML-only read-write transaction        -> precommit token from `ExecuteSql`
+//! 3. a batch-DML read-write transaction       -> precommit token from `ExecuteBatchDml`
+//! 4. a streaming query in a read-write transaction -> token from `PartialResultSet`
+//! 5. a mutation-only read-write transaction   -> needs `mutation_key` on `BeginTransaction`
+//! 6. a single-use read-only transaction
+//!
+//! Both tests are `#[ignore]`d because they need the container, and neither reads any
+//! environment variable. From the `spanner/` directory:
+//!
+//! ```sh
+//! docker compose -f docker-compose.omni.yml up -d
+//! docker compose -f docker-compose.omni.yml wait spanner-omni-init
+//! cargo test -p gcloud-spanner --test omni_test -- --ignored --nocapture
+//! ```
+//!
+//! Omni serves a single implicit instance and ignores the project/instance segments of the
+//! database path on the data plane, so `DATABASE` keeps the shape used against real Cloud
+//! Spanner.
+
+use gcloud_spanner::client::{ChannelConfig, Client, ClientConfig, Error};
+use gcloud_spanner::key::Key;
+use gcloud_spanner::mutation::insert_or_update;
+use gcloud_spanner::statement::Statement;
+use gcloud_spanner::value::CommitTimestamp;
+use google_cloud_gax::conn::Environment;
+use google_cloud_gax::grpc::Code;
+
+const DATABASE: &str = "projects/local-project/instances/test-instance/databases/local-database";
+/// Matches the default `SPANNER_OMNI_PORT` in docker-compose.omni.yml.
+const OMNI_HOST: &str = "localhost:9011";
+
+const OWNER_ID: &str = "omni-owner";
+
+const NEEDS_OMNI: &str = "requires a local Spanner Omni container; see spanner/docker-compose.omni.yml";
+
+/// A client pointed at Omni. `Environment::Emulator` is what skips auth, so nothing here
+/// depends on `SPANNER_EMULATOR_HOST` or any other variable being set.
+fn omni_config(multiplexed: bool) -> ClientConfig {
+    let mut config = ClientConfig {
+        environment: Environment::Emulator(OMNI_HOST.to_string()),
+        channel_config: ChannelConfig {
+            num_channels: 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    config.session_config.min_opened = 1;
+    config.session_config.max_opened = 4;
+    config.session_config.multiplexed = multiplexed;
+    config
+}
+
+/// The bug this feature fixes: without multiplexed sessions the client cannot even connect.
+#[tokio::test]
+#[ignore = "requires a local Spanner Omni container; see spanner/docker-compose.omni.yml"]
+async fn regular_sessions_are_rejected_by_omni() {
+    let result = Client::new(DATABASE, omni_config(false)).await;
+
+    let Err(Error::GRPC(status)) = result else {
+        panic!("expected Omni to reject regular sessions, got {:?}", result.err());
+    };
+    assert_eq!(
+        status.code(),
+        Code::InvalidArgument,
+        "unexpected status: {status:?} ({NEEDS_OMNI})"
+    );
+    assert!(
+        status.message().to_lowercase().contains("multiplexed"),
+        "expected the rejection to mention multiplexed sessions, got: {}",
+        status.message()
+    );
+}
+
+/// The same client with `multiplexed = true` drives every affected path end to end.
+#[tokio::test]
+#[ignore = "requires a local Spanner Omni container; see spanner/docker-compose.omni.yml"]
+async fn multiplexed_sessions_work() -> Result<(), Error> {
+    // Step 1: session creation. This is where the unmodified client dies.
+    let client = Client::new(DATABASE, omni_config(true)).await?;
+
+    // Step 2: DML-only read-write transaction. The precommit token arrives on the
+    // ExecuteSql response.
+    client
+        .read_write_transaction::<(), Error, _>(|tx| {
+            Box::pin(async move {
+                let mut stmt = Statement::new(
+                    "INSERT OR UPDATE INTO Guild (GuildId, OwnerUserId, UpdatedAt) \
+                     VALUES (@GuildId, @OwnerUserId, PENDING_COMMIT_TIMESTAMP())",
+                );
+                stmt.add_param("GuildId", &"omni-guild-dml");
+                stmt.add_param("OwnerUserId", &OWNER_ID);
+                assert_eq!(tx.update(stmt).await?, 1);
+                Ok(())
+            })
+        })
+        .await?;
+
+    // Step 3: batch DML. The precommit token arrives on the ExecuteBatchDml response.
+    client
+        .read_write_transaction::<(), Error, _>(|tx| {
+            Box::pin(async move {
+                let stmts = (0..2)
+                    .map(|i| {
+                        let mut stmt = Statement::new(
+                            "INSERT OR UPDATE INTO Guild (GuildId, OwnerUserId, UpdatedAt) \
+                             VALUES (@GuildId, @OwnerUserId, PENDING_COMMIT_TIMESTAMP())",
+                        );
+                        stmt.add_param("GuildId", &format!("omni-guild-batch-{i}"));
+                        stmt.add_param("OwnerUserId", &OWNER_ID);
+                        stmt
+                    })
+                    .collect();
+                assert_eq!(tx.batch_update(stmts).await?, vec![1, 1]);
+                Ok(())
+            })
+        })
+        .await?;
+
+    // Step 4: streaming query inside a read-write transaction, then a mutation. Tokens
+    // ride on PartialResultSet here, and the iterator holds the session borrow while they
+    // arrive.
+    let (_, found) = client
+        .read_write_transaction::<usize, Error, _>(|tx| {
+            Box::pin(async move {
+                let mut stmt = Statement::new("SELECT GuildId FROM Guild WHERE OwnerUserId = @OwnerUserId");
+                stmt.add_param("OwnerUserId", &OWNER_ID);
+                let mut iter = tx.query(stmt).await?;
+                let mut ids = vec![];
+                while let Some(row) = iter.next().await? {
+                    ids.push(row.column_by_name::<String>("GuildId")?);
+                }
+                drop(iter);
+                tx.buffer_write(vec![insert_or_update(
+                    "Guild",
+                    &["GuildId", "OwnerUserId", "UpdatedAt"],
+                    &[&"omni-guild-after-query", &OWNER_ID, &CommitTimestamp::new()],
+                )]);
+                Ok(ids.len())
+            })
+        })
+        .await?;
+    assert!(found >= 3, "steps 2 and 3 wrote three rows, query saw {found}");
+
+    // Step 5: mutation-only read-write transaction. No statement ever runs, so the only
+    // precommit token available is the one BeginTransaction returns -- and it only returns
+    // one when a `mutation_key` was supplied.
+    let guild_id = "omni-guild-mutation-only";
+    client
+        .read_write_transaction::<(), Error, _>(|tx| {
+            Box::pin(async move {
+                tx.buffer_write(vec![insert_or_update(
+                    "Guild",
+                    &["GuildId", "OwnerUserId", "UpdatedAt"],
+                    &[&guild_id, &OWNER_ID, &CommitTimestamp::new()],
+                )]);
+                Ok(())
+            })
+        })
+        .await?;
+
+    // Step 6: read it back with a single-use read-only transaction.
+    let mut tx = client.single().await?;
+    let row = tx
+        .read_row("Guild", &["GuildId", "OwnerUserId"], Key::new(&guild_id))
+        .await?
+        .expect("the row written in step 5 should be readable");
+    assert_eq!(row.column_by_name::<String>("GuildId")?, guild_id);
+    assert_eq!(row.column_by_name::<String>("OwnerUserId")?, OWNER_ID);
+
+    client.close().await;
+    Ok(())
+}

--- a/spanner/tests/transaction_ro_test.rs
+++ b/spanner/tests/transaction_ro_test.rs
@@ -20,7 +20,10 @@ fn init() {
     let filter = tracing_subscriber::filter::EnvFilter::from_default_env()
         .add_directive("google_cloud_spanner=trace".parse().unwrap());
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
-    std::env::set_var("SPANNER_EMULATOR_HOST", "localhost:9010");
+    // Leave an explicitly configured host alone so the suite can be pointed at Spanner Omni.
+    if std::env::var("SPANNER_EMULATOR_HOST").is_err() {
+        std::env::set_var("SPANNER_EMULATOR_HOST", "localhost:9010");
+    }
 }
 
 async fn assert_read(tx: &mut ReadOnlyTransaction, user_id: &str, now: &OffsetDateTime, cts: &OffsetDateTime) {
@@ -193,7 +196,9 @@ async fn test_batch_partition_query_and_read() {
     let many = (0..20000)
         .map(|x| create_user_mutation(&format!("user_partitionx_{x}"), &now))
         .collect();
-    let cr2 = data_client.apply(many).await.unwrap();
+    // Too many mutations for a single transaction, so each chunk lands at its own commit
+    // timestamp and rows have to be checked against the chunk that wrote them.
+    let cr2 = apply_in_chunks(&data_client, many, USER_ROWS_PER_COMMIT).await;
 
     // test
     let mut tx = data_client.batch_read_only_transaction().await.unwrap();
@@ -218,13 +223,9 @@ async fn test_batch_partition_query_and_read() {
         map.insert(user_id, row);
     }
 
-    let ts = cr2.timestamp.unwrap();
-    let ts = OffsetDateTime::from_unix_timestamp(ts.seconds)
-        .unwrap()
-        .replace_nanosecond(ts.nanos as u32)
-        .unwrap();
     (0..20000).for_each(|x| {
         let user_id = format!("user_partitionx_{x}");
+        let ts = chunk_timestamp(&cr2, x, USER_ROWS_PER_COMMIT);
         assert_user_row(map.get(&user_id).unwrap(), &user_id, &now, &ts)
     });
 }
@@ -235,22 +236,23 @@ async fn test_query(count: usize, prefix: &str) {
         .map(|x| create_user_mutation(&format!("user_{prefix}_{x}"), &now))
         .collect();
     let data_client = create_data_client().await;
-    let cr = data_client.apply(mutations).await.unwrap();
+    // Chunked because a large `count` would otherwise exceed Spanner's per-transaction
+    // mutation limit; each chunk lands at its own commit timestamp.
+    let cr = apply_in_chunks(&data_client, mutations, USER_ROWS_PER_COMMIT).await;
 
     let mut tx = data_client.read_only_transaction().await.unwrap();
     let stmt = Statement::new(format!("SELECT *, Array[UserId,UserId,UserId,UserId,UserId] as UserIds, Array[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20] as NumArray FROM User p WHERE p.UserId LIKE 'user_{prefix}_%' ORDER BY UserId "));
     let rows = execute_query(&mut tx, stmt).await;
     assert_eq!(count, rows.len());
 
-    let ts = cr.timestamp.unwrap();
-    let ts = OffsetDateTime::from_unix_timestamp(ts.seconds)
-        .unwrap()
-        .replace_nanosecond(ts.nanos as u32)
-        .unwrap();
     let mut user_ids: Vec<String> = (0..count).map(|x| format!("user_{prefix}_{x}")).collect();
     user_ids.sort();
     for (x, user_id) in user_ids.iter().enumerate() {
         let row = rows.get(x).unwrap();
+        // Sorted lexicographically, so recover the mutation index from the name to find
+        // which chunk -- and so which commit timestamp -- this row was written in.
+        let index: usize = user_id.rsplit('_').next().unwrap().parse().unwrap();
+        let ts = chunk_timestamp(&cr, index, USER_ROWS_PER_COMMIT);
         assert_user_row(row, user_id, &now, &ts);
         let user_ids = row.column_by_name::<Vec<String>>("UserIds").unwrap();
         user_ids.iter().for_each(|u| assert_eq!(u, user_id));

--- a/spanner/tests/transaction_rw_test.rs
+++ b/spanner/tests/transaction_rw_test.rs
@@ -13,7 +13,10 @@ fn init() {
     let filter = tracing_subscriber::filter::EnvFilter::from_default_env()
         .add_directive("google_cloud_spanner=trace".parse().unwrap());
     let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
-    std::env::set_var("SPANNER_EMULATOR_HOST", "localhost:9010");
+    // Leave an explicitly configured host alone so the suite can be pointed at Spanner Omni.
+    if std::env::var("SPANNER_EMULATOR_HOST").is_err() {
+        std::env::set_var("SPANNER_EMULATOR_HOST", "localhost:9010");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #449. Spanner Omni accepts only multiplexed sessions, so `Client::new` fails against it today; this adds opt-in support.

## What it does

- **`SessionConfig::multiplexed`**, default `false`. When set, session creation uses `CreateSession` with `Session.multiplexed = true` instead of `BatchCreateSessions`. Also settable via `SPANNER_MULTIPLEXED_SESSIONS`, alongside the `SPANNER_EMULATOR_HOST` variable `ClientConfig::default()` already reads.
- **Precommit tokens.** A read-write transaction on a multiplexed session must commit with the most recent token. Tokens arrive on `ExecuteSql`, `ExecuteBatchDml`, `BeginTransaction`, and the `PartialResultSet`s a `RowIterator` consumes while holding the session borrow, so the transaction keeps a shared slot holding the highest `seq_num` seen.
- **Mutation-only transactions** run no statement and so have no token source; at commit they re-issue `BeginTransaction` with a `mutation_key`, which is the only way to get one.
- **Commit retry.** A commit can answer "not applied, retry with this token"; that exchange is bounded to three attempts.

**Leave `multiplexed` at its default of `false` and nothing changes.** Sessions are still created with `BatchCreateSessions`, no precommit token is ever sent, and commit still issues exactly one request. Every existing caller gets today's behaviour without touching anything. All the new machinery costs that path is an empty `Arc<Mutex<Option<_>>>` per transaction and a token-recording call that returns immediately when there is no token.

The pool's sizing and health-check logic is left alone; for a multiplexed session it becomes redundant rather than wrong.

This is deliberately smaller than #437: no `SessionManager` rewrite, no inline-begin, no change to the default path.

## What it doesn't do

Multiplexed sessions are created into the existing pool rather than replacing it with a single shared handle, so their main benefit — one session instead of many — isn't realised. This is about making Omni usable, not about optimising session management.

## Testing

`spanner/docker-compose.omni.yml` brings up Omni with the test schema. The image pulls anonymously, so no Google Cloud account is needed:

```sh
cd spanner
docker compose -f docker-compose.omni.yml up -d --wait
docker wait gcloud-spanner-omni-spanner-omni-init-1
cargo test -p gcloud-spanner --test omni_test -- --ignored
```

`tests/omni_test.rs` is `#[ignore]`d and reads no environment variables. `regular_sessions_are_rejected_by_omni` pins the bug; `multiplexed_sessions_work` covers session creation, DML, batch DML, a streaming query inside a read-write transaction, a mutation-only commit, and a single-use read-only transaction.

The pre-existing integration suites run against Omni too, which is what turned up the fixture problem below:

```sh
SPANNER_EMULATOR_HOST=localhost:9011 SPANNER_MULTIPLEXED_SESSIONS=true \
  cargo test -p gcloud-spanner --features trace,otel-metrics \
  --test client_test --test transaction_ro_test --test transaction_rw_test
```

Three caveats there:

- Omni keeps its database in a named volume, so it wants `docker compose -f docker-compose.omni.yml down -v` between runs — otherwise fixture rows from the previous run make `test_complex_query` fail.
- The `--lib` tests construct `Environment::Emulator("localhost:9010")` directly, so they ignore `SPANNER_EMULATOR_HOST` and stay on the emulator.
- Several fixtures write a client-generated `OffsetDateTime::now_utc()` straight into an `allow_commit_timestamp` column, which the server rejects if the value is ahead of its own clock. A container clock trailing the host by a few tens of milliseconds is enough to fail `test_complex_query` with "Cannot write timestamps in the future". This is pre-existing and not specific to Omni — the Cloud Spanner emulator rejects it the same way — so I have left it alone here rather than widen this PR into unrelated test files.

|                                                              | result     |
| ------------------------------------------------------------ | ---------- |
| Emulator, `cargo test --features trace,otel-metrics`           | 109 passed |
| Omni, the three integration suites (command above)             | 21 passed  |
| `omni_test -- --ignored` against Omni                          | 2 passed   |
| `fmt.sh` / `clippy.sh`                                         | clean      |

Two tests fail identically with and without this change, on both backends: `change_stream_test`, because `tests/ddl/schema.sql` defines no change stream, and `test_complex_query` whenever the container clock trails the host as described above. The counts above are from a run where the clocks agreed.

Pointing the existing suites at Omni surfaced three fixtures committing tens of thousands of `User` rows in one transaction, past Spanner's 120,000-mutation limit. The emulator doesn't enforce it; real Cloud Spanner and Omni do. Those now commit in chunks and check each row against the timestamp of the chunk that wrote it, so they stay valid against both.

CI is gated behind the `safe to test` label, so the spanner job won't run here until you add it.

---

Written with Claude Code. I reviewed every line, and the verification above is real — run against a live Omni container and the emulator, with rows checked in the database rather than inferred from test output.
